### PR TITLE
add support for running pflake8 instead of flake8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -222,7 +222,7 @@ jobs:
           EXPECTED_LINT_CMDS="\
               pydocstyle \
               codespell \
-              flake8 \
+              p?flake8 \
               isort \
               black \
               mypy \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -210,7 +210,7 @@ jobs:
               "
           for EXPECTED_LINT_DEP in $EXPECTED_LINT_DEPS; do
               # Check that the `lint: ` includes the expected dependency
-              DEP_REGEX="lint: .*$EXPECTED_LINT_DEP"
+              DEP_REGEX="lint.*$EXPECTED_LINT_DEP"
               if ! grep -q "$DEP_REGEX" stdout.log ; then
                   # Write to stderr
                   >&2 echo "$EXPECTED_LINT_DEP should be in deps of [testenv:lint] environment in tox.ini"
@@ -218,11 +218,11 @@ jobs:
               fi
           done
 
-          # Check cmmands
+          # Check commands
           EXPECTED_LINT_CMDS="\
               pydocstyle \
               codespell \
-              (p?)flake8 \
+              flake8 \
               isort \
               black \
               mypy \
@@ -230,7 +230,8 @@ jobs:
               "
           for EXPECTED_LINT_CMD in $EXPECTED_LINT_CMDS; do
               # Check that there was a `lint run-test: ` line for the expected command
-              CMD_REGEX="lint run-test: commands\[\d+\] \| $EXPECTED_LINT_CMD"
+              # CMD_REGEX="lint.*commands\[\d+\].*$EXPECTED_LINT_CMD"
+              CMD_REGEX="lint.*commands.*$EXPECTED_LINT_CMD"
               if ! grep -q "$CMD_REGEX" stdout.log ; then
                   # Write to stderr
                   >&2 echo "$EXPECTED_LINT_CMD should be in commands of [testenv:lint] environment in tox.ini"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -230,7 +230,6 @@ jobs:
               "
           for EXPECTED_LINT_CMD in $EXPECTED_LINT_CMDS; do
               # Check that there was a `lint run-test: ` line for the expected command
-              # CMD_REGEX="lint.*commands\[\d+\].*$EXPECTED_LINT_CMD"
               CMD_REGEX="lint.*commands.*$EXPECTED_LINT_CMD"
               if ! grep -q "$CMD_REGEX" stdout.log ; then
                   # Write to stderr

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -222,7 +222,7 @@ jobs:
           EXPECTED_LINT_CMDS="\
               pydocstyle \
               codespell \
-              p?flake8 \
+              (p?)flake8 \
               isort \
               black \
               mypy \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -209,7 +209,7 @@ jobs:
               pydocstyle \
               "
           for EXPECTED_LINT_DEP in $EXPECTED_LINT_DEPS; do
-              # Check that the `lint: ` includes the expected dependency
+              # Check that there is a `lint...<dependency>` line for each of the expected dependencies
               DEP_REGEX="lint.*$EXPECTED_LINT_DEP"
               if ! grep -q "$DEP_REGEX" stdout.log ; then
                   # Write to stderr
@@ -229,7 +229,7 @@ jobs:
               pylint \
               "
           for EXPECTED_LINT_CMD in $EXPECTED_LINT_CMDS; do
-              # Check that there was a `lint run-test: ` line for the expected command
+              # Check that there is a `lint...commands...<command>` line for each of the expected commands
               CMD_REGEX="lint.*commands.*$EXPECTED_LINT_CMD"
               if ! grep -q "$CMD_REGEX" stdout.log ; then
                   # Write to stderr

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -28,14 +28,15 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - simple
+      - pflake8
       - metadata_yaml
       - dockerfile
     steps:
       - run: |
           [ '${{ needs.simple.outputs.metadata-lint-outcome }}' = 'skip' ] || (echo metadata lint failed && false)
           [ '${{ needs.simple.outputs.docker-lint-outcome }}' = 'skip' ] || (echo docker lint failed && false)
