### PR TITLE
Add setup-devstack-swift option to test_and_publish_charm

### DIFF
--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -28,6 +28,10 @@ on:
         description: List of testing modules to run the tests in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument
         type: string
         default: '[""]'
+      setup-devstack-swift:
+        description: Use setup-devstack-swift action to prepare a swift server for integration tests.
+        type: boolean
+        default: false
 
 jobs:
   lib-check:
@@ -57,6 +61,7 @@ jobs:
       provider: ${{ inputs.integration-test-provider }}
       series: ${{ inputs.integration-test-series }}
       modules: ${{ inputs.integration-test-modules }}
+      setup-devstack-swift: ${{ inputs.setup-devstack-swift }}
     secrets: inherit
   select-channel:
     name: Select target channel

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following workflows are available:
 | integration-test-provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | integration-test-series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
 | integration-test-modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |
+| setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for integration tests. |
 
 The runner image will be set to the value of `bases[0].build-on[0]` in the `charmcraft.yaml` file, defaulting to ubuntu-22.04 if the file does not exist.
 


### PR DESCRIPTION
Set setup-devstack-swift action to prepare a swift server for integration tests.  Default: false.
