### PR TITLE
Feat/linters - enable hadolint and shellcheck

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,13 @@ jobs:
   get-runner-image:
     name: Get runner image
     uses: ./.github/workflows/get_runner_image.yaml
+  docker-lint:
+    name: Dockerfile lint
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hadolint/hadolint-action@v2.0.0
+        with:
+          dockerfile: "*Dockerfile"
   lint-and-unit-test:
     name: Lint and unit tests
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,13 +40,23 @@ jobs:
   get-runner-image:
     name: Get runner image
     uses: ./.github/workflows/get_runner_image.yaml
+  shellcheck-lint:
+    name: Shell scripts lint
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
   docker-lint:
     name: Dockerfile lint
     steps:
       - uses: actions/checkout@v3
-      - uses: hadolint/hadolint-action@v2.0.0
+      - name: Check for Dockerfiles
+        run: echo Dockerfiles=$(find . -name "*Dockerfile") >> $GITHUB_ENV
+      - if: ${{ env.Dockerfiles != '' }}
+        name: Run HadoLint
+        uses: jbergstroem/hadolint-gh-action@v1
         with:
-          dockerfile: "*Dockerfile"
+          dockerfile: "${{ env.Dockerfiles }}"
   lint-and-unit-test:
     name: Lint and unit tests
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}


### PR DESCRIPTION
This PR implements running hadolint on `Dockerfile` files and also running shellcheck on shell script files (they have to be with _.sh_ suffix). If there are no Dockerfiles, the hadolint is skipped. If there are no shell script files, shellcheck exits successfully.
Tests were done on the indico-operator repo:
shellcheck picks up errors in a shell script: https://github.com/canonical/indico-operator/actions/runs/3445082347/jobs/5748384398
by default, there are no errors for shell scripts on indico: https://github.com/canonical/indico-operator/actions/runs/3444988091/jobs/5748187023
with dockerfiles hadolint scans and emits warnings: https://github.com/canonical/indico-operator/actions/runs/3444988091/jobs/5748187164
with no dockerfiles hadolint is skipped: https://github.com/canonical/indico-operator/actions/runs/3444969657/jobs/5748149700