### PR TITLE
GitHub token

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -51,6 +51,7 @@ jobs:
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          base_branch: main
   publish-docs:
     if: ${{ github.event.inputs.destination-channel }} == 'latest/stable'
     name: Publish docs
@@ -70,6 +71,7 @@ jobs:
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          base_branch: main
       - name: Show index page
         if: steps.docs-exist.outputs.docs_exist == 'True'
         run: echo '${{ steps.publishDocumentation.outputs.index_url }}'

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -50,6 +50,7 @@ jobs:
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
+          github_token: ${{ secrets.CHARMHUB_TOKEN }}
   publish-docs:
     if: ${{ github.event.inputs.destination-channel }} == 'latest/stable'
     name: Publish docs
@@ -68,6 +69,7 @@ jobs:
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
+          github_token: ${{ secrets.CHARMHUB_TOKEN }}
       - name: Show index page
         if: steps.docs-exist.outputs.docs_exist == 'True'
         run: echo '${{ steps.publishDocumentation.outputs.index_url }}'

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -50,7 +50,7 @@ jobs:
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
-          github_token: ${{ secrets.CHARMHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
   publish-docs:
     if: ${{ github.event.inputs.destination-channel }} == 'latest/stable'
     name: Publish docs
@@ -69,7 +69,7 @@ jobs:
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
-          github_token: ${{ secrets.CHARMHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Show index page
         if: steps.docs-exist.outputs.docs_exist == 'True'
         run: echo '${{ steps.publishDocumentation.outputs.index_url }}'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -330,7 +330,7 @@ jobs:
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
-          github_token: ${{ secrets.CHARMHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
   lib-check:
     name: Check libraries
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -330,6 +330,7 @@ jobs:
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
+          github_token: ${{ secrets.CHARMHUB_TOKEN }}
   lib-check:
     name: Check libraries
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -331,6 +331,7 @@ jobs:
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          base_branch: main
   lib-check:
     name: Check libraries
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This fixes a problem where `upload-charm-docs` got the Charmhub token instead of the GitHub token

I thought about adding tests for this, it wouldn't be straight forward, I'll add it to our backlog. Since our CI is blocked by this not working I propose to merge this without adding an integration test initially