### PR TITLE
Release charm libs

### DIFF
--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -90,9 +90,9 @@ jobs:
   release-charm-libs:
     name: Release charm libs
     runs-on: ubuntu-22.04
+    needs: [ lib-check, tests, integration-tests ]
     steps:
       - uses: canonical/charming-actions/release-libraries@2.2.2
-        needs: [ lib-check, tests, integration-tests ]
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -87,17 +87,15 @@ jobs:
       trivy-fs-ref: ${{ inputs.trivy-fs-ref }}
       trivy-image-config: ${{ inputs.trivy-image-config }}
     secrets: inherit
-  # The following job is causing thises kinds of problems:
-  # https://github.com/canonical/indico-operator/actions/runs/4000676362
-  # A bug has been filed to investigate the issue, until then this job should stay disabled:
-  # https://github.com/canonical/charming-actions/issues/82
-  # release-charm-libs:
-  #   name: Release charm libs
-  #   uses: canonical/charming-actions/release-libraries@2.2.1
-  #   needs: [ lib-check, tests, integration-tests ]
-  #   with:
-  #     credentials: ${{ secrets.CHARMHUB_TOKEN }}
-  #     github-token: ${{ secrets.GITHUB_TOKEN }}
+  release-charm-libs:
+    name: Release charm libs
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: canonical/charming-actions/release-libraries@2.2.2
+        needs: [ lib-check, tests, integration-tests ]
+        with:
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
   select-channel:
     name: Select target channel
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Test run: https://github.com/canonical/indico-operator/actions/runs/4005455192
Canceled to avoid pushing unwanted releases.