### PR TITLE
feat(ISD-374): Add ZAP GitHub Action Full Scan

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -77,10 +77,13 @@ on:
       zap-before-command:
         description: Command to run before ZAP testing
         type: string
-      zap-options:
+      zap-cmd-options:
         description: Options to be used by ZAP
         type: string
         default: "-T 60"
+      zap-rules-file-name:
+        description: Rules file to ignore any alerts from the ZAP scan
+        type: string
     outputs:
       images:
         description: Pushed docker images
@@ -273,10 +276,11 @@ jobs:
           ZAP_AUTH_HEADER:  ${{ inputs.zap-auth-header }}
           ZAP_AUTH_HEADER_VALUE:  ${{ inputs.zap-auth-header-value  }}
         with:
-          issue_title: 'ZAP report'
+          issue_title: 'OWASP ZAP report'
           fail_action: false
           target: ${{ inputs.zap-target-protocol }}://${{ env.ZAP_TARGET }}:${{ inputs.zap-target-port }}/
-          cmd_options: ${{ inputs.zap-options }}
+          cmd_options: ${{ inputs.zap-cmd-options }}
+          rules_file_name: ${{ inputs.zap-rules-file-name }}
   required_status_checks:
     name: Required Integration Test Status Checks
     runs-on: ubuntu-latest

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -279,7 +279,7 @@ jobs:
           APP_NS: ${{ inputs.chaos-app-namespace }}
           CHAOS_INTERVAL: ${{ inputs.chaos-interval }}
           CHAOS_NAMESPACE: ${{ inputs.chaos-namespace }}
