### PR TITLE
Install the woke snap for inclusive naming testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,10 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - uses: actions/checkout@v3
-      - name: Install dependencies
+      - name: Install tox
         run: python3 -m pip install tox
+      - name: Install woke snap
+        run: sudo snap install woke
       - name: Run tests
         run: tox --result-json=test-result.json
       - name: Export test report


### PR DESCRIPTION
We're planning to standardise on using the `woke` snap to check for inclusive naming in our projects. To do this we'll need to install the snap before running tests.