### PR TITLE
Add setting for base for promote charm

### DIFF
--- a/.github/workflows/get_runner_image.yaml
+++ b/.github/workflows/get_runner_image.yaml
@@ -26,11 +26,11 @@ jobs:
       - name: Get build-on value
         run: |
           name="ubuntu"
-          channel="20.04"
+          channel="22.04"
           image="ubuntu-22.04"
           if [ -f charmcraft.yaml ]; then
             name=$(yq '.bases.[0].build-on.[0].name // "ubuntu"' charmcraft.yaml)
-            channel=$(yq '.bases.[0].build-on.[0].channel // '20.04'' charmcraft.yaml)
+            channel=$(yq '.bases.[0].build-on.[0].channel // '22.04'' charmcraft.yaml)
             image="$name-$channel"
           fi
           echo "BUILD_ON_NAME=$name" >> $GITHUB_ENV

--- a/.github/workflows/get_runner_image.yaml
+++ b/.github/workflows/get_runner_image.yaml
@@ -27,12 +27,11 @@ jobs:
         run: |
           name="ubuntu"
           channel="22.04"
-          image="ubuntu-22.04"
           if [ -f charmcraft.yaml ]; then
             name=$(yq '.bases.[0].build-on.[0].name // "ubuntu"' charmcraft.yaml)
             channel=$(yq '.bases.[0].build-on.[0].channel // '22.04'' charmcraft.yaml)
-            image="$name-$channel"
           fi
+          image="$name-$channel"
           echo "BUILD_ON_NAME=$name" >> $GITHUB_ENV
           echo "BUILD_ON_CHANNEL=$channel" >> $GITHUB_ENV
           echo "BUILD_ON=$image" >> $GITHUB_ENV

--- a/.github/workflows/get_runner_image.yaml
+++ b/.github/workflows/get_runner_image.yaml
@@ -3,8 +3,14 @@ name: Get runner image
 on:
   workflow_call:
     outputs:
+      name:
+        description: "Get first occurrence of build-on base name"
+        value: ${{ jobs.get-runner-image.outputs.name }}
+      channel:
+        description: "Get first occurrence of build-on base channel"
+        value: ${{ jobs.get-runner-image.outputs.channel }}
       runs-on:
-        description: "Get first occurence of build-on base as image runner"
+        description: "Get first occurrence of build-on base as image runner"
         value: ${{ jobs.get-runner-image.outputs.runs-on }}
 
 jobs:
@@ -12,6 +18,8 @@ jobs:
     name: Get runner image
     runs-on: ubuntu-22.04
     outputs:
+      name: ${{ env.BUILD_ON_NAME }}
+      channel: ${{ env.BUILD_ON_CHANNEL }}
       runs-on: ${{ env.BUILD_ON }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/get_runner_image.yaml
+++ b/.github/workflows/get_runner_image.yaml
@@ -17,8 +17,14 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get build-on value
         run: |
+          name="ubuntu"
+          channel="20.04"
           image="ubuntu-22.04"
           if [ -f charmcraft.yaml ]; then
-            image=$(yq '[.bases.[0].build-on.[0].name, .bases.[0].build-on.[0].channel] | join("-")' charmcraft.yaml)
+            name=$(yq '.bases.[0].build-on.[0].name // "ubuntu"' charmcraft.yaml)
+            channel=$(yq '.bases.[0].build-on.[0].channel // '20.04'' charmcraft.yaml)
+            image="$name-$channel"
           fi
+          echo "BUILD_ON_NAME=$name" >> $GITHUB_ENV
+          echo "BUILD_ON_CHANNEL=$channel" >> $GITHUB_ENV
           echo "BUILD_ON=$image" >> $GITHUB_ENV

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -24,6 +24,14 @@ jobs:
     needs: get-runner-image
     steps:
       - uses: actions/checkout@v3
+      - name: Get build-on value
+        run: |
+          name="ubuntu"
+          channel="20.04"
+          if [ -f charmcraft.yaml ]; then
+            name=$(yq '.bases.[0].build-on.[0].name' charmcraft.yaml)
+            channel=$(yq '.bases.[0].build-on.[0].channel' charmcraft.yaml)
+          fi
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.1.1
         with:
@@ -31,6 +39,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ inputs.origin-channel }}
           destination-channel: ${{ inputs.destination-channel }}
