### PR TITLE
Update woke version to latest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,7 @@ jobs:
           woke-args: '. -c /tmp/config.yml'
           filter-mode: nofilter
           workdir: ${{ inputs.working-directory }}
+          woke-version: latest
   get-runner-image:
     name: Get runner image
     uses: ./.github/workflows/get_runner_image.yaml


### PR DESCRIPTION
`woke` version `v0` is removed in [get-woke/woke](https://github.com/get-woke/woke), use `woke` version `latest` instead.