### PR TITLE
[DO NOT MERGE] Isd 420 investigate GitHub workflow caching

### DIFF
--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -63,9 +63,11 @@ jobs:
           echo "date=$(/bin/date -u "+%Y%W")" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         id: cache
+        env:
+          ROCK_PATH: ${{ matrix.path }}
         with:
           path: ${{ matrix.path }}
-          key: rock-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles(${{ matrix.path }}/rockcraft.yaml) }}
+          key: rock-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles($ROCK_PATH/rockcraft.yaml) }}
       - name: Build rock
         if: steps.cache.outputs.cache-hit != 'true'
         uses: canonical/craft-actions/rockcraft-pack@main

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -65,7 +65,7 @@ jobs:
         id: cache
         with:
           path: ${{ matrix.path }}
-        key: rock-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles(${{ matrix.path }}/rockcraft.yaml) }}
+          key: rock-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles(${{ matrix.path }}/rockcraft.yaml) }}
       - name: Build rock
         if: steps.cache.outputs.cache-hit != 'true'
         uses: canonical/craft-actions/rockcraft-pack@main

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -63,11 +63,9 @@ jobs:
           echo "date=$(/bin/date -u "+%Y%W")" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         id: cache
-        env:
-          ROCK_PATH: ${{ matrix.path }}
         with:
           path: ${{ matrix.path }}
-          key: rock-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles($ROCK_PATH/rockcraft.yaml) }}
+          key: rock-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles(matrix.path/rockcraft.yaml) }}
       - name: Build rock
         if: steps.cache.outputs.cache-hit != 'true'
         uses: canonical/craft-actions/rockcraft-pack@main

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -65,7 +65,7 @@ jobs:
         id: cache
         with:
           path: ${{ matrix.path }}
-          key: rock-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles(matrix.path/rockcraft.yaml) }}
+          key: rock-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles(matrix.path + "/rockcraft.yaml") }}
       - name: Build rock
         if: steps.cache.outputs.cache-hit != 'true'
         uses: canonical/craft-actions/rockcraft-pack@main

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -57,7 +57,17 @@ jobs:
         path: ${{ fromJSON(needs.get-rocks.outputs.rock-paths) }}
     steps:
       - uses: actions/checkout@v3
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "date=$(/bin/date -u "+%Y%W")" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: ${{ matrix.path }}
+        key: rock-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles(${{ matrix.path }}/rockcraft.yaml) }}
       - name: Build rock
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: canonical/craft-actions/rockcraft-pack@main
         with:
           path: ${{ matrix.path }}

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -65,7 +65,7 @@ jobs:
         id: cache
         with:
           path: ${{ matrix.path }}
-          key: rock-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles(matrix.path + "/rockcraft.yaml") }}
+          key: rock-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles(matrix.path) }}
       - name: Build rock
         if: steps.cache.outputs.cache-hit != 'true'
         uses: canonical/craft-actions/rockcraft-pack@main

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -177,7 +177,7 @@ jobs:
             /snap
             /var/snap
             /var/lib/snapd
-        key: snap-cache-${{ steps.get-date.outputs.date }}
+          key: snap-cache-${{ steps.get-date.outputs.date }}
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -226,7 +226,7 @@ jobs:
           path: |
             '**.charm'
             .tox
-        key: integration-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/charmcraft.yaml') }}-${{ hashFiles('**/metadata.yaml') }}
+          key: integration-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/charmcraft.yaml') }}-${{ hashFiles('**/metadata.yaml') }}
       - name: Run integration tests
         working-directory: ${{ inputs.working-directory }}
         run: |

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -220,7 +220,7 @@ jobs:
           path: |
             '**.charm'
             .tox
-          key: integration-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/charmcraft.yaml') }}-${{ hashFiles('**/metadata.yaml') }}
+          key: integration-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/charmcraft.yaml', '**/metadata.yaml') }}
       - name: Run integration tests
         working-directory: ${{ inputs.working-directory }}
         run: |

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -218,7 +218,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
-            '**.charm'
+            '**/*.charm'
             .tox
           key: integration-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/charmcraft.yaml', '**/metadata.yaml') }}
       - name: Run integration tests

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -166,6 +166,18 @@ jobs:
       - name: Create OpenStack credential file
         working-directory: ${{ inputs.working-directory }}
         run: echo "${{ steps.setup-devstack-swift.outputs.credentials }}" > openrc
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "date=$(/bin/date -u "+%Y%W")" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            /snap
+            /var/snap
+            /var/lib/snapd
+        key: snap-cache-${{ steps.get-date.outputs.date }}
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -204,6 +216,17 @@ jobs:
       - name: Pre-run script
         if: ${{ inputs.pre-run-script != '' }}
         run: bash ${{ inputs.pre-run-script }}
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "date=$(/bin/date -u "+%Y%W")" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            '**.charm'
+            .tox
+        key: integration-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/charmcraft.yaml') }}-${{ hashFiles('**/metadata.yaml') }}
       - name: Run integration tests
         working-directory: ${{ inputs.working-directory }}
         run: |

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -214,7 +214,7 @@ jobs:
           path: |
             '**/*.charm'
             .tox
