### PR TITLE
Fix workflow "Comment on PR" by passing Github token explicitly

### DIFF
--- a/.github/actions/comment_pr/action.yaml
+++ b/.github/actions/comment_pr/action.yaml
@@ -4,6 +4,9 @@ inputs:
   artifact-name:
     required: true
     description: Artifact containing a JSON file with the list of comments to be published
+  github-token:
+    required: true
+    description: Github token to authenticate the creation of comments.
 
 runs:
   using: composite
@@ -37,7 +40,7 @@ runs:
     - name: Comment on PR
       uses: actions/github-script@v6.2.0
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ inputs.github-token }}
         script: |
           const fs = require('fs');
           const comments = JSON.parse(fs.readFileSync('${{ inputs.artifact-name }}.json'));

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
     steps:
       - uses: actions/checkout@v3
-      - uses: weiiwang01/operator-workflows/.github/actions/comment_pr@main
+      - uses: canonical/operator-workflows/.github/actions/comment_pr@main
         with:
           artifact-name: report
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
     steps:
       - uses: actions/checkout@v3
-      - uses: canonical/operator-workflows/.github/actions/comment_pr@main
+      - uses: weiiwang01/operator-workflows/.github/actions/comment_pr@main
         with:
           artifact-name: report
-        secrets: inherit
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See a demo of the fixed version in https://github.com/weiiwang01/wordpress-k8s-operator/pull/10 and https://github.com/weiiwang01/wordpress-k8s-operator/actions/runs/3335715442.