### PR TITLE
ISD-302-make-chaos-tests-reusable-in-operator-workflows-for-charm-repos

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -214,7 +214,7 @@ jobs:
           APP_NS: ${{ inputs.chaos-app-namespace }}
 
       - name: Run Litmus Chaos experiments
-        uses: merkata/github-chaos-actions@run-multiple-scenarios
+        uses: merkata/github-chaos-actions@feat/run-multiple-scenarios
         env:
           EXPERIMENT_NAME: ${{ inputs.chaos-experiments }}
           APP_LABEL: ${{ inputs.chaos-app-label }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -217,4 +217,7 @@ jobs:
         uses: merkata/github-chaos-actions@feat/run-multiple-scenarios
         env:
           EXPERIMENT_NAME: ${{ inputs.chaos-experiments }}
+          CHAOS_NAMESPACE: ${{ inputs.chaos-namespace }}
+          APP_NS: ${{ inputs.chaos-app-namespace }}
           APP_LABEL: ${{ inputs.chaos-app-label }}
+          APP_KIND: ${{ inputs.chaos-app-kind }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -25,6 +25,30 @@ on:
         description: Use setup-devstack-swift action to prepare a swift server for testing.
         type: boolean
         default: false
+      chaos-enabled:
+        type: boolean
+        description: Whether Chaos testing is enabled
+        default: false
+      chaos-experiments:
+        type: string
+        description: List of experiments to run
+        default: ""
+      chaos-namespace:
+        type: string
+        description: Namespace to install Litmus Chaos
+        default: testing
+      chaos-app-namespace:
+        type: string
+        description: Namespace of chaos tested application
+        default: testing
+      chaos-app-label:
+        type: string
+        description: Label for chaos selection
+        default: ""
+      chaos-app-kind:
+        type: string
+        description: Application kind
+        default: statefulset
     outputs:
       images:
         description: Pushed docker images
@@ -168,10 +192,29 @@ jobs:
           if [ ! -z ${{ matrix.modules }} ]; then
             module="-k ${{ matrix.modules }}"
           fi
-          tox -e integration -- --model testing $series $module $args ${{ inputs.extra-arguments }}
+          tox -e integration -- --model testing --keep-models $series $module $args ${{ inputs.extra-arguments }}
       - name: Dump logs
         uses: canonical/charm-logdump-action@main
         if: failure()
         with:
           app: ${{ env.CHARM_NAME }}
           model: testing
+      - name: Setting up kubeconfig ENV for Github Chaos Action
+        if: ${{ inputs.chaos-enabled }}
+        run: echo ::set-env name=KUBE_CONFIG_DATA::$(sudo microk8s config | base64 -w 0)
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
+      - name: Setup Litmus
+        if: ${{ inputs.chaos-enabled }}
+        uses: merkata/github-chaos-actions@master
+        env:
+          INSTALL_LITMUS: true
+          CHAOS_NAMESPACE: ${{ inputs.chaos-namespace }}
+          APP_NS: ${{ inputs.chaos-app-namespace }}
+
+      - name: Run Litmus Chaos experiments
+        uses: merkata/github-chaos-actions@run-multiple-scenarios
+        env:
+          EXPERIMENT_NAME: ${{ inputs.chaos-experiments }}
+          APP_LABEL: ${{ inputs.chaos-app-label }}


### PR DESCRIPTION
This feature adds the capability of reusable chaos tests. A calling repo needs to supply a set of experiments and a label for pod selection such as

```yaml
jobs:
  integration-tests:
    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@ISD-302-make-chaos-tests-reusable-in-operator-workflows-for-charm-repos
    secrets: inherit
    with:
      chaos-enabled: true
      chaos-experiments: pod-delete
      chaos-app-label: app.kubernetes.io/name=indico
```

The other inputs have defaults that make sense in a testing environment and is tailored towards our applications, meaning that the namespace is `testing` (default of pytest-operator) and the app kind is `statefulset` (default of charmed applications).

The chaos github action does not support specifying multiple experiments, it is either "all" or a specific experiment, which hampers reusability, so I've added that option in the forked repo (I'll make a PR upstream). That's why I'm pointing to my fork currently.

A successful run is available at https://github.com/canonical/indico-operator/actions/runs/3841524657/jobs/6551337982