### PR TITLE
feat(shellcheck): Gather shell script files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,9 +47,60 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Gather files to scan
+        shell: bash
+        id: gather
+        run: |
+          declare -a filepaths
+          shebangregex="^#! */[^ ]*/(env *)?[abk]*sh"
+
+          set -f # temporarily disable globbing so that globs in inputs aren't expanded
+
+          while IFS= read -r -d '' file; do
+          filepaths+=("$file")
+          done < <(find . \
+                        -type f \
+                        '(' \
+                        -name '*.bash' \
+                        -o -name '.bashrc' \
+                        -o -name 'bashrc' \
+                        -o -name '.bash_aliases' \
+                        -o -name '.bash_completion' \
+                        -o -name '.bash_login' \
+                        -o -name '.bash_logout' \
+                        -o -name '.bash_profile' \
+                        -o -name 'bash_profile' \
+                        -o -name '*.ksh' \
+                        -o -name 'suid_profile' \
+                        -o -name '*.zsh' \
+                        -o -name '.zlogin' \
+                        -o -name 'zlogin' \
+                        -o -name '.zlogout' \
+                        -o -name 'zlogout' \
+                        -o -name '.zprofile' \
+                        -o -name 'zprofile' \
+                        -o -name '.zsenv' \
+                        -o -name 'zsenv' \
+                        -o -name '.zshrc' \
+                        -o -name 'zshrc' \
+                        -o -name '*.sh' \
+                        -o -path '*/.profile' \
+                        -o -path '*/profile' \
+                        -o -name '*.shlib' \
+                        ')' \
+                        -print0)
+
+          while IFS= read -r -d '' file; do
+          head -n1 "$file" | grep -Eqs "$shebangregex" || continue
+          filepaths+=("$file")
+          done < <(find . \
+                        -type f ! -name '*.*' -perm /111 \
+                        -print0)
+          echo "filepaths=${filepaths[@]}" >> $GITHUB_OUTPUT
+          set +f # re-enable globbing
       - name: Shellcheck Problem Matchers
         uses: lumaxis/shellcheck-problem-matchers@v1.1.2
-      - run: shellcheck -f gcc $(find . -name "*.sh" -type f)
+      - run: shellcheck -f gcc ${{steps.gather.outputs.filepaths}}
   docker-lint:
     name: Dockerfile lint
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,9 +98,11 @@ jobs:
                         -print0)
           echo "filepaths=${filepaths[@]}" >> $GITHUB_OUTPUT
           set +f # re-enable globbing
-      - name: Shellcheck Problem Matchers
+      - if: ${{ steps.gather.outputs.filepaths != '' }}
+        name: Shellcheck Problem Matchers
         uses: lumaxis/shellcheck-problem-matchers@v1.1.2
-      - run: shellcheck -f gcc ${{steps.gather.outputs.filepaths}}
+      - if: ${{ steps.gather.outputs.filepaths != '' }}
+        run: shellcheck -f gcc ${{steps.gather.outputs.filepaths}}
   docker-lint:
     name: Dockerfile lint
     runs-on: ubuntu-22.04


### PR DESCRIPTION
I've combined the functionality of the previously used shellcheck action that looks for shell script files with the current shellcheck action that did not have that functionality (but properly annotates issues on PR). It is directly taken from the action with slight modifications (rather reductions) - it will scan for well-known shell files, shell scripts ending in .sh, files that are executable (via `perm /111` filter) and do not have an extension (via `! -f *.*` filter). This was tested in indico-operator prior to this PR.