-          [ '${{ needs.simple.outputs.lint-and-unit-test-outcome }}' = 'success' ] || (echo tox lint failed && false)
-          [ '${{ needs.pflake8.outputs.lint-and-unit-test-outcome }}' = 'success' ] || (echo tox lint failed && false)
+          [ '${{ needs.simple.outputs.lint-and-unit-test-outcome }}' = 'success' ] || (echo lint-and-unit-test failed && false)
+          [ '${{ needs.pflake8.outputs.lint-and-unit-test-outcome }}' = 'success' ] || (echo lint-and-unit-test failed && false)
           [ '${{ needs.metadata_yaml.outputs.metadata-lint-outcome }}' = 'success' ] || (echo metadata lint failed && false)
           [ '${{ needs.metadata_yaml.outputs.docker-lint-outcome }}' = 'skip' ] || (echo docker lint failed && false)
           [ '${{ needs.dockerfile.outputs.metadata-lint-outcome }}' = 'skip' ] || (echo metadata lint failed && false)

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -9,6 +9,11 @@ jobs:
     secrets: inherit
     with:
       working-directory: 'tests/workflows/test/simple/'
+  pflake8:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+    with:
+      working-directory: 'tests/workflows/test/pflake8/'
   metadata_yaml:
     uses: ./.github/workflows/test.yaml
     secrets: inherit
@@ -30,6 +35,7 @@ jobs:
           [ '${{ needs.simple.outputs.metadata-lint-outcome }}' = 'skip' ] || (echo metadata lint failed && false)
           [ '${{ needs.simple.outputs.docker-lint-outcome }}' = 'skip' ] || (echo docker lint failed && false)
           [ '${{ needs.simple.outputs.lint-and-unit-test-outcome }}' = 'success' ] || (echo tox lint failed && false)
+          [ '${{ needs.pflake8.outputs.lint-and-unit-test-outcome }}' = 'success' ] || (echo tox lint failed && false)
           [ '${{ needs.metadata_yaml.outputs.metadata-lint-outcome }}' = 'success' ] || (echo metadata lint failed && false)
           [ '${{ needs.metadata_yaml.outputs.docker-lint-outcome }}' = 'skip' ] || (echo docker lint failed && false)
           [ '${{ needs.dockerfile.outputs.metadata-lint-outcome }}' = 'skip' ] || (echo metadata lint failed && false)

--- a/tests/workflows/test/pflake8/main.py
+++ b/tests/workflows/test/pflake8/main.py
@@ -1,0 +1,1 @@
+../simple/main.py

--- a/tests/workflows/test/pflake8/tox.ini
+++ b/tests/workflows/test/pflake8/tox.ini
@@ -1,0 +1,53 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist=True
+skip_missing_interpreters = True
+envlist = lint, unit, static, coverage-report
+
+[testenv]
+basepython = python3
+allowlist_externals = /bin/echo
+
+[testenv:lint]
+description = Run lint
+deps =
+    mypy
+    isort
+    black
+    flake8-docstrings
+    flake8-docstrings-complete
+    flake8-builtins
+    flake8-test-docs
+    pyproject-flake8
+    pep8-naming
+    codespell
+    pylint
+    pydocstyle
+    pytest
+commands =
+    pydocstyle main.py
+    codespell {toxinidir} --skip {toxinidir}/.tox --skip {toxinidir}/.mypy_cache
+    pflake8 main.py
+    isort --check-only main.py
+    black --check main.py
+    mypy main.py
+    pylint main.py
+
+[testenv:unit]
+description = Run unit tests
+commands = /bin/echo Run unit tests
+
+[testenv:static]
+description = Run static analysis tests
+commands = /bin/echo Run static analysis tests
+
+[testenv:coverage-report]
+description = Create test coverage report
+output = '\
+    Name           Stmts   Miss Branch BrPart  Cover   Missing\
+    ----------------------------------------------------------\
+    sample_report     0      0     0     0    0%   0\
+    ----------------------------------------------------------\
+    TOTAL            0      0     0     0    0%'
+commands = /bin/echo -e {[testenv:coverage-report]output}


### PR DESCRIPTION
The linting checks assume `flake8` is used when many of our projects use `pflake8`, this PR adds support for either `flake8` of `pflake8`. It also is more flexible with reading tox output to support more versions of `tox` (the previous regex wasn't going to work with the latest `tox` version released)