### PR TITLE
Fail the integration test if pre-run script failed

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -213,7 +213,7 @@ jobs:
           sudo microk8s enable ingress
       - name: Pre-run script
         if: ${{ inputs.pre-run-script != '' }}
-        run: bash ${{ inputs.pre-run-script }}
+        run: bash -xe ${{ inputs.pre-run-script }}
       - name: Run integration tests
         working-directory: ${{ inputs.working-directory }}
         run: |


### PR DESCRIPTION
Right now, if the `pre-run-script` in the integration test workflow failed, the integration test will proceed without an error.