### PR TITLE
Add test for integration test workflow

### DIFF
--- a/.github/workflows/get_runner_image.yaml
+++ b/.github/workflows/get_runner_image.yaml
@@ -2,6 +2,11 @@ name: Get runner image
 
 on:
   workflow_call:
+    inputs:
+      working-directory:
+        type: string
+        description: The working directory for jobs
+        default: "./"
     outputs:
       name:
         description: "Get first occurrence of build-on base name"
@@ -24,6 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Get build-on value
+        working-directory: ${{ inputs.working-directory }}
         run: |
           name="ubuntu"
           channel="22.04"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -75,6 +75,10 @@ on:
           Retry is chaos-duration/chaos-delay times and each retry
           sleeps chaos-delay
         default: 90
+      working-directory:
+        type: string
+        description: The working directory for jobs
+        default: "./"
     outputs:
       images:
         description: Pushed docker images
@@ -88,6 +92,8 @@ jobs:
   get-runner-image:
     name: Get runner image
     uses: ./.github/workflows/get_runner_image.yaml
+    with:
+      working-directory: ${{ inputs.working-directory }}
   get-images:
     name: Get images
     runs-on: ubuntu-22.04
@@ -96,6 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Get dockerfiles
+        working-directory: ${{ inputs.working-directory }}
         run: echo "DOCKER_IMAGES=$(ls *.Dockerfile 2> /dev/null | sed s/\.Dockerfile// |  jq -Rsc '. / "\n" - [""]')" >> $GITHUB_ENV
   build-images:
     name: Build image
@@ -121,7 +128,7 @@ jobs:
           context: .
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ github.run_id }}
-          file: ${{ matrix.image }}.Dockerfile
+          file: ${{ inputs.working-directory }}/${{ matrix.image }}.Dockerfile
       # GitHub doesn't currently support pushing images in the Docker registry when opening a PR from a fork
       # so an artifact is published instead
       - name: Set up Docker Buildx
@@ -132,7 +139,7 @@ jobs:
         if: ${{ github.event.pull_request.head.repo.fork }}
         with:
           context: .
-          file: ${{ matrix.image }}.Dockerfile
+          file: ${{ inputs.working-directory }}/${{ matrix.image }}.Dockerfile
           tags: localhost:32000/${{ matrix.image }}:latest
           outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar
       - name: Upload image artifact
@@ -160,6 +167,7 @@ jobs:
         id: setup-devstack-swift
         uses: canonical/setup-devstack-swift@v1
       - name: Create OpenStack credential file
+        working-directory: ${{ inputs.working-directory }}
         run: echo "${{ steps.setup-devstack-swift.outputs.credentials }}" > openrc
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
@@ -200,6 +208,7 @@ jobs:
         if: ${{ inputs.pre-run-script != '' }}
         run: bash ${{ inputs.pre-run-script }}
       - name: Run integration tests
+        working-directory: ${{ inputs.working-directory }}
         run: |
           echo "CHARM_NAME=$([ -f metadata.yaml ] && yq '.name' metadata.yaml || echo UNKNOWN)" >> $GITHUB_ENV
           args=""

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -13,6 +13,10 @@ on:
       integration-test-extra-arguments:
         description: Additional arguments to pass to the integration tests
         type: string
+      integration-test-extra-test-matrix:
+        description: Additional mapping of test matrices to pass to the integration tests in JSON format, i.e. '{"extras":["foo","bar"]}'
+        type: string
+        default: '{}'
       integration-test-pre-run-script:
         description: Path to the bash script to be run before the integration tests
         type: string
@@ -58,6 +62,7 @@ jobs:
     uses: ./.github/workflows/integration_test.yaml
     with:
       extra-arguments: ${{ inputs.integration-test-extra-arguments }}
+      extra-test-matrix: ${{ inputs.integration-test-extra-test-matrix }}
       pre-run-script: ${{ inputs.integration-test-pre-run-script }}
       provider: ${{ inputs.integration-test-provider }}
       series: ${{ inputs.integration-test-series }}

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -24,6 +24,11 @@ jobs:
     secrets: inherit
     with:
       working-directory: 'tests/workflows/test/dockerfile/'
+  integration:
+    uses: ./.github/workflows/integration_test.yaml
+    secrets: inherit
+    with:
+      working-directory: 'tests/workflows/integration/simple/'
   check:
     runs-on: ubuntu-latest
     needs:
@@ -31,6 +36,7 @@ jobs:
       - pflake8
       - metadata_yaml
       - dockerfile
+      - integration
     steps:
       - run: |
           [ '${{ needs.simple.outputs.metadata-lint-outcome }}' = 'skip' ] || (echo metadata lint failed && false)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The following workflows are available:
 | Name | Type | Default | Description |
 |--------------------|----------|--------------------|-------------------|
 | extra-arguments | string | "" | Additional arguments to pass to the integration test execution |
+| extra-test-matrix | string | '{}' | Additional test matrices to run the integration test combinations |
+| working-directory | string | "./" | Custom working directory for jobs to run on |
 | pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
 | provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
@@ -35,6 +37,7 @@ The following workflows are available:
 | Name | Type | Default | Description |
 |--------------------|----------|--------------------|-------------------|
 | integration-test-extra-arguments | string | "" | Additional arguments to pass to the integration test execution |
+| integration-test-extra-test-matrix | string | '{}' | Additional test matrices to run the integration test combinations |
 | integration-test-pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
 | integration-test-provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | integration-test-series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |

