### PR TITLE
Add support for extra matrices

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -6,6 +6,12 @@ on:
       extra-arguments:
         description: Additional arguments to pass to the integration test execution
         type: string
+      extra-test-matrix:
+        description: |
+          Aditional mapping to lists of matrices to be applied on top of series and modules matrix in JSON format, i.e. '{"extras":["foo","bar"]}'.
+          Each mapping will be injected into the matrix section of the integration-test.
+        type: string
+        default: '{}'
       pre-run-script:
         description: Path to the bash script to be run before the integration tests
         type: string
@@ -126,6 +132,7 @@ jobs:
       matrix:
         series: ${{ fromJSON(inputs.series) }}
         modules: ${{ fromJSON(inputs.modules) }}
+        ${{ insert }}: ${{ fromJSON(inputs.extra-test-matrix) }}
       fail-fast: false
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
     needs: [get-images, get-runner-image, build-images]


### PR DESCRIPTION
This PR addresses the issue #71, where additional matrices can be injected into the integration-test matrix, on top of the series and modules.

This helps charms like wordpress-k8s-operator to leverage testing with custom matrices([link](https://github.com/canonical/wordpress-k8s-operator/blob/448da97b3a7720c2ba7f8ed3d80712f3b33a8b38/.github/workflows/integration_test.yaml#L13)).

A demo run for the workflow: [link](https://github.com/yanksyoon/demo-matrix-inject/actions/runs/3901593866)
Link to demo code for workflow [caller](https://github.com/yanksyoon/demo-matrix-inject/blob/main/.github/workflows/caller.yaml)
Link to demo code workflow [integration test](https://github.com/yanksyoon/demo-matrix-inject/blob/main/.github/workflows/integration_test.yaml)