-          key: integration-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/charmcraft.yaml', '**/metadata.yaml') }}
+          key: integration-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/charmcraft.yaml', '**/metadata.yaml', '**/actions.yaml', '**/config.yaml', '**/src') }}
       - name: Pack charm
         if: ${{ steps.cache-integration.outputs.cache-hit != 'true' }}
         run: |

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -209,11 +209,16 @@ jobs:
         if: ${{ inputs.pre-run-script != '' }}
         run: bash ${{ inputs.pre-run-script }}
       - uses: actions/cache@v3
+        id: cache-integration
         with:
           path: |
             '**/*.charm'
             .tox
           key: integration-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/charmcraft.yaml', '**/metadata.yaml') }}
+      - name: Pack charm
+        if: ${{ steps.cache-integration.outputs.cache-hit != 'true' }}
+        run: |
+          charmcraft pack
       - name: Run integration tests
         working-directory: ${{ inputs.working-directory }}
         run: |

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -170,13 +170,6 @@ jobs:
         id: get-date
         run: |
           echo "date=$(/bin/date -u "+%Y%W")" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        with:
-          path: |
-            /snap
-            /var/snap
-            /var/lib/snapd
-          key: snap-cache-${{ steps.get-date.outputs.date }}
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -171,7 +171,6 @@ jobs:
         run: |
           echo "date=$(/bin/date -u "+%Y%W")" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
-        id: cache
         with:
           path: |
             /snap
@@ -216,12 +215,7 @@ jobs:
       - name: Pre-run script
         if: ${{ inputs.pre-run-script != '' }}
         run: bash ${{ inputs.pre-run-script }}
-      - name: Get Date
-        id: get-date
-        run: |
-          echo "date=$(/bin/date -u "+%Y%W")" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
-        id: cache
         with:
           path: |
             '**.charm'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -208,7 +208,9 @@ jobs:
           key: unit-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/tox.ini') }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/pyproject.toml') }}
       - name: Install tox
         if: steps.cache.outputs.cache-hit != 'true'
-        run: python3 -m pip install tox
+        run: |
+          python3 -m pip install tox
+          python3 -m pip show tox
       - name: Run tests
         id: run-tests
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -205,7 +205,6 @@ jobs:
             .tox
             .mypy_cache
             venv
-            /usr/lib/python3/dist-packages
             ~/.local/lib
             ~/.local/bin
           key: unit-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/tox.ini') }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/pyproject.toml') }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -207,6 +207,7 @@ jobs:
             venv
             /usr/lib/python3/dist-packages
             ~/.local/lib
+            ~/.local/bin
           key: unit-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/tox.ini') }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/pyproject.toml') }}
       - name: Install tox
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -194,7 +194,20 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v3
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "date=$(/bin/date -u "+%Y%W")" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            .tox
+            .mypy_cache
+            venv
+        key: unit-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/tox.ini') }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/pyproject.toml') }}
       - name: Install tox
+        if: steps.cache.outputs.cache-hit != 'true'
         run: python3 -m pip install tox
       - name: Run tests
         id: run-tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -207,7 +207,7 @@ jobs:
             venv
             ~/.local/lib
             ~/.local/bin
-          key: unit-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/tox.ini') }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/pyproject.toml') }}
+          key: unit-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/tox.ini', '**/requirements.txt', '**/pyproject.toml') }}
       - name: Install tox
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -211,6 +211,7 @@ jobs:
       - name: Install tox
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
+          python3 -m pip install --upgrade pip
           python3 -m pip install tox
       - name: Run tests
         id: run-tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -205,7 +205,7 @@ jobs:
             .tox
             .mypy_cache
             venv
-        key: unit-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/tox.ini') }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/pyproject.toml') }}
+          key: unit-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/tox.ini') }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/pyproject.toml') }}
       - name: Install tox
         if: steps.cache.outputs.cache-hit != 'true'
         run: python3 -m pip install tox

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -205,12 +205,13 @@ jobs:
             .tox
             .mypy_cache
             venv
+            /usr/lib/python3/dist-packages
+            ~/.local/lib
           key: unit-cache-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/tox.ini') }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/pyproject.toml') }}
       - name: Install tox
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python3 -m pip install tox
-          python3 -m pip show tox
       - name: Run tests
         id: run-tests
         run: |


### PR DESCRIPTION
This PR relates to the spike on Github caching and how it can speed up our workflows. It is a POC and design should be discussed if we decide to move forward with using caching for some components in our CI/CD. Currently there is caching for unit tests and integration tests, the integration tests include caching of dependencies and built rocks and a built charm. In order for the integration tests to make use of the built charm, there needs to be a local change in the integration tests for the charm repo under test. The speed improvements vary from a minute on unit tests to several minutes (built rocks 5-8 mins and built charm 4-5 mins). The cache is invalidated either weekly or on a dependency file change. This PR is for review and feedback only.