### PR TITLE
Add reusable workflow for testing and email notification on failure.

### DIFF
--- a/.github/workflows/test_and_notify_faliure.yaml
+++ b/.github/workflows/test_and_notify_faliure.yaml
@@ -29,21 +29,6 @@ on:
       type: string
 
 jobs:
-  lib-check:
-    # This job is the precondition of all jobs that need the Charmhub token.
-    # By disabling this job on forked repositories, we can achieve
-    # disabling the publishing to Charmhub action on forked repositories
-    # while still running tests on push events
-    if: github.repository_owner == 'canonical'
-    name: Check libraries
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.1.1
-        with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
   tests:
     name: Run tests
     uses: ./.github/workflows/test.yaml
@@ -58,15 +43,12 @@ jobs:
     secrets: inherit
   notify-on-failure:
     name: Notify on failure
-    needs: [integration-test]
-    if: ${{ inputs.notify && failure() }}
+    needs: [integration-test, tests]
+    if: ${{ failure() }}
     runs-on: ubuntu-latest
-    env:
-      USERNAME: ${{ secrets.EMAIL_USERNAME }}
-      PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
     steps:
       - name: Check credential exists
-        if: ${{ env.USERNAME == null || env.PASSWORD == null }}
+        if: ${{ secrets.EMAIL_USERNAME == null || secrets.EMAIL_PASSWORD == null }}
         run: |
           echo "Missing email username and password as input for this workflow."
           exit 1
@@ -75,9 +57,9 @@ jobs:
         with:
           server_address: ${{ inputs.email-server-address }}
           server_port: ${{ inputs.email-server-port }}
-          username: ${{ env.USERNAME }}
-          password: ${{ env.PASSWORD }}
-          from: ${{ env.USERNAME }}
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          from: ${{ secrets.EMAIL_USERNAME }}
           to: ${{ inputs.email-receiver }}
           subject: "[Scheduled Test] Test in ${{ github.repository }} has failed"
           body: |

--- a/.github/workflows/test_and_notify_faliure.yaml
+++ b/.github/workflows/test_and_notify_faliure.yaml
@@ -1,32 +1,33 @@
 name: Test and notify failure
 
 on:
-  inputs:
-    integration-test-extra-arguments:
-      description: Additional arguments to pass to the integration tests
-      type: string
-    integration-test-pre-run-script:
-      description: Path to the bash script to be run before the integration tests
-      type: string
-    integration-test-provider:
-      description: Actions operator provider for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
-      type: string
-      default: microk8s
-    integration-test-series:
-      description: List of series to run the integration tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to tox as --series argument
-      type: string
-      default: '[""]'
-    email-server-address:
-      description: Address of email server used for sending email
-      type: string
-      default: smtp.gmail.com
-    email-server-port:
-      description: Port of email server used for sending email
-      type: int
-      default: 465
-    email-receiver:
-      description: Email address for receiving the failure notification.
-      type: string
+  workflow_call:
+    inputs:
+      integration-test-extra-arguments:
+        description: Additional arguments to pass to the integration tests
+        type: string
+      integration-test-pre-run-script:
+        description: Path to the bash script to be run before the integration tests
+        type: string
+      integration-test-provider:
+        description: Actions operator provider for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: microk8s
+      integration-test-series:
+        description: List of series to run the integration tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to tox as --series argument
+        type: string
+        default: '[""]'
+      email-server-address:
+        description: Address of email server used for sending email
+        type: string
+        default: smtp.gmail.com
+      email-server-port:
+        description: Port of email server used for sending email
+        type: int
+        default: 465
+      email-receiver:
+        description: Email address for receiving the failure notification.
+        type: string
 
 jobs:
   tests:

