### PR TITLE
Add support for forks

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -55,6 +55,7 @@ jobs:
           echo '${{ github.event_name != 'pull_request' }}'
           echo '${{ github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name}}'
           echo '${{ github.event_name != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name}}'
+          echo ${{ fromJSON(github.event) }}
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
         if: ${{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -37,6 +37,9 @@ jobs:
     outputs:
       images: ${{ env.DOCKER_IMAGES }}
     steps:
+      - name: Dump GitHub context
+        id: github_context_step
+        run: echo '${{ toJSON(github) }}'
       - uses: actions/checkout@v3
       - name: Get dockerfiles
         id: set-images

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -37,9 +37,6 @@ jobs:
     outputs:
       images: ${{ env.DOCKER_IMAGES }}
     steps:
-      - name: Dump GitHub context
-        id: github_context_step
-        run: echo '${{ toJSON(github) }}'
       - uses: actions/checkout@v3
       - name: Get dockerfiles
         id: set-images
@@ -55,6 +52,8 @@ jobs:
       - name: Dump GitHub context
         id: github_context_step
         run: |
+          echo '${{ github.event.workflow_run.event != 'pull_request' }}'
+          echo '${{ github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name}}'
           echo '${{ github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name}}'
       - uses: actions/checkout@v3
       - name: Log in to the Container registry

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -55,7 +55,7 @@ jobs:
           echo '${{ github.event_name != 'pull_request' }}'
           echo '${{ github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name}}'
           echo '${{ github.event_name != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name}}'
-          echo '${{ fromJSON(github.event) }}'
+          echo '${{ fromJSON(github) }}'
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
         if: ${{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -49,7 +49,7 @@ jobs:
     name: Build image
     runs-on: ubuntu-20.04
     needs: get-images
-    if: env.USE_REGISTRY
+    if: env.USE_REGISTRY == 'true'
     strategy:
       matrix:
         image: ${{ fromJSON(needs.get-images.outputs.images) }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -29,6 +29,7 @@ on:
 env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
+  USE_REGISTRY: ${{ github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
 
 jobs:
   get-images:
@@ -48,13 +49,14 @@ jobs:
     name: Build image
     runs-on: ubuntu-20.04
     needs: get-images
-    if: ${{ needs.get-images.outputs.images != '[]' }}
+    if: ${{ env.USE_REGISTRY }}
     strategy:
       matrix:
         image: ${{ fromJSON(needs.get-images.outputs.images) }}
     steps:
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
+        if: ${{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -55,7 +55,7 @@ jobs:
           echo '${{ github.event_name != 'pull_request' }}'
           echo '${{ github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name}}'
           echo '${{ github.event_name != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name}}'
-          echo ${{ fromJSON(github.event) }}
+          echo '${{ fromJSON(github.event) }}'
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
         if: ${{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -55,9 +55,7 @@ jobs:
       - name: Dump GitHub context
         id: github_context_step
         run: |
-          echo '${{ github.event.workflow_run.event == 'pull_request' || github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}'
-          echo '${{ github.event.workflow_run.event == 'pull_request' }}'
-          echo '${{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}'
+          echo '${{ github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name}}'
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
         if: ${{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}
@@ -71,7 +69,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
+          push: ${{ github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name }}
           tags: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ github.run_id }}
           file: ${{ matrix.image }}.Dockerfile
 

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -117,6 +117,8 @@ jobs:
         run: |
           for image_name in $(echo '${{ needs.get-images.outputs.images }}' | jq -cr '.[]'); do
             imageId=$(docker load --input ${image_name}/${image_name}.tar | sed -e "s/^Loaded image ID: //")
+            echo "docker load --input ${image_name}/${image_name}.tar"
+            echo "docker tag $imageId localhost:32000/${image_name}:latest"
             docker tag $imageId localhost:32000/${image_name}:latest
             docker push localhost:32000/${image_name}:latest
           done

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -54,7 +54,7 @@ jobs:
         run: echo '${{ toJSON(github) }}'
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
-        if: ${{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}
+        if: ${{ !github.event.repository.fork }}
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
@@ -62,7 +62,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push image
         uses: docker/build-push-action@v3
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name }}
+        if: ${{ !github.event.repository.fork }}
         with:
           context: .
           push: true
@@ -72,10 +72,10 @@ jobs:
       # so an artifact is published instead
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
+        if: ${{ github.event.repository.fork }}
       - name: Build image and publish artifact
         uses: docker/build-push-action@v3
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
+        if: $${{ github.event.repository.fork }}
         with:
           context: .
           file: ${{ matrix.image }}.Dockerfile
@@ -83,7 +83,7 @@ jobs:
           outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar
       - name: Upload image artifact
         uses: actions/upload-artifact@v3
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
+        if: ${{ github.event.repository.fork }}
         with:
           name: ${{ matrix.image }}
           path: /tmp/${{ matrix.image }}.tar
@@ -104,18 +104,18 @@ jobs:
         with:
           provider: ${{ inputs.provider }}
       - name: Enable microk8s registry
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}  
+        if: ${{ github.event.repository.fork }}
         run: |
           sudo microk8s.enable registry
           sudo microk8s.kubectl -n container-registry rollout status -w deployment/registry
       - name: Download all artifacts
         uses: actions/download-artifact@v3
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}  
+        if: ${{ github.event.repository.fork }}
         with:
           name: ${{ inputs.resource-name }}
           path: /tmp
       - name: Push images to microk8s registry
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}  
+        if: ${{ github.event.repository.fork }}
         run: |
           for image_name in $(echo '${{ needs.get-images.outputs.images }}' | jq -cr '.[]'); do
             imageId=$(docker load --input ${image_name}/${image_name}.tar | sed -e "s/^Loaded image ID: //")
@@ -123,7 +123,7 @@ jobs:
             docker push localhost:32000/${image_name}:latest
           done
       - name: Configure GHCR in microk8s
-        if: ${{ inputs.provider == 'microk8s' &&  (github.event_name != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name) }}
+        if: ${{ !github.event.repository.fork }}
         run: |
           # Adding authentication for ghcr.io for containerd as per https://microk8s.io/docs/registry-private
           # Note: containerd has to be restarted for the changes to take effect

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -50,9 +50,6 @@ jobs:
       matrix:
         image: ${{ fromJSON(needs.get-images.outputs.images) }}
     steps:
-      - name: Dump GitHub context
-        id: github_context_step
-        run: echo '${{ toJSON(github) }}'
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
         if: ${{ !github.event.pull_request.head.repo.fork }}
@@ -74,7 +71,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         if: ${{ github.event.pull_request.head.repo.fork }}
-      - name: Build image and publish artifact
+      - name: Build image as tarball
         uses: docker/build-push-action@v3
         if: ${{ github.event.pull_request.head.repo.fork }}
         with:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -72,6 +72,8 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ github.run_id }}
           file: ${{ matrix.image }}.Dockerfile
+      # GitHub doesn't currently support pushing images in the Docker registry when opening a PR from a fork
+      # so an artifact is published instead
       - name: Build image and publish artifact
         uses: docker/build-push-action@v3
         if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
@@ -99,13 +101,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
-        if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}  
         with:
           provider: ${{ inputs.provider }}
       - name: Enable microk8s registry
-        # Add a step to wait for the registry to become available after it has
-        # been deployed to avoid any issues with trying to push images to it
-        # before it is ready
+        if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}  
         run: |
           sudo microk8s.enable registry
           sudo microk8s.kubectl -n container-registry rollout status -w deployment/registry

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -114,7 +114,6 @@ jobs:
         run: |
           for image_name in $(echo '${{ needs.get-images.outputs.images }}' | jq -cr '.[]'); do
             docker load --input ${image_name}/${image_name}.tar
-            imageId=$(docker images localhost:32000/indico-nginx:latest --format "{{.ID}}")
             docker push localhost:32000/${image_name}:latest
           done
       - name: Configure GHCR in microk8s
@@ -137,7 +136,11 @@ jobs:
           echo "CHARM_NAME=$(yq '.name' metadata.yaml)" >> $GITHUB_ENV
           args=""
           for image_name in $(echo '${{ needs.get-images.outputs.images }}' | jq -cr '.[]'); do
-            args="${args} --${image_name}-image ${{ env.REGISTRY }}/${{ env.OWNER }}/${image_name}:${{ github.run_id }}"
+            if [ ${{ github.event.pull_request.head.repo.fork }} = "true" ]; then
+              args="${args} --${image_name}-image localhost:32000/${image_name}:latest"
+            else
+              args="${args} --${image_name}-image ${{ env.REGISTRY }}/${{ env.OWNER }}/${image_name}:${{ github.run_id }}"
+            fi
           done
 
           series=""

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -76,7 +76,7 @@ jobs:
         if: ${{ github.event.pull_request.head.repo.fork }}
       - name: Build image and publish artifact
         uses: docker/build-push-action@v3
-        if: $${{ github.event.pull_request.head.repo.fork }}
+        if: ${{ github.event.pull_request.head.repo.fork }}
         with:
           context: .
           file: ${{ matrix.image }}.Dockerfile

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -49,7 +49,7 @@ jobs:
     name: Build image
     runs-on: ubuntu-20.04
     needs: get-images
-    if: env.USE_REGISTRY == 'true'
+    if: ${{ env.USE_REGISTRY == 'true' }}
     strategy:
       matrix:
         image: ${{ fromJSON(needs.get-images.outputs.images) }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -52,6 +52,11 @@ jobs:
       matrix:
         image: ${{ fromJSON(needs.get-images.outputs.images) }}
     steps:
+       - name: Dump GitHub context
+        id: github_context_step
+        run: echo '{{ github.event.workflow_run.event == 'pull_request' || github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}'
+        run: echo '{{ github.event.workflow_run.event == 'pull_request' }}'
+        run: echo '{{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}'
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
         if: ${{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -65,13 +65,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push image
-        id: build
         uses: docker/build-push-action@v3
+        if: ${{ github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name }}
         with:
           context: .
-          push: ${{ github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name }}
+          push: true
           tags: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ github.run_id }}
           file: ${{ matrix.image }}.Dockerfile
+      - name: Build image and publish artifact
+        uses: docker/build-push-action@v3
+        if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
+        with:
+          context: .
+          file: ${{ matrix.image }}.Dockerfile
+          outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
+        with:
+          name: ${{ matrix.image }}
+          path: /tmp/${{ matrix.image }}.tar
 
   integration-test:
     name: Integration tests
@@ -86,10 +99,32 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
+        if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}  
         with:
           provider: ${{ inputs.provider }}
+      - name: Enable microk8s registry
+        # Add a step to wait for the registry to become available after it has
+        # been deployed to avoid any issues with trying to push images to it
+        # before it is ready
+        run: |
+          sudo microk8s.enable registry
+          sudo microk8s.kubectl -n container-registry rollout status -w deployment/registry
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}  
+        with:
+          name: ${{ inputs.resource-name }}
+          path: /tmp
+      - name: Push images to microk8s registry
+        if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}  
+        run: |
+          for image_name in $(echo '${{ needs.get-images.outputs.images }}' | jq -cr '.[]'); do
+            imageId=$(docker load --input ${image_name}/${image_name}.tar | sed -e "s/^Loaded image ID: //")
+            docker tag $imageId localhost:32000/${image_name}:latest
+            docker push localhost:32000/${image_name}:latest
+          done
       - name: Configure GHCR in microk8s
