### PR TITLE
Build-args for docker/build-push-action

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -27,10 +27,6 @@ on:
         type: string
         description: The working directory for jobs
         default: "./"
-      trivy-fs-enabled:
-        type: boolean
-        description: Whether Trivy testing of type fs is enabled
-        default: false
     outputs:
       images:
         description: List of images built
@@ -105,7 +101,6 @@ jobs:
         run: |
           echo "IMAGE_TAR=${{ matrix.image }}.tar" >> $GITHUB_ENV
       - name: Run Github Trivy Image Action
-        if: ${{ inputs.trivy-fs-enabled }}
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ inputs.registry }}/${{ inputs.owner }}/${{ matrix.image }}:${{ github.run_id }}

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -22,6 +22,10 @@ on:
         type: string
         description: The working directory for jobs
         default: "./"
+      build-args:
+        description: Map of build args to pass to the build image job. This should be supplied in JSON format, i.e. '{"some_arg": "some_value"}'
+        type: string
+        default: '{}'
     outputs:
       images:
         description: List of images built
@@ -60,6 +64,7 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           context: .
+          build-args: ${{ fromJSON(inputs.build-args) }}
           push: true
           tags: ${{ inputs.registry }}/${{ inputs.owner }}/${{ matrix.image }}:${{ github.run_id }}
           file: ${{ inputs.working-directory }}/${{ matrix.image }}.Dockerfile

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -3,6 +3,11 @@ name: Build images
 on:
   workflow_call:
     inputs:
+      build-args:
+        description: |
+          List of build args to pass to the build image job.
+        type: string
+        default: ""
       owner:
         type: string
         description: Registry owner to push the built images
@@ -22,11 +27,10 @@ on:
         type: string
         description: The working directory for jobs
         default: "./"
-      build-args:
-        description: |
-          List of build args to pass to the build image job.
-        type: string
-        default: ""
+      trivy-fs-enabled:
+        type: boolean
+        description: Whether Trivy testing of type fs is enabled
+        default: false
     outputs:
       images:
         description: List of images built
@@ -101,6 +105,7 @@ jobs:
         run: |
           echo "IMAGE_TAR=${{ matrix.image }}.tar" >> $GITHUB_ENV
       - name: Run Github Trivy Image Action
+        if: ${{ inputs.trivy-fs-enabled }}
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ inputs.registry }}/${{ inputs.owner }}/${{ matrix.image }}:${{ github.run_id }}

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -24,9 +24,9 @@ on:
         default: "./"
       build-args:
         description: |
-          List of build args to pass to the build image job. This should be supplied in JSON format, i.e. '["some_arg=some_value"]'.
+          List of build args to pass to the build image job.
         type: string
-        default: '[""]'
+        default: ""
     outputs:
       images:
         description: List of images built
@@ -65,7 +65,7 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           context: .
-          build-args: ${{ fromJSON(inputs.build-args) }}
+          build-args: ${{ inputs.build-args }}
           push: true
           tags: ${{ inputs.registry }}/${{ inputs.owner }}/${{ matrix.image }}:${{ github.run_id }}
           file: ${{ inputs.working-directory }}/${{ matrix.image }}.Dockerfile

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -24,9 +24,9 @@ on:
         default: "./"
       build-args:
         description: |
-          Map of build args to pass to the build image job. This should be supplied in JSON format, i.e. '{"some_arg": "some_value"}'.
+          List of build args to pass to the build image job. This should be supplied in JSON format, i.e. '["some_arg=some_value"]'.
         type: string
-        default: '{}'
+        default: '[""]'
     outputs:
       images:
         description: List of images built

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -23,7 +23,8 @@ on:
         description: The working directory for jobs
         default: "./"
       build-args:
-        description: Map of build args to pass to the build image job. This should be supplied in JSON format, i.e. '{"some_arg": "some_value"}'
+        description: |
+          Map of build args to pass to the build image job. This should be supplied in JSON format, i.e. '{"some_arg": "some_value"}'.
         type: string
         default: '{}'
     outputs:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -58,9 +58,9 @@ on:
         default: '{}'
       image-build-args:
         description: |
-          Map of build args to pass to the build image job. This should be supplied in JSON format, i.e. '{"some_arg": "some_value"}'.
+          List of build args to pass to the build image job. This should be supplied in JSON format, i.e. '["some_arg=some_value"]'.
         type: string
-        default: '{}'
+        default: '[""]'
       load-test-enabled:
         type: boolean
         description: Whether load testing is enabled

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -58,9 +58,9 @@ on:
         default: '{}'
       image-build-args:
         description: |
-          List of build args to pass to the build image job. This should be supplied in JSON format, i.e. '["some_arg=some_value"]'.
+          List of build args to pass to the build image job.
         type: string
-        default: '[""]'
+        default: ""
       load-test-enabled:
         type: boolean
         description: Whether load testing is enabled

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -56,6 +56,10 @@ on:
           Each mapping will be injected into the matrix section of the integration-test.
         type: string
         default: '{}'
+      image-build-args:
+        description: Map of build args to pass to the build image job. This should be supplied in JSON format, i.e. '{"some_arg": "some_value"}'
+        type: string
+        default: '{}'
       load-test-enabled:
         type: boolean
         description: Whether load testing is enabled
@@ -169,6 +173,7 @@ jobs:
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       trivy-image-config: ${{ inputs.trivy-image-config }}
       working-directory: ${{ inputs.working-directory }}
+      build-args: ${{ inputs.image-build-args }}
   build-rocks:
     name: Build rock
     uses: ./.github/workflows/build_rocks.yaml

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -57,7 +57,8 @@ on:
         type: string
         default: '{}'
       image-build-args:
-        description: Map of build args to pass to the build image job. This should be supplied in JSON format, i.e. '{"some_arg": "some_value"}'
+        description: |
+          Map of build args to pass to the build image job. This should be supplied in JSON format, i.e. '{"some_arg": "some_value"}'.
         type: string
         default: '{}'
       load-test-enabled:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -173,7 +173,6 @@ jobs:
       registry: ghcr.io
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       trivy-image-config: ${{ inputs.trivy-image-config }}
-      trivy-fs-enabled: ${{ inputs.trivy-fs-enabled }}
       working-directory: ${{ inputs.working-directory }}
       build-args: ${{ inputs.image-build-args }}
   build-rocks:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -173,6 +173,7 @@ jobs:
       registry: ghcr.io
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       trivy-image-config: ${{ inputs.trivy-image-config }}
+      trivy-fs-enabled: ${{ inputs.trivy-fs-enabled }}
       working-directory: ${{ inputs.working-directory }}
       build-args: ${{ inputs.image-build-args }}
   build-rocks:


### PR DESCRIPTION
- Add an `image-build-args` option to `integration_test` job to pass `build-args` to the `build_image` job.

CI with `image-build-args`: https://github.com/canonical/mattermost-k8s-operator/pull/7
CI without `image-build-args`: https://github.com/canonical/discourse-k8s-operator/pull/51