-          DELAY: $${{ inputs.chaos-status-delay }}
+          DELAY: ${{ inputs.chaos-status-delay }}
           DURATION: ${{ inputs.chaos-status-duration }}
           EXPERIMENT_NAME: ${{ inputs.chaos-experiments }}
           TOTAL_CHAOS_DURATION: ${{ inputs.chaos-duration }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -75,27 +75,12 @@ on:
           Retry is chaos-duration/chaos-delay times and each retry
           sleeps chaos-delay
         default: 90
-      zap-dast-enabled:
-        type: boolean
-        description: Whether ZAP testing is enabled
-        default: false
       zap-auth-header:
         description: If this is defined then its value will be added as a header to all of the ZAP requests
         type: string
       zap-auth-header-value:
         description:  If this is defined then its value will be used as the header name to all of the ZAP requests
         type: string
-      zap-target:
-        description:  If this is not set, the unit IP address will be used as ZAP target
-        type: string
-      zap-target-protocol:
-        description:  ZAP target protocol
-        type: string
-        default: "http"
-      zap-target-port:
-        description:  ZAP target port
-        type: string
-        default: 80
       zap-before-command:
         description: Command to run before ZAP testing
         type: string
@@ -103,6 +88,21 @@ on:
         description: Options to be used by ZAP
         type: string
         default: "-T 60"
+      zap-enabled:
+        type: boolean
+        description: Whether ZAP testing is enabled
+        default: false
+      zap-target:
+        description:  If this is not set, the unit IP address will be used as ZAP target
+        type: string
+      zap-target-port:
+        description:  ZAP target port
+        type: string
+        default: 80
+      zap-target-protocol:
+        description:  ZAP target protocol
+        type: string
+        default: "http"
       zap-rules-file-name:
         description: Rules file to ignore any alerts from the ZAP scan
         type: string
@@ -285,18 +285,18 @@ jobs:
           TOTAL_CHAOS_DURATION: ${{ inputs.chaos-duration }}
           KUBE_CONFIG_DATA: ${{ env.KUBE_CONFIG_DATA }}
       - name: Set Zap target env for Github Zap Action to Juju Unit IP Address
-        if: ${{ inputs.zap-dast-enabled && inputs.zap-target == '' }}
+        if: ${{ inputs.zap-enabled && inputs.zap-target == '' }}
         run: echo "ZAP_TARGET=$(juju show-unit ${{ env.CHARM_NAME }}/0 --format=json | jq -r '.["${{ env.CHARM_NAME }}/0"]["address"]')" >> $GITHUB_ENV
       - name: Set Zap target env for Github Zap Action to zap-target value
-        if: ${{ inputs.zap-dast-enabled && inputs.zap-target != '' }}
+        if: ${{ inputs.zap-enabled && inputs.zap-target != '' }}
         run: echo "ZAP_TARGET=${{ inputs.zap-target }}" >> $GITHUB_ENV
       - name: Run command before Github Zap Action
-        if: ${{ inputs.zap-dast-enabled && inputs.zap-before-command != '' }}
+        if: ${{ inputs.zap-enabled && inputs.zap-before-command != '' }}
         run: ${{ inputs.zap-before-command }}
         env:
           ZAP_TARGET: ${{ env.ZAP_TARGET }}
       - name: Run Github Zap Action
-        if: ${{ inputs.zap-dast-enabled }}
+        if: ${{ inputs.zap-enabled }}
         uses: zaproxy/action-full-scan@v0.4.0
         env:
           ZAP_AUTH_HEADER:  ${{ inputs.zap-auth-header }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -53,6 +53,34 @@ on:
         type: string
         description: Duration of the chaos experiment
         default: 60
+      zap-dast-enabled:
+        type: boolean
+        description: Whether ZAP testing is enabled
+        default: false
+      zap-auth-header:
+        description: If this is defined then its value will be added as a header to all of the ZAP requests
+        type: string
+      zap-auth-header-value:
+        description:  If this is defined then its value will be used as the header name to all of the ZAP requests
+        type: string
+      zap-target:
+        description:  If this is not set, the unit IP address will be used as ZAP target
+        type: string
+      zap-target-protocol:
+        description:  ZAP target protocol
+        type: string
+        default: "http"
+      zap-target-port:
+        description:  ZAP target port
+        type: string
+        default: 80
+      zap-before-command:
+        description: Command to run before ZAP testing
+        type: string
+      zap-options:
+        description: Options to be used by ZAP
+        type: string
+        default: "-T 60"
     outputs:
       images:
         description: Pushed docker images
@@ -205,10 +233,9 @@ jobs:
           model: testing
       - name: Setting up kubeconfig ENV for Github Chaos Action
         if: ${{ inputs.chaos-enabled }}
-        run: echo ::set-env name=KUBE_CONFIG_DATA::$(sudo microk8s config | base64 -w 0)
+        run: echo "KUBE_CONFIG_DATA=$(sudo microk8s config | base64 -w 0)" >> $GITHUB_ENV
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-
       - name: Setup Litmus
         if: ${{ inputs.chaos-enabled }}
         uses: merkata/github-chaos-actions@master
@@ -216,8 +243,9 @@ jobs:
           INSTALL_LITMUS: true
           CHAOS_NAMESPACE: ${{ inputs.chaos-namespace }}
           APP_NS: ${{ inputs.chaos-app-namespace }}
-
+          KUBE_CONFIG_DATA: ${{ env.KUBE_CONFIG_DATA }}
       - name: Run Litmus Chaos experiments
+        if: ${{ inputs.chaos-enabled }}
         uses: merkata/github-chaos-actions@feat/run-multiple-scenarios
         env:
           EXPERIMENT_NAME: ${{ inputs.chaos-experiments }}
@@ -226,6 +254,29 @@ jobs:
           APP_LABEL: ${{ inputs.chaos-app-label }}
           APP_KIND: ${{ inputs.chaos-app-kind }}
           TOTAL_CHAOS_DURATION: ${{ inputs.chaos-duration }}
+          KUBE_CONFIG_DATA: ${{ env.KUBE_CONFIG_DATA }}
+      - name: Set Zap target env for Github Zap Action to Juju Unit IP Address
+        if: ${{ inputs.zap-dast-enabled && inputs.zap-target == '' }}
+        run: echo "ZAP_TARGET=$(juju show-unit ${{ env.CHARM_NAME }}/0 --format=json | jq -r '.["${{ env.CHARM_NAME }}/0"]["address"]')" >> $GITHUB_ENV
+      - name: Set Zap target env for Github Zap Action to zap-target value
+        if: ${{ inputs.zap-dast-enabled && inputs.zap-target != '' }}
+        run: echo "ZAP_TARGET=${{ inputs.zap-target }}" >> $GITHUB_ENV
+      - name: Run command before Github Zap Action
+        if: ${{ inputs.zap-dast-enabled && inputs.zap-before-command != '' }}
+        run: ${{ inputs.zap-before-command }}
+        env:
+          ZAP_TARGET: ${{ env.ZAP_TARGET }}
+      - name: Run Github Zap Action
+        if: ${{ inputs.zap-dast-enabled }}
+        uses: zaproxy/action-full-scan@v0.4.0
+        env:
+          ZAP_AUTH_HEADER:  ${{ inputs.zap-auth-header }}
+          ZAP_AUTH_HEADER_VALUE:  ${{ inputs.zap-auth-header-value  }}
+        with:
+          issue_title: 'ZAP report'
+          fail_action: false
+          target: ${{ inputs.zap-target-protocol }}://${{ env.ZAP_TARGET }}:${{ inputs.zap-target-port }}/
+          cmd_options: ${{ inputs.zap-options }}
   required_status_checks:
     name: Required Integration Test Status Checks
     runs-on: ubuntu-latest

--- a/OWASPZAP.md
+++ b/OWASPZAP.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-By enabling ZAP in our integration test, the [ZAP full scan GitHub action](https://github.com/marketplace/actions/owasp-zap-full-scan) will run a ZAP full scan that attacks the web application to find additional vulnerabilities.
+By enabling ZAP in the integration test, the [ZAP full scan GitHub action](https://github.com/marketplace/actions/owasp-zap-full-scan) will run a ZAP full scan that attacks the web application to find additional vulnerabilities.
 
 The alerts will be maintained as a GitHub issue in the corresponding repository as well as an artifact in the Integration Test workflow.
 

--- a/OWASPZAP.md
+++ b/OWASPZAP.md
@@ -1,0 +1,141 @@
+# OWASP ZAP
+
+[OWASP ZAP](https://www.zaproxy.org/) is an open-source web application security scanner.
+
+## Description
+
+By enabling ZAP in our integration test, the [ZAP full scan GitHub action](https://github.com/marketplace/actions/owasp-zap-full-scan) will run a ZAP full scan that attacks the web application to find additional vulnerabilities.
+
+The alerts will be maintained as a GitHub issue in the corresponding repository as well as an artifact in the Integration Test workflow.
+
+## Warnings
+
+- The script can potentially run for a long period. The default value for ``zap-cmd-options`` prevents that by setting a max time of 60 minutes. Mind that when changing this parameter.
+- By deciding to run against an external target, since it simulates an attack, you should only use the full scan against targets that you have permission to test.
+
+## How to use
+
+If there is no need for customization, the test can be enabled by setting the parameter ``zap-dast-enabled`` to true.
+
+Then, after the integration tests, the ZAP full scan will run against the Charm unit IP address (port 80) and the logs can be viewed in the Job output, the artifact, or if vulnerabilities are found, in an issue entitled 'OWASP ZAP report'.
+
+If future scans identify a fixed issue or new alerts the action will update the issue with the required information.
+
+## Examples
+
+### Default
+
+```yaml
+jobs:
+  integration-tests:
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    secrets: inherit
+    with:
+      zap-dast-enabled: true
+```
+
+### Custom target port and run command before the test
+
+A ``ZAP_TARGET`` environment variable is available with the ``zap_target`` parameter value or if is not set, with the unit IP address.
+
+```yaml
+jobs:
+  integration-tests:
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    secrets: inherit
+    with:
+      zap-dast-enabled: true
+      zap-target-port: 8080
+      zap-before-command: "curl -H \"Host: indico.local\" $ZAP_TARGET:8080/bootstrap --data-raw 'csrf_token=00000000-0000-0000-0000-000000000000&first_name=admin&last_name=admin&email=admin%40admin.com&username=admin&password=lunarlobster&confirm_password=lunarlobster&affiliation=Canonical'"
+```
+
+### Authorization Header
+
+See more information about authorization headers in [Authentication Env Vars](https://www.zaproxy.org/docs/authentication/handling-auth-yourself/#authentication-env-vars).
+
+```yaml
+jobs:
+  integration-tests:
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    secrets: inherit
+    with:
+      zap-dast-enabled: true
+      zap-auth-header: Auth
+      zap-auth-value: SomeValue
+```
+
+### Custom Header
+
+It's possible to override or modify the behavior of the script components by using a [Scan Hook](https://www.zaproxy.org/docs/docker/scan-hooks/). Within the hook, a script can be loaded to change the request and add a new header.
+
+First, create a ```hook.py``` file with the following content:
+```python
+def zap_started(zap, target):
+   print(zap.script.load('Add Header Script', 'httpsender', 'python : jython', '/zap/wrk/tests/zap/add_header_request.py'))
+   print(zap.script.enable('Add Header Script'))
+
+def zap_pre_shutdown(zap):
+    print("script.listEngines")
+    print(zap.script.list_engines)
+    print()
+    print("script.listScripts")
+    print(zap.script.list_scripts)
+```
+
+Note: The ```zap_pre_shutdown``` was altered just to show the script list and confirm if it was loaded as expected.
+
+Then, create a ```add_header_request.py``` file with the following content:
+```python
+headers = dict({"Host": "indico.local"})
+
+def sendingRequest(msg, initiator, helper):
+    for item in list(headers):
+      msg.getRequestHeader().setHeader(item, headers[item])
+
+def responseReceived(msg, initiator, helper):
+    pass;
+```
+
+This will add every header defined in ```headers``` to every request made by ZAP.
+
+The workflow should look like this:
+```
+jobs:
+  integration-tests:
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    secrets: inherit
+    with:
+      zap-dast-enabled: true
+      zap-cmd-options: '-T 60 -z "-addoninstall jython" --hook "/zap/wrk/tests/zap/hook.py"'
+```
+
+1. Install the ```jython``` addon. See [addons](https://www.zaproxy.org/addons/) for a complete list.
+2. Set the hook parameter to the ```hook.py``` file inside the repository.
+3. The ```hook.py``` should be updated accordingly to the ```add_header_request.py``` path in the repository as well.
+
+### Bonus: Rewrite the URL and log the requests
+
+Same procedure as the previous item but with the ```rewrite_and_log_request.py``` file.
+
+```python
+import os
+
+log_filename = r'/zap/wrk/requests.log'
+target = os.getenv('ZAP_TARGET')
+
+def sendingRequest(msg, initiator, helper):
+    host = msg.getRequestHeader().getURI().getHost()
+
+    if "indico.local" in host:
+        uri = msg.getRequestHeader().getURI()
+        uri.setEscapedAuthority(target + ":8080")
+        msg.getRequestHeader().setURI(uri);
+
+    with open(log_filename, 'a') as f:
+      f.write(msg.getRequestHeader().toString())
+
+
+
+def responseReceived(msg, initiator, helper):
+    pass;
+```

--- a/OWASPZAP.md
+++ b/OWASPZAP.md
@@ -15,7 +15,7 @@ The alerts will be maintained as a GitHub issue in the corresponding repository 
 
 ## How to use
 
-If there is no need for customization, the test can be enabled by setting the parameter ``zap-dast-enabled`` to true.
+If there is no need for customization, the test can be enabled by setting the parameter ``zap-enabled`` to true.
 
 Then, after the integration tests, the ZAP full scan will run against the Charm unit IP address (port 80) and the logs can be viewed in the Job output, the artifact, or if vulnerabilities are found, in an issue entitled 'OWASP ZAP report'.
 
@@ -31,8 +31,10 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      zap-dast-enabled: true
+      zap-enabled: true
 ```
+
+Since zap-target is not set, the unit IP address will be used as the target.
 
 ### Custom target port and run command before the test
 
@@ -44,7 +46,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      zap-dast-enabled: true
+      zap-enabled: true
       zap-target-port: 8080
       zap-before-command: "curl -H \"Host: indico.local\" $ZAP_TARGET:8080/bootstrap --data-raw 'csrf_token=00000000-0000-0000-0000-000000000000&first_name=admin&last_name=admin&email=admin%40admin.com&username=admin&password=lunarlobster&confirm_password=lunarlobster&affiliation=Canonical'"
 ```
@@ -59,7 +61,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      zap-dast-enabled: true
+      zap-enabled: true
       zap-auth-header: Auth
       zap-auth-value: SomeValue
 ```
@@ -105,7 +107,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      zap-dast-enabled: true
+      zap-enabled: true
       zap-cmd-options: '-T 60 -z "-addoninstall jython" --hook "/zap/wrk/tests/zap/hook.py"'
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ The following workflows are available:
 | zap-target-protocol | string | "http" | ZAP target protocol |
 | zap-target-port | string | 80 | ZAP target port |
 | zap-before-command | string | "" | Command to run before ZAP testing |
-| zap-options | string | "-T 60" | Options to be used by ZAP |
+| zap-cmd-options | string | "-T 60" | Options to be used by ZAP. Default sets maximum scanning time to 60 minutes |
+| zap-rules-file-name | string | "" | Rules file to ignore any alerts from the ZAP scan |
 
+More information about OWASP ZAP testing can be found [here](OWASPZAP.md).
 
 * test_and_publish_charm: Builds and publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel).  The following parameters are available for this workflow:
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ The following workflows are available:
 | chaos-app-label | string | "" | Label for chaos selection |
 | chaos-app-kind | string | statefulset | Application kind |
 | chaos-duration | string | 60 | Duration of the chaos experiment |
-| zap-dast-enabled | boolean | false | Whether ZAP testing is enabled |
 | zap-auth-header | string | "" | If this is defined then its value will be added as a header to all of the ZAP requests |
 | zap-auth-header-value | string | "" | If this is defined then its value will be used as the header name to all of the ZAP requests |
+| zap-before-command | string | "" | Command to run before ZAP testing |
+| zap-cmd-options | string | "-T 60" | Options to be used by ZAP. Default sets maximum scanning time to 60 minutes |
+| zap-enabled | boolean | false | Whether ZAP testing is enabled |
 | zap-target | string | "" | If this is not set, the unit IP address will be used as ZAP target |
 | zap-target-protocol | string | "http" | ZAP target protocol |
 | zap-target-port | string | 80 | ZAP target port |
-| zap-before-command | string | "" | Command to run before ZAP testing |
-| zap-cmd-options | string | "-T 60" | Options to be used by ZAP. Default sets maximum scanning time to 60 minutes |
 | zap-rules-file-name | string | "" | Rules file to ignore any alerts from the ZAP scan |
 
 More information about OWASP ZAP testing can be found [here](OWASPZAP.md).

--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ The following workflows are available:
 | series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
 | modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |
 | setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for testing. |
+| chaos-enabled  | bool | false | Whether Chaos testing is enabled |
+| chaos-experiments | string | "" | List of experiments to run |
+| chaos-namespace | string | testing | Namespace to install Litmus Chaos |
+| chaos-app-namespace | string | testing | Namespace of chaos tested application |
+| chaos-app-label | string | "" | Label for chaos selection |
+| chaos-app-kind | string | statefulset | Application kind |
+| chaos-duration | string | 60 | Duration of the chaos experiment |
+| zap-dast-enabled | boolean | false | Whether ZAP testing is enabled |
+| zap-auth-header | string | "" | If this is defined then its value will be added as a header to all of the ZAP requests |
+| zap-auth-header-value | string | "" | If this is defined then its value will be used as the header name to all of the ZAP requests |
+| zap-target | string | "" | If this is not set, the unit IP address will be used as ZAP target |
+| zap-target-protocol | string | "http" | ZAP target protocol |
+| zap-target-port | string | 80 | ZAP target port |
+| zap-before-command | string | "" | Command to run before ZAP testing |
+| zap-options | string | "-T 60" | Options to be used by ZAP |
+
 
 * test_and_publish_charm: Builds and publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel).  The following parameters are available for this workflow:
 


### PR DESCRIPTION
- Remove set-env
- Update README.md
- Add following new inputs:
```yaml
     zap-dast-enabled:
        type: boolean
        description: Whether ZAP testing is enabled
        default: false
      zap-auth-header:
        description: If this is defined then its value will be added as a header to all of the ZAP requests
        type: string
      zap-auth-header-value:
        description:  If this is defined then its value will be used as the header name to all of the ZAP requests
        type: string
      zap-target:
        description:  If this is not set, the unit IP address will be used as ZAP target
        type: string
      zap-target-protocol:
        description:  ZAP target protocol
        type: string
        default: "http"
      zap-target-port:
        description:  ZAP target port
        type: string
        default: 80
      zap-before-command:
        description: Command to run before ZAP testing
        type: string
      zap-options:
        description: Options to be used by ZAP
        type: string
        default: "-T 60"
```

Note: Since the ZAP testing runs together with the Integration test, the option fail_action is set to False to prevent the entire action to fail if vulnerabilities are found.

References:
https://www.zaproxy.org/docs/docker/full-scan/
https://github.com/marketplace/actions/owasp-zap-full-scan