### PR TITLE
ci(action): Add Jira sync

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -27,7 +27,7 @@ jobs:
 
           # send JIRA request
 
-          # Canonical discourages discussions in JIRA on pulic project issues.
+          # Canonical discourages discussions in JIRA on public project issues.
           # It is NOT recommended to put description in JIRA in order to
           # push conversation to GitHub. If strongly required,
           # replace '--arg body ""' with '--arg body "$ISSUE_DESCRIPTION"'

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -1,0 +1,44 @@
+# this workflow requires to provide JIRA webhook URL via JIRA_URL GitHub Secret
+# read more: https://support.atlassian.com/cloud-automation/docs/jira-automation-triggers/#Automationtriggers-Incomingwebhook
+# original code source: https://github.com/beliaev-maksim/github-to-jira-automation
+
+name: Issues to JIRA
+
+on:
+  workflow_call:
+
+jobs:
+  update:
+    name: Update Issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create JIRA ticket
+        env:
+          # put into env vars to properly escape special bash chars
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_DESCRIPTION: ${{ github.event.issue.body }}
+        run: |
+          # Determine Bug/Enhancement
+          if ${{ contains(github.event.*.labels.*.name, 'Bug') }}; then
+            type=bug
+          else
+            type=story
+          fi
+
+          # send JIRA request
+
+          # Canonical discourages discussions in JIRA on pulic project issues.
+          # It is NOT recommended to put description in JIRA in order to
+          # push conversation to GitHub. If strongly required,
+          # replace '--arg body ""' with '--arg body "$ISSUE_DESCRIPTION"'
+
+          data=$( jq -n \
+                  --arg title "$ISSUE_TITLE" \
+                  --arg url '${{ github.event.issue.html_url }}' \
+                  --arg submitter '${{ github.event.issue.user.login }}' \
+                  --arg body "" \
+                  --arg type "$type" \
+                  --arg action '${{ github.event.action }}' \
+                  '{title: $title, url: $url, submitter: $submitter, body: $body, type: $type, action: $action}' )
+
+          curl -X POST -H 'Content-type: application/json' --data "${data}" "${{ secrets.JIRA_URL }}"

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -36,7 +36,7 @@ jobs:
                   --arg title "$ISSUE_TITLE" \
                   --arg url '${{ github.event.issue.html_url }}' \
                   --arg submitter '${{ github.event.issue.user.login }}' \
-                  --arg body "" \
+                  --arg body "$ISSUE_DESCRIPTION" \
                   --arg type "$type" \
                   --arg action '${{ github.event.action }}' \
                   '{title: $title, url: $url, submitter: $submitter, body: $body, type: $type, action: $action}' )


### PR DESCRIPTION
The Jira sync used at https://github.com/beliaev-maksim/github-to-jira-automation/blob/master/.github/workflows/issues_to_jira.yaml is not meant to be reused (missing on.workflow_call), so I'm placing it in our workflows and under Canonical. Also reformatted a bit.