-        if: ${{ inputs.provider == 'microk8s' }}
+        if: ${{ inputs.provider == 'microk8s' &&  (github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name) }}
         run: |
           # Adding authentication for ghcr.io for containerd as per https://microk8s.io/docs/registry-private
           # Note: containerd has to be restarted for the changes to take effect

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -29,7 +29,6 @@ on:
 env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
-  USE_REGISTRY: ${{ github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
 
 jobs:
   get-images:
@@ -49,7 +48,6 @@ jobs:
     name: Build image
     runs-on: ubuntu-20.04
     needs: get-images
-    if: ${{ env.USE_REGISTRY == 'true' }}
     strategy:
       matrix:
         image: ${{ fromJSON(needs.get-images.outputs.images) }}
@@ -67,7 +65,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: true
+          push: if: ${{ github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
           tags: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ github.run_id }}
           file: ${{ matrix.image }}.Dockerfile
 

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -54,9 +54,10 @@ jobs:
     steps:
        - name: Dump GitHub context
         id: github_context_step
-        run: echo '{{ github.event.workflow_run.event == 'pull_request' || github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}'
-        run: echo '{{ github.event.workflow_run.event == 'pull_request' }}'
-        run: echo '{{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}'
+        run: |
+          echo '{{ github.event.workflow_run.event == 'pull_request' || github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}'
+          echo '{{ github.event.workflow_run.event == 'pull_request' }}'
+          echo '{{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}'
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
         if: ${{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -49,7 +49,7 @@ jobs:
     name: Build image
     runs-on: ubuntu-20.04
     needs: get-images
-    if: ${{ env.USE_REGISTRY }}
+    if: env.USE_REGISTRY
     strategy:
       matrix:
         image: ${{ fromJSON(needs.get-images.outputs.images) }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -45,6 +45,7 @@ jobs:
     name: Build image
     runs-on: ubuntu-20.04
     needs: get-images
+    if: ${{ needs.get-images.outputs.images != '[]' }}
     strategy:
       matrix:
         image: ${{ fromJSON(needs.get-images.outputs.images) }}
@@ -54,7 +55,7 @@ jobs:
         run: echo '${{ toJSON(github) }}'
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
-        if: ${{ !github.event.repository.fork }}
+        if: ${{ !github.event.pull_request.base.repo.fork }}
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
@@ -62,7 +63,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push image
         uses: docker/build-push-action@v3
-        if: ${{ !github.event.repository.fork }}
+        if: ${{ !github.event.pull_request.base.repo.fork }}
         with:
           context: .
           push: true
@@ -72,10 +73,10 @@ jobs:
       # so an artifact is published instead
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        if: ${{ github.event.repository.fork }}
+        if: ${{ github.event.pull_request.base.repo.fork }}
       - name: Build image and publish artifact
         uses: docker/build-push-action@v3
-        if: $${{ github.event.repository.fork }}
+        if: $${{ github.event.pull_request.base.repo.fork }}
         with:
           context: .
           file: ${{ matrix.image }}.Dockerfile
@@ -83,7 +84,7 @@ jobs:
           outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar
       - name: Upload image artifact
         uses: actions/upload-artifact@v3
-        if: ${{ github.event.repository.fork }}
+        if: ${{ github.event.pull_request.base.repo.fork }}
         with:
           name: ${{ matrix.image }}
           path: /tmp/${{ matrix.image }}.tar
@@ -104,15 +105,15 @@ jobs:
         with:
           provider: ${{ inputs.provider }}
       - name: Enable microk8s registry
-        if: ${{ github.event.repository.fork }}
+        if: ${{ github.event.pull_request.base.repo.fork }}
         run: |
           sudo microk8s.enable registry
           sudo microk8s.kubectl -n container-registry rollout status -w deployment/registry
       - name: Download all artifacts
         uses: actions/download-artifact@v3
-        if: ${{ github.event.repository.fork }}
+        if: ${{ github.event.pull_request.base.repo.fork }}
       - name: Push images to microk8s registry
-        if: ${{ github.event.repository.fork }}
+        if: ${{ github.event.pull_request.base.repo.fork }}
         run: |
           for image_name in $(echo '${{ needs.get-images.outputs.images }}' | jq -cr '.[]'); do
             imageId=$(docker load --input ${image_name}/${image_name}.tar | sed -e "s/^Loaded image ID: //")
@@ -120,7 +121,7 @@ jobs:
             docker push localhost:32000/${image_name}:latest
           done
       - name: Configure GHCR in microk8s
-        if: ${{ !github.event.repository.fork }}
+        if: ${{ inputs.provider == 'microk8s' && !github.event.pull_request.base.repo.fork }}
         run: |
           # Adding authentication for ghcr.io for containerd as per https://microk8s.io/docs/registry-private
           # Note: containerd has to be restarted for the changes to take effect

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -79,6 +79,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.image }}.Dockerfile
+          tags: localhost:32000/${{ matrix.image }}:latest
           outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar
       - name: Upload image artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -73,6 +73,9 @@ jobs:
           file: ${{ matrix.image }}.Dockerfile
       # GitHub doesn't currently support pushing images in the Docker registry when opening a PR from a fork
       # so an artifact is published instead
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
       - name: Build image and publish artifact
         uses: docker/build-push-action@v3
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -52,9 +52,9 @@ jobs:
       - name: Dump GitHub context
         id: github_context_step
         run: |
-          echo '${{ github.event.workflow_run.event != 'pull_request' }}'
+          echo '${{ github.event_name != 'pull_request' }}'
           echo '${{ github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name}}'
-          echo '${{ github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name}}'
+          echo '${{ github.event_name != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name}}'
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
         if: ${{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}
@@ -65,7 +65,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push image
         uses: docker/build-push-action@v3
-        if: ${{ github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name }}
         with:
           context: .
           push: true
@@ -75,14 +75,14 @@ jobs:
       # so an artifact is published instead
       - name: Build image and publish artifact
         uses: docker/build-push-action@v3
-        if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
         with:
           context: .
           file: ${{ matrix.image }}.Dockerfile
           outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar
       - name: Upload image artifact
         uses: actions/upload-artifact@v3
-        if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
         with:
           name: ${{ matrix.image }}
           path: /tmp/${{ matrix.image }}.tar
@@ -103,18 +103,18 @@ jobs:
         with:
           provider: ${{ inputs.provider }}
       - name: Enable microk8s registry
-        if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}  
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}  
         run: |
           sudo microk8s.enable registry
           sudo microk8s.kubectl -n container-registry rollout status -w deployment/registry
       - name: Download all artifacts
         uses: actions/download-artifact@v3
-        if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}  
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}  
         with:
           name: ${{ inputs.resource-name }}
           path: /tmp
       - name: Push images to microk8s registry