--- a/README.md
+++ b/README.md
@@ -23,14 +23,6 @@ The following workflows are available:
 
 | Name | Type | Default | Description |
 |--------------------|----------|--------------------|-------------------|
-| extra-arguments | string | "" | Additional arguments to pass to the integration test execution |
-| extra-test-matrix | string | '{}' | Additional test matrices to run the integration test combinations |
-| working-directory | string | "./" | Custom working directory for jobs to run on |
-| pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
-| provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
-| series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
-| modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |
-| setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for testing. |
 | chaos-enabled  | bool | false | Whether Chaos testing is enabled |
 | chaos-experiments | string | "" | List of experiments to run |
 | chaos-namespace | string | testing | Namespace to install Litmus Chaos |
@@ -38,6 +30,14 @@ The following workflows are available:
 | chaos-app-label | string | "" | Label for chaos selection |
 | chaos-app-kind | string | statefulset | Application kind |
 | chaos-duration | string | 60 | Duration of the chaos experiment |
+| extra-arguments | string | "" | Additional arguments to pass to the integration test execution |
+| extra-test-matrix | string | '{}' | Additional test matrices to run the integration test combinations |
+| pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
+| provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
+| modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |
+| setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for testing. |
+| working-directory | string | "./" | Custom working directory for jobs to run on |
 | zap-auth-header | string | "" | If this is defined then its value will be added as a header to all of the ZAP requests |
 | zap-auth-header-value | string | "" | If this is defined then its value will be used as the header name to all of the ZAP requests |
 | zap-before-command | string | "" | Command to run before ZAP testing |

--- a/tests/workflows/integration/simple/metadata.yaml
+++ b/tests/workflows/integration/simple/metadata.yaml
@@ -1,0 +1,1 @@
+name: integration-test-charm-1

--- a/tests/workflows/integration/simple/simple.Dockerfile
+++ b/tests/workflows/integration/simple/simple.Dockerfile
@@ -1,0 +1,1 @@
+FROM ubuntu:latest

--- a/tests/workflows/integration/simple/simple.Dockerfile
+++ b/tests/workflows/integration/simple/simple.Dockerfile
@@ -1,1 +1,1 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04

--- a/tests/workflows/integration/simple/tox.ini
+++ b/tests/workflows/integration/simple/tox.ini
@@ -1,0 +1,52 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist=True
+skip_missing_interpreters = True
+envlist = lint, unit, static, coverage-report
+
+[testenv]
+basepython = python3
+allowlist_externals = /bin/echo
+
+[testenv:lint]
+description = Run lint
+deps =
+    mypy
+    isort
+    black
+    flake8-docstrings
+    flake8-docstrings-complete
+    flake8-builtins
+    flake8-test-docs
+    pep8-naming
+    codespell
+    pylint
+    pydocstyle
+    pytest
+commands =
+    pydocstyle main.py
+    codespell {toxinidir} --skip {toxinidir}/.tox --skip {toxinidir}/.mypy_cache
+    flake8 main.py
+    isort --check-only main.py
+    black --check main.py
+    mypy main.py
+    pylint main.py
+
+[testenv:unit]
+description = Run unit tests
+commands = /bin/echo Run unit tests
+
+[testenv:static]
+description = Run static analysis tests
+commands = /bin/echo Run static analysis tests
+
+[testenv:coverage-report]
+description = Create test coverage report
+output = '\
+    Name           Stmts   Miss Branch BrPart  Cover   Missing\
+    ----------------------------------------------------------\
+    sample_report     0      0     0     0    0%   0\
+    ----------------------------------------------------------\
+    TOTAL            0      0     0     0    0%'
+commands = /bin/echo -e {[testenv:coverage-report]output}

--- a/tests/workflows/integration/simple/tox.ini
+++ b/tests/workflows/integration/simple/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 [tox]
 skipsdist=True
@@ -9,44 +9,6 @@ envlist = lint, unit, static, coverage-report
 basepython = python3
 allowlist_externals = /bin/echo
 
-[testenv:lint]
-description = Run lint
-deps =
-    mypy
-    isort
-    black
-    flake8-docstrings
-    flake8-docstrings-complete
-    flake8-builtins
-    flake8-test-docs
-    pep8-naming
-    codespell
-    pylint
-    pydocstyle
-    pytest
-commands =
-    pydocstyle main.py
-    codespell {toxinidir} --skip {toxinidir}/.tox --skip {toxinidir}/.mypy_cache
-    flake8 main.py
-    isort --check-only main.py
-    black --check main.py
-    mypy main.py
-    pylint main.py
-
-[testenv:unit]
-description = Run unit tests
-commands = /bin/echo Run unit tests
-
-[testenv:static]
-description = Run static analysis tests
-commands = /bin/echo Run static analysis tests
-
-[testenv:coverage-report]
-description = Create test coverage report
-output = '\
-    Name           Stmts   Miss Branch BrPart  Cover   Missing\
-    ----------------------------------------------------------\
-    sample_report     0      0     0     0    0%   0\
-    ----------------------------------------------------------\
-    TOTAL            0      0     0     0    0%'
-commands = /bin/echo -e {[testenv:coverage-report]output}
+[testenv:integration]
+description = Run integration tests
+commands = /bin/echo Run integration tests


### PR DESCRIPTION
This PR adds support for integration test workflow testing to help securely make updates to the `integration_test.yaml` workflow.

Other workflows have been also changed to support `working-directory` input.