-          base-name: $(yq '.bases.[0].build-on.[0].name' charmcraft.yaml)
-          base-channel: $(yq '.bases.[0].build-on.[0].channel' charmcraft.yaml)
+          base-name: $name
+          base-channel: $channel
           base-architecture: ${{ inputs.base-architecture }}

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -2,13 +2,13 @@ name: Promote charm
 
 on:
   workflow_call:
+    inputs:
       origin-channel:
         type: string
         description: 'Origin Channel'
       destination-channel:
         type: string
         description: 'Destination Channel'
-    inputs:
       base-name:
         type: string
         description: 'Charmcraft Base Name'

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -24,12 +24,6 @@ jobs:
     needs: get-runner-image
     steps:
       - uses: actions/checkout@v3
-      - name: Get build-on value
-        run: |
-          name=$(yq '.bases.[0].build-on.[0].name // "ubuntu"' charmcraft.yaml)
-          channel=$(yq '.bases.[0].build-on.[0].channel // '20.04'' charmcraft.yaml)
-          echo "BASE_NAME=$name" >> $GITHUB_ENV
-          echo "BASE_CHANNEL=$channel" >> $GITHUB_ENV
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.1.1
         with:
@@ -37,6 +31,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ inputs.origin-channel }}
           destination-channel: ${{ inputs.destination-channel }}
-          base-name: ${{ env.BASE_NAME }}
-          base-channel: ${{ env.BASE_CHANNEL }}
+          base-name: ${{ env.BUILD_ON_NAME }}
+          base-channel: ${{ env.BUILD_ON_CHANNEL }}
           base-architecture: ${{ inputs.base-architecture }}

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -32,7 +32,8 @@ jobs:
             name=$(yq '.bases.[0].build-on.[0].name' charmcraft.yaml)
             channel=$(yq '.bases.[0].build-on.[0].channel' charmcraft.yaml)
           fi
-          echo "BASE_NAME=$name\nBASE_CHANNEL=$channel" >> $GITHUB_ENV
+          echo "BASE_NAME=$name" >> $GITHUB_ENV
+          echo "BASE_CHANNEL=$channel" >> $GITHUB_ENV
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.1.1
         with:

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: debug
-        run: echo "${{github.event.inputs.base-name}} ${{github.event.inputs.base-channel}} ${{github.event.inputs.base-architecture}}"
+        run: echo "${{ github.event.inputs.origin-channel }} ${{ github.event.inputs.base-name }} ${{ github.event.inputs.base-channel }} ${{ github.event.inputs.base-architecture }}"
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.1.1
         with:

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -10,17 +10,14 @@ on:
         type: string
         description: 'Destination Channel'
       base-name:
-        required: true
+        type: string
         description: 'Charmcraft Base Name'
-        default: 'ubuntu'
       base-channel:
-        required: true
+        type: string
         description: 'Charmcraft Base Channel'
-        default: '20.04'
       base-architecture:
-        required: true
+        type: string
         description: 'Charmcraft Base Architecture'
-        default: 'amd64'
 
 jobs:
   get-runner-image:

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -10,14 +10,17 @@ on:
         type: string
         description: 'Destination Channel'
       base-name:
+        type: string
         description: 'Charmcraft Base Name'
         required: true
         default: ''
       base-channel:
+        type: string
         description: 'Charmcraft Base Channel'
         required: true
         default: ''
       base-architecture:
+        type: string
         description: 'Charmcraft Base Architecture'
         required: true
         default: ''

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -9,6 +9,15 @@ on:
       destination-channel:
         type: string
         description: 'Destination Channel'
+      base-name:
+        type: string
+        description: 'Charmcraft Base Name'
+      base-channel:
+        type: string
+        description: 'Charmcraft Base Channel'
+      base-architecture:
+        type: string
+        description: 'Charmcraft Base Architecture'
 
 jobs:
   get-runner-image:
@@ -27,3 +36,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
+          base-name: ${{ github.event.inputs.base-name }}
+          base-channel: ${{ github.event.inputs.base-channel }}
+          base-architecture: ${{ github.event.inputs.base-architecture }}

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -9,14 +9,6 @@ on:
       destination-channel:
         type: string
         description: 'Destination Channel'
