### PR TITLE
Add module to the matrix

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,7 +14,11 @@ on:
         type: string
         default: microk8s
       series:
-        description: List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to tox as --series argument
+        description: List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument
+        type: string
+        default: '[""]'
+      module:
+        description: List of testing modules to run the tests in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument
         type: string
         default: '[""]'
       setup-devstack-swift:
@@ -93,6 +97,7 @@ jobs:
     strategy:
       matrix:
         series: ${{ fromJSON(inputs.series) }}
+        module: ${{ fromJSON(inputs.module) }}
       fail-fast: false
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
     needs: [get-images, get-runner-image, build-images]
@@ -159,7 +164,11 @@ jobs:
           if [ ! -z ${{ matrix.series }} ]; then
             series="--series ${{ matrix.series }}"
           fi
-          tox -e integration -- --model testing $series $args ${{ inputs.extra-arguments }}
+          module=""
+          if [ ! -z ${{ matrix.module }} ]; then
+            module="-k ${{ matrix.module }}"
+          fi
+          tox -e integration -- --model testing $series $module $args ${{ inputs.extra-arguments }}
       - name: Dump logs
         uses: canonical/charm-logdump-action@main
         if: failure()

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -17,7 +17,7 @@ on:
         description: List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument
         type: string
         default: '[""]'
-      module:
+      modules:
         description: List of testing modules to run the tests in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument
         type: string
         default: '[""]'
@@ -97,7 +97,7 @@ jobs:
     strategy:
       matrix:
         series: ${{ fromJSON(inputs.series) }}
-        module: ${{ fromJSON(inputs.module) }}
+        modules: ${{ fromJSON(inputs.modules) }}
       fail-fast: false
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
     needs: [get-images, get-runner-image, build-images]
@@ -165,8 +165,8 @@ jobs:
             series="--series ${{ matrix.series }}"
           fi
           module=""
-          if [ ! -z ${{ matrix.module }} ]; then
-            module="-k ${{ matrix.module }}"
+          if [ ! -z ${{ matrix.modules }} ]; then
+            module="-k ${{ matrix.modules }}"
           fi
           tox -e integration -- --model testing $series $module $args ${{ inputs.extra-arguments }}
       - name: Dump logs

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -21,7 +21,11 @@ on:
         type: string
         default: microk8s
       integration-test-series:
-        description: List of series to run the integration tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to tox as --series argument
+        description: List of series to run the integration tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument
+        type: string
+        default: '[""]'
+      integration-test-modules:
+        description: List of testing modules to run the tests in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument
         type: string
         default: '[""]'
 
@@ -52,6 +56,7 @@ jobs:
       pre-run-script: ${{ inputs.integration-test-pre-run-script }}
       provider: ${{ inputs.integration-test-provider }}
       series: ${{ inputs.integration-test-series }}
+      modules: ${{ inputs.integration-test-modules }}
     secrets: inherit
   select-channel:
     name: Select target channel

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The following workflows are available:
 | extra-arguments | string | "" | Additional arguments to pass to the integration test execution |
 | pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
 | provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
-| series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to tox as --series argument |
+| series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
+| modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |
 
 
 * test_and_publish_charm: Builds and publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel).  The following parameters are available for this workflow:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ The following workflows are available:
 | integration-test-extra-arguments | string | "" | Additional arguments to pass to the integration test execution |
 | integration-test-pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
 | integration-test-provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
-| integration-test-series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to tox as --series argument |
+| integration-test-series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
+| integration-test-modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |
 
 The runner image will be set to the value of `bases[0].build-on[0]` in the `charmcraft.yaml` file, defaulting to ubuntu-22.04 if the file does not exist.
 


### PR DESCRIPTION
Adds an additional parameter `modules` so that, if the integration tests have multiple modules, they can be run in parallel. Note that currently, any integration tests in multiple modules that require charms with the same name will fail because the `model` fixture from pytest operator is module scoped and we use the fixed model `testing` which means that any attempts to redeploy a charm in another module will have failures. This parameter also speeds up test execution.