### PR TITLE
Feat/annotations - fix shellcheck missing annotations

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,10 +48,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Shellcheck Problem Matchers
         uses: lumaxis/shellcheck-problem-matchers@v1.1.2
-      - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
-        with:
-          severity: error
+      - run: shellcheck -f gcc $(find . -name "*.sh" -type f)
   docker-lint:
     name: Dockerfile lint
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,8 +45,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Shellcheck Problem Matchers
+        uses: lumaxis/shellcheck-problem-matchers@v1.1.2
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
+        with:
+          severity: error
   docker-lint:
     name: Dockerfile lint
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Shellcheck action does not have annotations, they fail currently (see https://github.com/ludeeus/action-shellcheck/issues/55). Another project explicitly modifies the output of shellcheck to have annotations and that works (see https://github.com/lumaxis/shellcheck-problem-matchers). I've sacrificed scanning through a set of well-known files (.bashrc, .zshrc etc.) and looking at a supported shebang (to denote a file without a suffix is a shell script file that shellcheck will ingest), these are all supported in the action-shellcheck, in favor of annotations and passing a custom find to run shellcheck against every file that has a *.sh* suffix. Looking at the `hadolint` action (see https://github.com/jbergstroem/hadolint-gh-action/blob/main/lib/main.sh) I don't know what the one action repo does differently than the other, yet one fails. They all set what is required in terms of enabling annotations via scripts and `echo`ing, still one does the job and the other doesn't. If I solve this by Christmas I'd be happy. You can see how annotations look like at a draft (throw away) PR at https://github.com/canonical/indico-operator/pull/180/files.