### PR TITLE
Add setup-devstack-swift option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following workflows are available:
 | provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
 | modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |
-
+| setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for testing. |
 
 * test_and_publish_charm: Builds and publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel).  The following parameters are available for this workflow:
 


### PR DESCRIPTION
Available here:
https://github.com/canonical/operator-workflows/blob/main/.github/workflows/integration_test.yaml#L24