### PR TITLE
Hotfix/linters - add `runs-on` required clause

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,13 @@ jobs:
   get-runner-image:
     name: Get runner image
     uses: ./.github/workflows/get_runner_image.yaml
+  docker-lint:
+    name: Dockerfile lint
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hadolint/hadolint-action@v2.0.0
+        with:
+          dockerfile: "*Dockerfile"
   lint-and-unit-test:
     name: Lint and unit tests
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,13 +40,23 @@ jobs:
   get-runner-image:
     name: Get runner image
     uses: ./.github/workflows/get_runner_image.yaml
+  shellcheck-lint:
+    name: Shell scripts lint
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
   docker-lint:
     name: Dockerfile lint
     steps:
       - uses: actions/checkout@v3
-      - uses: hadolint/hadolint-action@v2.0.0
+      - name: Check for Dockerfiles
+        run: echo Dockerfiles=$(find . -name "*Dockerfile") >> $GITHUB_ENV
+      - if: ${{ env.Dockerfiles != '' }}
+        name: Run HadoLint
+        uses: jbergstroem/hadolint-gh-action@v1
         with:
-          dockerfile: "*Dockerfile"
+          dockerfile: "${{ env.Dockerfiles }}"
   lint-and-unit-test:
     name: Lint and unit tests
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,12 +42,14 @@ jobs:
     uses: ./.github/workflows/get_runner_image.yaml
   shellcheck-lint:
     name: Shell scripts lint
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
   docker-lint:
     name: Dockerfile lint
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Check for Dockerfiles


### PR DESCRIPTION
Left out a runs-on that is required, this hotfix brings it in (using the same image as the inclusive naming above for consistency).