### PR TITLE
feat: allow skipping of publish docs

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -10,7 +10,9 @@ on:
       images:
         type: string
         description: 'Docker images'
-
+      publish-docs:
+        type: boolean
+        description: 'Publish charm documentations to Charmhub'
 env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
@@ -50,7 +52,7 @@ jobs:
     name: Publish charm to ${{ inputs.channel }}
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
     needs: [get-runner-image, publish-images]
-    if: ${{ !failure() }}
+    if: ${{ !failure() && inputs.publish-docs }}
     steps:
       - uses: actions/checkout@v3
       - name: Upload charm to charmhub

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -354,7 +354,8 @@ jobs:
     if: always()
     steps:
       - run: |
-          [ '${{ needs.draft-publish-docs.result }}' = 'success' ] || (echo draft-publish-docs failed && false)
+          [ '${{ needs.draft-publish-docs.result }}' = 'success' ] || [ '${{ needs.draft-publish-docs.result }}' = 'skipped' ] \
+            || (echo draft-publish-docs failed && false)
           [ '${{ needs.docker-lint.result }}' = 'success' ] || (echo docker-lint failed && false)
           [ '${{ needs.inclusive-naming-check.result }}' = 'success' ] || (echo inclusive-naming-check failed && false)
           [ '${{ needs.lib-check.result }}' = 'success' ] || (echo lib-check failed && false)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,10 @@ on:
         type: string
         description: The working directory for jobs
         default: './'
+      publish-docs:
+        description: Publish documentations to Charmhub.
+        type: boolean
+        default: false
     outputs:
       docker-lint-outcome:
         description: |
@@ -308,6 +312,7 @@ jobs:
   draft-publish-docs:
     name: Draft publish docs
     runs-on: ubuntu-22.04
+    if: ${{ inputs.publish-docs }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -354,8 +354,8 @@ jobs:
     if: always()
     steps:
       - run: |
-          [ '${{ needs.draft-publish-docs.result }}' = 'success' ] || [ '${{ needs.draft-publish-docs.result }}' = 'skipped' ] \
-            || (echo draft-publish-docs failed && false)
+          [ '${{ needs.draft-publish-docs.result }}' = 'success' ] || [ '${{ needs.draft-publish-docs.result }}' = 'skipped' ] || \
+            (echo draft-publish-docs failed && false)
           [ '${{ needs.docker-lint.result }}' = 'success' ] || (echo docker-lint failed && false)
           [ '${{ needs.inclusive-naming-check.result }}' = 'success' ] || (echo inclusive-naming-check failed && false)
           [ '${{ needs.lib-check.result }}' = 'success' ] || (echo lib-check failed && false)

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -32,6 +32,10 @@ on:
         description: List of testing modules to run the tests in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument
         type: string
         default: '[""]'
+      publish-docs:
+        description: Publish documentations to Charmhub.
+        type: boolean
+        default: false
       setup-devstack-swift:
         description: Use setup-devstack-swift action to prepare a swift server for integration tests.
         type: boolean
@@ -113,4 +117,5 @@ jobs:
     with:
       channel: ${{ needs.select-channel.outputs.channel }}
       images: ${{ needs.integration-tests.outputs.images }}
+      publish-docs: ${{ inputs.publish-docs }}
     secrets: inherit


### PR DESCRIPTION
Since the automation for uploading documentation is on hold, this PR introduces `publish-docs` input variable to the workflow that defaults to false to skip Charmhub documentation automation workflow. No changes have to be made to repositories using the workflow.

Link to working [skipped workflow](https://github.com/canonical/wordpress-k8s-operator/actions/runs/4302974557/jobs/7502135654).