-      base-name:
-        type: string
-        description: 'Charmcraft Base Name'
-        default: 'ubuntu'
-      base-channel:
-        type: string
-        description: 'Charmcraft Base Channel'
-        default: '20.04'
       base-architecture:
         type: string
         description: 'Charmcraft Base Architecture'
@@ -39,6 +31,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ inputs.origin-channel }}
           destination-channel: ${{ inputs.destination-channel }}
-          base-name: ${{ inputs.base-name }}
-          base-channel: ${{ inputs.base-channel }}
+          base-name: $(yq '.bases.[0].build-on.[0].name' charmcraft.yaml)
+          base-channel: $(yq '.bases.[0].build-on.[0].channel' charmcraft.yaml)
           base-architecture: ${{ inputs.base-architecture }}

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -29,6 +29,8 @@ jobs:
     needs: get-runner-image
     steps:
       - uses: actions/checkout@v3
+      - name: debug
+        run: echo "${{github.event.inputs.base-name}} ${{github.event.inputs.base-channel}} ${{github.event.inputs.base-architecture}}"
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.1.1
         with:

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -32,6 +32,7 @@ jobs:
             name=$(yq '.bases.[0].build-on.[0].name' charmcraft.yaml)
             channel=$(yq '.bases.[0].build-on.[0].channel' charmcraft.yaml)
           fi
+          echo "BASE_NAME=$name\nBASE_CHANNEL=$channel" >> $GITHUB_ENV
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.1.1
         with:
@@ -39,6 +40,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ inputs.origin-channel }}
           destination-channel: ${{ inputs.destination-channel }}
-          base-name: ${{ name }}
-          base-channel: ${{ channel }}
+          base-name: ${{ env.BASE_NAME }}
+          base-channel: ${{ env.BASE_CHANNEL }}
           base-architecture: ${{ inputs.base-architecture }}

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -9,18 +9,6 @@ on:
       destination-channel:
         type: string
         description: 'Destination Channel'
-      base-name:
-        type: string
-        description: 'Charmcraft Base Name'
-        default: 'ubuntu'
-      base-channel:
-        type: string
-        description: 'Charmcraft Base Channel'
-        default: '20.04'
-      base-architecture:
-        type: string
-        description: 'Charmcraft Base Architecture'
-        default: 'amd64'
 
 jobs:
   get-runner-image:
@@ -39,6 +27,3 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
-          base-name: ${{ github.event.inputs.base-name }}
-          base-channel: ${{ github.event.inputs.base-channel }}
-          base-architecture: ${{ github.event.inputs.base-architecture}}

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -2,22 +2,22 @@ name: Promote charm
 
 on:
   workflow_call:
-    inputs:
       origin-channel:
         type: string
         description: 'Origin Channel'
       destination-channel:
         type: string
         description: 'Destination Channel'
-      charm-base-name:
+    inputs:
+      base-name:
         type: string
         description: 'Charmcraft Base Name'
         default: 'ubuntu'
-      charm-base-channel:
+      base-channel:
         type: string
         description: 'Charmcraft Base Channel'
         default: '20.04'
-      charm-base-architecture:
+      base-architecture:
         type: string
         description: 'Charmcraft Base Architecture'
         default: 'amd64'
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Debug logging
-        run: echo "${{ github.event.inputs.charm-base-name }} ${{ github.event.inputs.origin-channel }} ${{ github.event.inputs.charm-base-channel }}"
+        run: echo "${{ inputs.base-name }} ${{ github.event.inputs.origin-channel }} ${{ inputs.base-channel }}"
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.1.1
         with:
@@ -41,6 +41,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
-          base-name: ${{ github.event.inputs.charm-base-name }}
-          base-channel: ${{ github.event.inputs.charm-base-channel }}
-          base-architecture: ${{ github.event.inputs.charm-base-architecture }}
+          base-name: ${{ inputs.base-name }}
+          base-channel: ${{ inputs.base-channel }}
+          base-architecture: ${{ inputs.base-architecture }}

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -12,12 +12,15 @@ on:
       base-name:
         type: string
         description: 'Charmcraft Base Name'
