### PR TITLE
Feat/configurable chaos duration

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -51,8 +51,24 @@ on:
         default: statefulset
       chaos-duration:
         type: string
-        description: Duration of the chaos experiment
+        description: |
+          Duration of the chaos experiment (added to 600s for go test timeout)
         default: 60
+      chaos-interval:
+        type: string
+        description: Interval to attempt re-run of an experiment
+        default: 30
+      chaos-status-duration:
+        type: string
+        description: |
+          Duration used for status check retries
+          Retry is chaos-duration/chaos-delay times and each retry
+          sleeps chaos-delay
+        default: 90
+      chaos-status-delay:
+        type: string
+        description: Delay is the wait(sleep) time on every status retry
+        default: 5
     outputs:
       images:
         description: Pushed docker images
@@ -218,6 +234,7 @@ jobs:
           APP_NS: ${{ inputs.chaos-app-namespace }}
 
       - name: Run Litmus Chaos experiments
+        if: ${{ inputs.chaos-enabled }}
         uses: merkata/github-chaos-actions@feat/run-multiple-scenarios
         env:
           EXPERIMENT_NAME: ${{ inputs.chaos-experiments }}
@@ -226,6 +243,9 @@ jobs:
           APP_LABEL: ${{ inputs.chaos-app-label }}
           APP_KIND: ${{ inputs.chaos-app-kind }}
           TOTAL_CHAOS_DURATION: ${{ inputs.chaos-duration }}
+          CHAOS_INTERVAL: ${{ inputs.chaos-interval }}
+          DURATION: ${{ inputs.chaos-status-duration }}
+          DELAY: $${{ inputs.chaos-status-delay }}
   required_status_checks:
     name: Required Integration Test Status Checks
     runs-on: ubuntu-latest

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -25,6 +25,23 @@ on:
         description: Use setup-devstack-swift action to prepare a swift server for testing.
         type: boolean
         default: false
+      chaos-app-kind:
+        type: string
+        description: Application kind
+        default: statefulset
+      chaos-app-label:
+        type: string
+        description: Label for chaos selection
+        default: ""
+      chaos-app-namespace:
+        type: string
+        description: Namespace of chaos tested application
+        default: testing
+      chaos-duration:
+        type: string
+        description: |
+          Duration of the chaos experiment (added to 600s for go test timeout)
+        default: 60
       chaos-enabled:
         type: boolean
         description: Whether Chaos testing is enabled
@@ -33,31 +50,18 @@ on:
         type: string
         description: List of experiments to run
         default: ""
-      chaos-namespace:
-        type: string
-        description: Namespace to install Litmus Chaos
-        default: testing
-      chaos-app-namespace:
-        type: string
-        description: Namespace of chaos tested application
-        default: testing
-      chaos-app-label:
-        type: string
-        description: Label for chaos selection
-        default: ""
-      chaos-app-kind:
-        type: string
-        description: Application kind
-        default: statefulset
-      chaos-duration:
-        type: string
-        description: |
-          Duration of the chaos experiment (added to 600s for go test timeout)
-        default: 60
       chaos-interval:
         type: string
         description: Interval to attempt re-run of an experiment
         default: 30
+      chaos-namespace:
+        type: string
+        description: Namespace to install Litmus Chaos
+        default: testing
+      chaos-status-delay:
+        type: string
+        description: Delay is the wait(sleep) time on every status retry
+        default: 5
       chaos-status-duration:
         type: string
         description: |
@@ -65,10 +69,6 @@ on:
           Retry is chaos-duration/chaos-delay times and each retry
           sleeps chaos-delay
         default: 90
-      chaos-status-delay:
-        type: string
-        description: Delay is the wait(sleep) time on every status retry
-        default: 5
     outputs:
       images:
         description: Pushed docker images
@@ -229,23 +229,23 @@ jobs:
         if: ${{ inputs.chaos-enabled }}
         uses: merkata/github-chaos-actions@master
         env:
-          INSTALL_LITMUS: true
-          CHAOS_NAMESPACE: ${{ inputs.chaos-namespace }}
           APP_NS: ${{ inputs.chaos-app-namespace }}
+          CHAOS_NAMESPACE: ${{ inputs.chaos-namespace }}
+          INSTALL_LITMUS: true
 
       - name: Run Litmus Chaos experiments
         if: ${{ inputs.chaos-enabled }}
         uses: merkata/github-chaos-actions@feat/run-multiple-scenarios
         env:
-          EXPERIMENT_NAME: ${{ inputs.chaos-experiments }}
-          CHAOS_NAMESPACE: ${{ inputs.chaos-namespace }}
-          APP_NS: ${{ inputs.chaos-app-namespace }}
-          APP_LABEL: ${{ inputs.chaos-app-label }}
           APP_KIND: ${{ inputs.chaos-app-kind }}
-          TOTAL_CHAOS_DURATION: ${{ inputs.chaos-duration }}
+          APP_LABEL: ${{ inputs.chaos-app-label }}
+          APP_NS: ${{ inputs.chaos-app-namespace }}
           CHAOS_INTERVAL: ${{ inputs.chaos-interval }}
-          DURATION: ${{ inputs.chaos-status-duration }}
+          CHAOS_NAMESPACE: ${{ inputs.chaos-namespace }}
           DELAY: $${{ inputs.chaos-status-delay }}
+          DURATION: ${{ inputs.chaos-status-duration }}
+          EXPERIMENT_NAME: ${{ inputs.chaos-experiments }}
+          TOTAL_CHAOS_DURATION: ${{ inputs.chaos-duration }}
   required_status_checks:
     name: Required Integration Test Status Checks
     runs-on: ubuntu-latest

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -49,6 +49,10 @@ on:
         type: string
         description: Application kind
         default: statefulset
+      chaos-duration:
+        type: string
+        description: Duration of the chaos experiment
+        default: 60
     outputs:
       images:
         description: Pushed docker images
@@ -221,6 +225,7 @@ jobs:
           APP_NS: ${{ inputs.chaos-app-namespace }}
           APP_LABEL: ${{ inputs.chaos-app-label }}
           APP_KIND: ${{ inputs.chaos-app-kind }}
+          TOTAL_CHAOS_DURATION: ${{ inputs.chaos-duration }}
   required_status_checks:
     name: Required Integration Test Status Checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
This feature enables charms that take longer to recover (like discourse) to pass an experiment such as pod-delete successfully. It relies on three variables that are set:

CHAOS_INTERVAL: when to attempt another run of the experiment
DURATION: used for retries (see example below)
DELAY: sleep time in seconds

When checking the status of an experiment, the flow is that the engine runner is checked (starts a pod that controls the experiment), the pod runner is checked (the started pod in control of the experiment) and finally the application pod targeted by the experiment is checked. All three of them are checked with the same retry scheme, which is:

For DURATION/DELAY times, check the status, sleep DELAY seconds and retry if needed.