### PR TITLE
switch to dry run

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -67,6 +67,7 @@ jobs:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
+          dry_run: true
       - name: Show index page
         if: steps.docs-exist.outputs.docs_exist == 'True'
         run: echo '${{ steps.publishDocumentation.outputs.index_url }}'


### PR DESCRIPTION
Switching `upload-charm-docs` to be in dry run mode only (disabling any changes to the documentation) whilst a spec for the documentation team is under review.