+        default: 'ubuntu'
       base-channel:
         type: string
         description: 'Charmcraft Base Channel'
+        default: '20.04'
       base-architecture:
         type: string
         description: 'Charmcraft Base Architecture'
+        default: 'amd64'
 
 jobs:
   get-runner-image:

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -9,6 +9,21 @@ on:
       destination-channel:
         type: string
         description: 'Destination Channel'
+    base-name:
+      required: true
+      description: |
+        Charmcraft Base Name
+      default: 'ubuntu'
+    base-channel:
+      required: true
+      description: |
+        Charmcraft Base Channel
+      default: '20.04'
+    base-architecture:
+      required: true
+      description: |
+        Charmcraft Base Architecture
+      default: 'amd64'
 
 jobs:
   get-runner-image:
@@ -27,3 +42,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
+          base-name: ${{ github.event.inputs.base-name }}
+          base-channel: ${{ github.event.inputs.base-channel }}
+          base-architecture: ${{ github.event.inputs.base-architecture }}

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -32,8 +32,6 @@ jobs:
     needs: get-runner-image
     steps:
       - uses: actions/checkout@v3
-      - name: debug
-        run: echo "${{ github.event.inputs.origin-channel }} ${{ github.event.inputs.base-name }} ${{ github.event.inputs.base-channel }} ${{ github.event.inputs.base-architecture }}"
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.1.1
         with:
@@ -44,3 +42,8 @@ jobs:
           base-name: ${{ github.event.inputs.base-name }}
           base-channel: ${{ github.event.inputs.base-channel }}
           base-architecture: ${{ github.event.inputs.base-architecture }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ failure() }}
+        with:
+          limit-access-to-actor: true

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -9,15 +9,15 @@ on:
       destination-channel:
         type: string
         description: 'Destination Channel'
-      base-name:
+      charm-base-name:
         type: string
         description: 'Charmcraft Base Name'
         default: 'ubuntu'
-      base-channel:
+      charm-base-channel:
         type: string
         description: 'Charmcraft Base Channel'
         default: '20.04'
-      base-architecture:
+      charm-base-architecture:
         type: string
         description: 'Charmcraft Base Architecture'
         default: 'amd64'
@@ -32,6 +32,8 @@ jobs:
     needs: get-runner-image
     steps:
       - uses: actions/checkout@v3
+      - name: Debug logging
+        run: echo "${{ github.event.inputs.charm-base-name }} ${{ github.event.inputs.origin-channel }} ${{ github.event.inputs.charm-base-channel }}"
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.1.1
         with:
@@ -39,11 +41,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
-          base-name: ${{ github.event.inputs.base-name }}
-          base-channel: ${{ github.event.inputs.base-channel }}
-          base-architecture: ${{ github.event.inputs.base-architecture }}
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ failure() }}
-        with:
-          limit-access-to-actor: true
+          base-name: ${{ github.event.inputs.charm-base-name }}
+          base-channel: ${{ github.event.inputs.charm-base-channel }}
+          base-architecture: ${{ github.event.inputs.charm-base-architecture }}

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -10,14 +10,17 @@ on:
         type: string
         description: 'Destination Channel'
       base-name:
-        type: string
         description: 'Charmcraft Base Name'
+        required: true
+        default: ''
       base-channel:
-        type: string
         description: 'Charmcraft Base Channel'
+        required: true
+        default: ''
       base-architecture:
-        type: string
         description: 'Charmcraft Base Architecture'
+        required: true
+        default: ''
 
 jobs:
   get-runner-image:

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -36,6 +36,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
-          base-name: 'ubuntu'
-          base-channel: '22.04'
-          base-architecture: 'amd64'
+          base-name: ${{ github.event.inputs.base-name }}
+          base-channel: ${{ github.event.inputs.base-channel }}
+          base-architecture: ${{ github.event.inputs.base-architecture}}

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -31,6 +31,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ inputs.origin-channel }}
           destination-channel: ${{ inputs.destination-channel }}
-          base-name: ${{ env.BUILD_ON_NAME }}
-          base-channel: ${{ env.BUILD_ON_CHANNEL }}
+          base-name: ${{ needs.get-runner-image.outputs.name }}
+          base-channel: ${{ needs.get-runner-image.outputs.channel }}
           base-architecture: ${{ inputs.base-architecture }}

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -39,6 +39,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ inputs.origin-channel }}
           destination-channel: ${{ inputs.destination-channel }}
