### PR TITLE
add job that can be used as the required check to enforce status checks pass

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -175,6 +175,7 @@ jobs:
         with:
           app: ${{ env.CHARM_NAME }}
           model: testing
+  required_status_checks:
     name: Required Integration Test Status Checks
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -175,3 +175,9 @@ jobs:
         with:
           app: ${{ env.CHARM_NAME }}
           model: testing
+    name: Required Integration Test Status Checks
+    runs-on: ubuntu-latest
+    needs:
+      - integration-test
+    steps:
+      - run: echo required checks passed

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -261,10 +261,14 @@ jobs:
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
   required_status_checks:
-    name: Required Status Checks
+    name: Required Test Status Checks
     runs-on: ubuntu-latest
     needs:
-      - test
-      - lint
+      - inclusive-naming-check
+      - shellcheck-lint
+      - docker-lint
+      - metadata-lint
+      - lint-and-unit-test
+      - draft-publish-docs
     steps:
-      - run: echo tests passed
+      - run: echo required checks passed

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -260,3 +260,11 @@ jobs:
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
+  required_status_checks:
+    name: Required Status Checks
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - lint
+    steps:
+      - run: echo tests passed


### PR DESCRIPTION
The `required_status_checks` job depends on all the individual checks and is intended to be used in the branch protection settings in a repo to enforce that all the status checks pass in a PR. This reduces the maintenance effort of the required status checks in the GitHub repo which otherwise would need to be adjusted over and over as the names of tests changes. Based on: https://jdkandersson.com/2023/01/04/enforce-all-github-actions-status-checks-to-pass-in-prs/