### PR TITLE
Add support for running script before integration tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -18,9 +18,9 @@ on:
         type: string
         default: ubuntu-20.04
       series:
-        description: List of series to run the tests in JSON format. Each element will be passed to tox as --series argument
+        description: List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to tox as --series argument
         type: string
-        default: [""]
+        default: '[""]'
     outputs:
       images:
         description: Pushed docker images

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -105,7 +105,7 @@ jobs:
           done
 
           series=""
-          if [[ -z ${{ matrix.series }} ]]; then
+          if [ -z ${{ matrix.series }} ]; then
             series="--series ${{ matrix.series }}"
           fi
           tox -e integration -- --model testing $series $args ${{ inputs.extra-arguments }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -4,16 +4,23 @@ on:
   workflow_call:
     inputs:
       extra-arguments:
-        description: Additional arguments to pass to the integration tests
+        description: Additional arguments to pass to the integration tests step
         type: string
-      is-machine-charm:
-        description: Charm substrate (k8s or machine)
-        type: boolean
-        default: false
+      pre-run-script:
+        description: Path to the bash script to be run before the integration tests
+        type: string
+      provider:
+        description: Actions operator provider as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: microk8s
       runs-on:
         description: Runner image for the integration tests
         type: string
         default: ubuntu-20.04
+      series:
+        description: List of series to run the tests in JSON format. Each element will be passed to tox as --series argument
+        type: string
+        default: [""]
     outputs:
       images:
         description: Pushed docker images
@@ -59,18 +66,23 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ github.run_id }}
           file: ${{ matrix.image }}.Dockerfile
 
-  integration-test-k8s:
-    name: Integration tests (k8s)
+integration-test:
+    name: Integration tests
+    strategy:
+      matrix:
+        series: ${{ fromJSON(inputs.series) }}
+      fail-fast: false
     runs-on: ${{ inputs.runs-on }}
     needs: [get-images, build-images]