-          base-name: $name
-          base-channel: $channel
+          base-name: ${{ name }}
+          base-channel: ${{ channel }}
           base-architecture: ${{ inputs.base-architecture }}

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -36,7 +36,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
-          base-name: ${{ github.event.inputs.base-name }}
-          base-channel: ${{ github.event.inputs.base-channel }}
-          base-architecture: ${{ github.event.inputs.base-architecture }}
-
+          base-name: 'ubuntu'
+          base-channel: '22.04'
+          base-architecture: 'amd64'

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -26,12 +26,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get build-on value
         run: |
-          name="ubuntu"
-          channel="20.04"
-          if [ -f charmcraft.yaml ]; then
-            name=$(yq '.bases.[0].build-on.[0].name' charmcraft.yaml)
-            channel=$(yq '.bases.[0].build-on.[0].channel' charmcraft.yaml)
-          fi
+          name=$(yq '.bases.[0].build-on.[0].name // "ubuntu"' charmcraft.yaml)
+          channel=$(yq '.bases.[0].build-on.[0].channel // '20.04'' charmcraft.yaml)
           echo "BASE_NAME=$name" >> $GITHUB_ENV
           echo "BASE_CHANNEL=$channel" >> $GITHUB_ENV
       - name: Release charm to channel

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -32,15 +32,13 @@ jobs:
     needs: get-runner-image
     steps:
       - uses: actions/checkout@v3
-      - name: Debug logging
-        run: echo "${{ inputs.base-name }} ${{ github.event.inputs.origin-channel }} ${{ inputs.base-channel }}"
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.1.1
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          origin-channel: ${{ github.event.inputs.origin-channel }}
-          destination-channel: ${{ github.event.inputs.destination-channel }}
+          origin-channel: ${{ inputs.origin-channel }}
+          destination-channel: ${{ inputs.destination-channel }}
           base-name: ${{ inputs.base-name }}
           base-channel: ${{ inputs.base-channel }}
           base-architecture: ${{ inputs.base-architecture }}

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -12,18 +12,12 @@ on:
       base-name:
         type: string
         description: 'Charmcraft Base Name'
-        required: true
-        default: ''
       base-channel:
         type: string
         description: 'Charmcraft Base Channel'
-        required: true
-        default: ''
       base-architecture:
         type: string
         description: 'Charmcraft Base Architecture'
-        required: true
-        default: ''
 
 jobs:
   get-runner-image:

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -9,21 +9,18 @@ on:
       destination-channel:
         type: string
         description: 'Destination Channel'
-    base-name:
-      required: true
-      description: |
-        Charmcraft Base Name
-      default: 'ubuntu'
-    base-channel:
-      required: true
-      description: |
-        Charmcraft Base Channel
-      default: '20.04'
-    base-architecture:
-      required: true
-      description: |
-        Charmcraft Base Architecture
-      default: 'amd64'
+      base-name:
+        required: true
+        description: 'Charmcraft Base Name'
+        default: 'ubuntu'
+      base-channel:
+        required: true
+        description: 'Charmcraft Base Channel'
+        default: '20.04'
+      base-architecture:
+        required: true
+        description: 'Charmcraft Base Architecture'
+        default: 'amd64'
 
 jobs:
   get-runner-image:
@@ -45,3 +42,4 @@ jobs:
           base-name: ${{ github.event.inputs.base-name }}
           base-channel: ${{ github.event.inputs.base-channel }}
           base-architecture: ${{ github.event.inputs.base-architecture }}
+


### PR DESCRIPTION
The [release charm action from charming-actions repo](https://github.com/canonical/charming-actions/tree/main/release-charm) has base related settings. Such as `Charmcraft Base Name`, `Charmcraft Base Channel`. 
It defaults to ubuntu 20.04 amd64 if not set in input.
This caused some problem with [jenkins-agent-k8s-operator](https://github.com/canonical/jenkins-agent-k8s-operator) as the base is 22.04 and not 20.04.

This PR adds the setting for base and default to the old setting for backward compatibility. 