-        if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}  
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}  
         run: |
           for image_name in $(echo '${{ needs.get-images.outputs.images }}' | jq -cr '.[]'); do
             imageId=$(docker load --input ${image_name}/${image_name}.tar | sed -e "s/^Loaded image ID: //")
@@ -122,7 +122,7 @@ jobs:
             docker push localhost:32000/${image_name}:latest
           done
       - name: Configure GHCR in microk8s
-        if: ${{ inputs.provider == 'microk8s' &&  (github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name) }}
+        if: ${{ inputs.provider == 'microk8s' &&  (github.event_name != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name) }}
         run: |
           # Adding authentication for ghcr.io for containerd as per https://microk8s.io/docs/registry-private
           # Note: containerd has to be restarted for the changes to take effect

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -55,9 +55,9 @@ jobs:
       - name: Dump GitHub context
         id: github_context_step
         run: |
-          echo '{{ github.event.workflow_run.event == 'pull_request' || github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}'
-          echo '{{ github.event.workflow_run.event == 'pull_request' }}'
-          echo '{{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}'
+          echo '${{ github.event.workflow_run.event == 'pull_request' || github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}'
+          echo '${{ github.event.workflow_run.event == 'pull_request' }}'
+          echo '${{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}'
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
         if: ${{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -51,11 +51,7 @@ jobs:
     steps:
       - name: Dump GitHub context
         id: github_context_step
-        run: |
-          echo '${{ github.event_name != 'pull_request' }}'
-          echo '${{ github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name}}'
-          echo '${{ github.event_name != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.base.head.full_name}}'
-          echo '${{ fromJSON(github) }}'
+        run: echo '${{ fromJSON(github) }}'
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
         if: ${{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         image: ${{ fromJSON(needs.get-images.outputs.images) }}
     steps:
-       - name: Dump GitHub context
+      - name: Dump GitHub context
         id: github_context_step
         run: |
           echo '{{ github.event.workflow_run.event == 'pull_request' || github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}'

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -65,7 +65,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: if: ${{ github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
+          push: ${{ github.event.workflow_run.event != 'pull_request' || github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name }}
           tags: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ github.run_id }}
           file: ${{ matrix.image }}.Dockerfile
 

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -116,10 +116,8 @@ jobs:
         if: ${{ github.event.pull_request.base.repo.fork }}
         run: |
           for image_name in $(echo '${{ needs.get-images.outputs.images }}' | jq -cr '.[]'); do
-            imageId=$(docker load --input ${image_name}/${image_name}.tar | sed -e "s/^Loaded image ID: //")
-            echo "docker load --input ${image_name}/${image_name}.tar"
-            echo "docker tag $imageId localhost:32000/${image_name}:latest"
-            docker tag $imageId localhost:32000/${image_name}:latest
+            docker load --input ${image_name}/${image_name}.tar
+            imageId=$(docker images localhost:32000/indico-nginx:latest --format "{{.ID}}")
             docker push localhost:32000/${image_name}:latest
           done
       - name: Configure GHCR in microk8s

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -111,9 +111,6 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v3
         if: ${{ github.event.repository.fork }}
-        with:
-          name: ${{ inputs.resource-name }}
-          path: /tmp
       - name: Push images to microk8s registry
         if: ${{ github.event.repository.fork }}
         run: |

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -55,7 +55,7 @@ jobs:
         run: echo '${{ toJSON(github) }}'
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
-        if: ${{ !github.event.pull_request.base.repo.fork }}
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
@@ -63,7 +63,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push image
         uses: docker/build-push-action@v3
-        if: ${{ !github.event.pull_request.base.repo.fork }}
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           context: .
           push: true
@@ -73,10 +73,10 @@ jobs:
       # so an artifact is published instead
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        if: ${{ github.event.pull_request.base.repo.fork }}
+        if: ${{ github.event.pull_request.head.repo.fork }}
       - name: Build image and publish artifact
         uses: docker/build-push-action@v3
-        if: $${{ github.event.pull_request.base.repo.fork }}
+        if: $${{ github.event.pull_request.head.repo.fork }}
         with:
           context: .
           file: ${{ matrix.image }}.Dockerfile
@@ -84,7 +84,7 @@ jobs:
           outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar
       - name: Upload image artifact
         uses: actions/upload-artifact@v3
-        if: ${{ github.event.pull_request.base.repo.fork }}
+        if: ${{ github.event.pull_request.head.repo.fork }}
         with:
           name: ${{ matrix.image }}
           path: /tmp/${{ matrix.image }}.tar
@@ -105,15 +105,15 @@ jobs:
         with:
           provider: ${{ inputs.provider }}
       - name: Enable microk8s registry
-        if: ${{ github.event.pull_request.base.repo.fork }}
+        if: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           sudo microk8s.enable registry
           sudo microk8s.kubectl -n container-registry rollout status -w deployment/registry
       - name: Download all artifacts
         uses: actions/download-artifact@v3
-        if: ${{ github.event.pull_request.base.repo.fork }}
+        if: ${{ github.event.pull_request.head.repo.fork }}
       - name: Push images to microk8s registry
-        if: ${{ github.event.pull_request.base.repo.fork }}
+        if: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           for image_name in $(echo '${{ needs.get-images.outputs.images }}' | jq -cr '.[]'); do
             docker load --input ${image_name}/${image_name}.tar
@@ -121,7 +121,7 @@ jobs:
             docker push localhost:32000/${image_name}:latest
           done
       - name: Configure GHCR in microk8s
-        if: ${{ inputs.provider == 'microk8s' && !github.event.pull_request.base.repo.fork }}
+        if: ${{ inputs.provider == 'microk8s' && !github.event.pull_request.head.repo.fork }}
         run: |
           # Adding authentication for ghcr.io for containerd as per https://microk8s.io/docs/registry-private
           # Note: containerd has to be restarted for the changes to take effect

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Dump GitHub context
         id: github_context_step
-        run: echo '${{ fromJSON(github) }}'
+        run: echo '${{ toJSON(github) }}'
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
         if: ${{ github.event.pull_request.base.repo.full_name != github.event.pull_request.base.head.full_name}}

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -35,7 +35,7 @@ jobs:
     # By disabling this job on forked repositories, we can achieve 
     # disabling the publishing to Charmhub action on forked repositories 
     # while still running tests on push events
-    if: ${{ !github.event.repository.fork }}
+    if: github.repository_owner == 'canonical'
     name: Check libraries
     runs-on: ubuntu-latest
     steps:
@@ -61,7 +61,6 @@ jobs:
       series: ${{ inputs.integration-test-series }}
     secrets: inherit
   select-channel:
-    if: ${{ !github.event.repository.fork }}
     name: Select target channel
     runs-on: ubuntu-latest
     outputs:
@@ -71,7 +70,6 @@ jobs:
         id: channel
         uses: canonical/charming-actions/channel@2.1.1
   publish-charm:
-    if: ${{ !github.event.repository.fork }}
     name: Publish
     uses: ./.github/workflows/publish_charm.yaml
     needs: [ tests, integration-tests, select-channel ]

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -61,6 +61,7 @@ jobs:
       series: ${{ inputs.integration-test-series }}
     secrets: inherit
   select-channel:
+    if: github.repository_owner == 'canonical'
     name: Select target channel
     runs-on: ubuntu-latest
     outputs:
@@ -70,6 +71,7 @@ jobs:
         id: channel
         uses: canonical/charming-actions/channel@2.1.1
   publish-charm:
+    if: github.repository_owner == 'canonical'
     name: Publish
     uses: ./.github/workflows/publish_charm.yaml
     needs: [ tests, integration-tests, select-channel ]

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -35,7 +35,7 @@ jobs:
     # By disabling this job on forked repositories, we can achieve 
     # disabling the publishing to Charmhub action on forked repositories 
     # while still running tests on push events
-    if: github.repository_owner == 'canonical'
+    if: ${{ !github.event.repository.fork }}
     name: Check libraries
     runs-on: ubuntu-latest
     steps:
@@ -61,7 +61,7 @@ jobs:
       series: ${{ inputs.integration-test-series }}
     secrets: inherit
   select-channel:
-    if: github.repository_owner == 'canonical'
+    if: ${{ !github.event.repository.fork }}
     name: Select target channel
     runs-on: ubuntu-latest
     outputs:
@@ -71,7 +71,7 @@ jobs:
         id: channel
         uses: canonical/charming-actions/channel@2.1.1
   publish-charm:
-    if: github.repository_owner == 'canonical'
+    if: ${{ !github.event.repository.fork }}
     name: Publish
     uses: ./.github/workflows/publish_charm.yaml
     needs: [ tests, integration-tests, select-channel ]

--- a/.github/workflows/test_and_publish.yaml
+++ b/.github/workflows/test_and_publish.yaml
@@ -1,4 +1,4 @@
-name: Publish to edge
+name: Publish charm
 
 # On push to a "special" branch, we:
 # * always publish to charmhub at latest/edge/branchname


### PR DESCRIPTION
Publish images as an artifact instead of using github's container registry to be able to run integration tests involving images from forks.