-    if: ${{ !failure() && !inputs.is-machine-charm }}
+    if: ${{ !failure() }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          provider: microk8s
+          provider: ${{ inputs.provider }}
       - name: Configure GHCR in microk8s
+        if: ${{ inputs.provider == 'microk8s' }}
         run: |
           # Adding authentication for ghcr.io for containerd as per https://microk8s.io/docs/registry-private
           # Note: containerd has to be restarted for the changes to take effect
@@ -81,6 +93,9 @@ jobs:
           password = \"${{ secrets.GITHUB_TOKEN }}\"
           " >> /var/snap/microk8s/current/args/containerd-template.toml'
           sudo su -c 'systemctl restart snap.microk8s.daemon-containerd.service && microk8s status --wait-ready'
+      - name: Pre-run script
+        if: ${{ inputs.pre-run-script != '' }}
+        run: bash ${{ inputs.pre-run-script }}
       - name: Run integration tests
         run: |
           echo "CHARM_NAME=$(yq '.name' metadata.yaml)" >> $GITHUB_ENV
@@ -88,39 +103,15 @@ jobs:
           for image_name in $(echo '${{ needs.get-images.outputs.images }}' | jq -cr '.[]'); do
             args="${args} --${image_name}-image ${{ env.REGISTRY }}/${{ env.OWNER }}/${image_name}:${{ github.run_id }}"
           done
-          tox -e integration -- --model testing $args ${{ inputs.extra-arguments }}
+
+          series=""
+          if [[ -z ${{ matrix.series }} ]]; then
+            series="--series ${{ matrix.series }}"
+          fi
+          tox -e integration -- --model testing $series $args ${{ inputs.extra-arguments }}
       - name: Dump logs
         uses: canonical/charm-logdump-action@main
         if: failure()
         with:
           app: ${{ env.CHARM_NAME }}
           model: testing
-
-  integration-test-lxd:
-    strategy:
-      matrix:
-        series: [xenial, bionic, focal]
-      fail-fast: false
-    name: Integration tests (lxd)
-    # [2022-09-29] The integration tests have to run on Ubuntu 18.04 to be able to support Xenial
-    runs-on: ubuntu-18.04
-    if: ${{ !failure() && inputs.is-machine-charm }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-        # [2022-09-29] Need to install Python 3.8 because that is what the tests run on and 18.04
-        # comes with Python 3.6
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.8'
-      - name: Run integration tests
-        run: |
-          args=""
-          for image_name in $(echo '${{ needs.get-images.outputs.images }}' | jq -cr '.[]'); do
-            args="${args} --${image_name}-image ${{ env.REGISTRY }}/${{ env.OWNER }}/${image_name}:${{ github.run_id }}"
-          done
-          tox -e integration -- --series ${{ matrix.series }} $args ${{ inputs.extra-arguments }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -66,7 +66,7 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ github.run_id }}
           file: ${{ matrix.image }}.Dockerfile
 
-integration-test:
+  integration-test:
     name: Integration tests
     strategy:
       matrix:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -105,7 +105,7 @@ jobs:
           done
 
           series=""
-          if [ -z ${{ matrix.series }} ]; then
+          if [ ! -z ${{ matrix.series }} ]; then
             series="--series ${{ matrix.series }}"
           fi
           tox -e integration -- --model testing $series $args ${{ inputs.extra-arguments }}

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -20,7 +20,7 @@ on:
         description: Actions operator provider for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
       integration-test-series:
-        description: List of series to run the integration tests in JSON format. Each element will be passed to tox as --series argument
+        description: List of series to run the integration tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to tox as --series argument
         type: string
       test-runs-on:
         description: Runner image for the tests

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -13,10 +13,15 @@ on:
       integration-test-extra-arguments:
         description: Additional arguments to pass to the integration tests
         type: string
-      is-machine-charm:
-        description: Charm substrate (k8s or machine)
-        type: boolean
-        default: false
+      integration-test-pre-run-script:
+        description: Path to the bash script to be run before the integration tests
+        type: string
+      integration-test-provider:
+        description: Actions operator provider for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+      integration-test-series:
+        description: List of series to run the integration tests in JSON format. Each element will be passed to tox as --series argument
+        type: string
       test-runs-on:
         description: Runner image for the tests
         type: string
@@ -48,8 +53,10 @@ jobs:
     uses: ./.github/workflows/integration_test.yaml
     with:
       extra-arguments: ${{ inputs.integration-test-extra-arguments }}
-      is-machine-charm: ${{ inputs.is-machine-charm }}
+      pre-run-script: ${{ inputs.integration-test-pre-run-script }}
+      provider: ${{ inputs.integration-test-provider }}
       runs-on: ${{ inputs.test-runs-on }}
+      series: ${{ inputs.integration-test-series }}
   select-channel:
     name: Select target channel
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_branch.yaml
+++ b/.github/workflows/publish_branch.yaml
@@ -6,10 +6,15 @@ on:
       integration-test-extra-arguments:
         description: Additional arguments to pass to the integration tests
         type: string
-      is-machine-charm:
-        description: Charm substrate (k8s or machine)
-        type: boolean
-        default: false
+      integration-test-pre-run-script:
+        description: Path to the bash script to be run before the integration tests
+        type: string
+      integration-test-provider:
+        description: Actions operator provider for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+      integration-test-series:
+        description: List of series to run the integration tests in JSON format. Each element will be passed to tox as --series argument
+        type: string
       test-runs-on:
         description: Runner image for the tests
         type: string
@@ -36,8 +41,10 @@ jobs:
     uses: ./.github/workflows/integration_test.yaml
     with:
       extra-arguments: ${{ inputs.integration-test-extra-arguments }}
-      is-machine-charm: ${{ inputs.is-machine-charm }}
+      pre-run-script: ${{ integration-test-pre-run-script }}
+      provider: ${{ inputs.integration-test-provider }}
       runs-on: ${{ inputs.test-runs-on }}
+      series: ${{ inputs.integration-test-series }}
   select-branch:
     name: Select target branch
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_branch.yaml
+++ b/.github/workflows/publish_branch.yaml
@@ -13,7 +13,7 @@ on:
         description: Actions operator provider for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
       integration-test-series:
-        description: List of series to run the integration tests in JSON format. Each element will be passed to tox as --series argument
+        description: List of series to run the integration tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to tox as --series argument
         type: string
       test-runs-on:
         description: Runner image for the tests


### PR DESCRIPTION
* Support running a script right before running the integration tests. This will allow to run cross-model tests.
* Some refactoring