### PR TITLE
Apply woke to all lines

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           woke-args: '. -c /tmp/config.yml'
+          filter-mode: nofilter
   get-runner-image:
     name: Get runner image
     uses: ./.github/workflows/get_runner_image.yaml


### PR DESCRIPTION
Analyze the whole repository and not just the added lines when running tox. Changes filter-mode from `added` to `nofilter`