--- a/.github/workflows/test_and_notify_faliure.yaml
+++ b/.github/workflows/test_and_notify_faliure.yaml
@@ -1,0 +1,88 @@
+name: Test and notify failure
+
+on:
+  inputs:
+    integration-test-extra-arguments:
+      description: Additional arguments to pass to the integration tests
+      type: string
+    integration-test-pre-run-script:
+      description: Path to the bash script to be run before the integration tests
+      type: string
+    integration-test-provider:
+      description: Actions operator provider for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
+      type: string
+      default: microk8s
+    integration-test-series:
+      description: List of series to run the integration tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to tox as --series argument
+      type: string
+      default: '[""]'
+    email-server-address:
+      description: Address of email server used for sending email
+      type: string
+      default: smtp.gmail.com
+    email-server-port:
+      description: Port of email server used for sending email
+      type: int
+      default: 465
+    email-receiver:
+      description: Email address for receiving the failure notification.
+      type: string
+
+jobs:
+  lib-check:
+    # This job is the precondition of all jobs that need the Charmhub token.
+    # By disabling this job on forked repositories, we can achieve
+    # disabling the publishing to Charmhub action on forked repositories
+    # while still running tests on push events
+    if: github.repository_owner == 'canonical'
+    name: Check libraries
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@2.1.1
+        with:
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+  tests:
+    name: Run tests
+    uses: ./.github/workflows/test.yaml
+  integration-tests:
+    name: Run integration tests
+    uses: ./.github/workflows/integration_test.yaml
+    with:
+      extra-arguments: ${{ inputs.integration-test-extra-arguments }}
+      pre-run-script: ${{ inputs.integration-test-pre-run-script }}
+      provider: ${{ inputs.integration-test-provider }}
+      series: ${{ inputs.integration-test-series }}
+    secrets: inherit
+  notify-on-failure:
+    name: Notify on failure
+    needs: [integration-test]
+    if: ${{ inputs.notify && failure() }}
+    runs-on: ubuntu-latest
+    env:
+      USERNAME: ${{ secrets.EMAIL_USERNAME }}
+      PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
+    steps:
+      - name: Check credential exists
+        if: ${{ env.USERNAME == null || env.PASSWORD == null }}
+        run: |
+          echo "Missing email username and password as input for this workflow."
+          exit 1
+      - name: Notify Failure
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: ${{ inputs.email-server-address }}
+          server_port: ${{ inputs.email-server-port }}
+          username: ${{ env.USERNAME }}
+          password: ${{ env.PASSWORD }}
+          from: ${{ env.USERNAME }}
+          to: ${{ inputs.email-receiver }}
+          subject: "[Scheduled Test] Test in ${{ github.repository }} has failed"
+          body: |
+            Scheduled test of ${{ github.repository }} has failed.
+            Run ID: ${{ github.run_id}}
+            Run Number: ${{ github.run_number }}
+            Run Attempt: ${{ github.run_attempt}}
+            URL: ${{ github.repositoryUrl }}

--- a/README.md
+++ b/README.md
@@ -43,3 +43,17 @@ The runner image will be set to the value of `bases[0].build-on[0]` in the `char
 | origin-channel | string | "" | Origin channel |
 
 The runner image will be set to the value of `bases[0].build-on[0]` in the `charmcraft.yaml` file, defaulting to ubuntu-22.04 if the file does not exist.
+
+* test_and_notify_failure: Performs test and integration_test and send email notification on failures. The following parameters are available for this workflow:
+
+| Name | Type | Default | Description |
+|--------------------|----------|--------------------|-------------------|
+| integration-test-extra-arguments | string | "" | Additional arguments to pass to the integration test execution |
+| integration-test-pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
+| integration-test-provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| integration-test-series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to tox as --series argument |
+| email-server-address | string | smtp.gmail.com | Address of email server used for sending email
+| email-server-port | int | smtp.gmail.com | Port of email server used for sending email
+| email-receiver | string | "" | Email address for receiving the failure notification
+
+The runner image will be set to the value of `bases[0].build-on[0]` in the `charmcraft.yaml` file, defaulting to ubuntu-22.04 if the file does not exist.


### PR DESCRIPTION
Example intended usage with schedule:
```
name: Scheduled tests

on:
  schedule:
     cron: "0 0 * * 1"

jobs:
  test-and-notify-failure:
    uses: canonical/operator-workflows/.github/workflows/test_and_notify_failure@main
    with:
      email-receiver: someone@example.com
    secrets: inherit
```