### PR TITLE
feat(chaos): Add experiment duration

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -49,6 +49,10 @@ on:
         type: string
         description: Application kind
         default: statefulset
+      chaos-duration:
+        type: string
+        description: Duration of the chaos experiment
+        default: 60
     outputs:
       images:
         description: Pushed docker images
@@ -221,6 +225,7 @@ jobs:
           APP_NS: ${{ inputs.chaos-app-namespace }}
           APP_LABEL: ${{ inputs.chaos-app-label }}
           APP_KIND: ${{ inputs.chaos-app-kind }}
+          TOTAL_CHAOS_DURATION: ${{ inputs.chaos-duration }}
   required_status_checks:
     name: Required Integration Test Status Checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR makes the TOTAL_CHAOS_DURATION configurable as an input - that is needed for charms like Discourse that take longer to recover from a chaos experiment such as a `pod delete` and the default of 60 seconds is not enough.