### PR TITLE
fix: move tox output log

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -200,7 +200,7 @@ jobs:
         id: run-tests
         run: |
           # Ensure that stdout appears as normal and redirect to file and exit depends on exit code of first command
-          tox --result-json=test-result.json | tee stdout.log ; test ${PIPESTATUS[0]} -eq 0
+          tox --result-json=test-result.json | tee /tmp/stdout.log ; test ${PIPESTATUS[0]} -eq 0
       - name: Check lint and test stdout
         run: |
           # Check dependencies
@@ -220,7 +220,7 @@ jobs:
           for EXPECTED_LINT_DEP in $EXPECTED_LINT_DEPS; do
               # Check that there is a `lint...<dependency>` line for each of the expected dependencies
               DEP_REGEX="lint.*$EXPECTED_LINT_DEP"
-              if ! grep -q "$DEP_REGEX" stdout.log ; then
+              if ! grep -q "$DEP_REGEX" /tmp/stdout.log ; then
                   # Write to stderr
                   >&2 echo "$EXPECTED_LINT_DEP should be in deps of [testenv:lint] environment in tox.ini"
                   exit 1
@@ -240,7 +240,7 @@ jobs:
           for EXPECTED_LINT_CMD in $EXPECTED_LINT_CMDS; do
               # Check that there is a `lint...commands...<command>` line for each of the expected commands
               CMD_REGEX="lint.*commands.*$EXPECTED_LINT_CMD"
-              if ! grep -q "$CMD_REGEX" stdout.log ; then
+              if ! grep -q "$CMD_REGEX" /tmp/stdout.log ; then
                   # Write to stderr
                   >&2 echo "$EXPECTED_LINT_CMD should be in commands of [testenv:lint] environment in tox.ini"
                   exit 1


### PR DESCRIPTION
This PR addresses issues arising from writing the `stdout.log` file in the working directory, making the codespell error on any of the dependencies that are getting installed.
For example, `astroid` is a package installed as a dependency for `pylint` which gets caught by `codespell`(astroid => asteroid) and causes the test to fail.
Link to failing [test](https://github.com/canonical/wordpress-k8s-operator/actions/runs/4372610779/jobs/7649903184#step:4:16)