### PR TITLE
Add microk8s-addons config for integration testing

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -75,6 +75,10 @@ on:
         description: Actions operator provider as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: microk8s
+      microk8s-addons:
+        description: Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.
+        type: string
+        default: "storage dns rbac"
       channel:
         description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
@@ -220,6 +224,7 @@ jobs:
       owner: ${{ github.repository_owner }}
       pre-run-script: ${{ inputs.pre-run-script }}
       provider: ${{ inputs.provider }}
+      microk8s-addons: ${{ inputs.microk8s-addons }}
       channel: ${{ inputs.channel }}
       juju-channel: ${{ inputs.juju-channel }}
       registry: ghcr.io

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -87,7 +87,7 @@ on:
       channel:
         description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
-        default: 1.26/stable
+        default: latest/stable
       juju-channel:
         description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -78,7 +78,7 @@ on:
       channel:
         description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
-        default: 1.26-strict/stable
+        default: 1.26/stable
       juju-channel:
         description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -75,6 +75,14 @@ on:
         description: Actions operator provider as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: microk8s
+      channel:
+        description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: 1.26-strict/stable
+      juju-channel:
+        description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: 2.9/stable
       series:
         description: List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument
         type: string
@@ -212,6 +220,8 @@ jobs:
       owner: ${{ github.repository_owner }}
       pre-run-script: ${{ inputs.pre-run-script }}
       provider: ${{ inputs.provider }}
+      channel: ${{ inputs.channel }}
+      juju-channel: ${{ inputs.juju-channel }}
       registry: ghcr.io
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       series: ${{ inputs.series }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -90,7 +90,7 @@ on:
       channel:
         description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
-        default: 1.26/stable
+        default: latest/stable
       juju-channel:
         description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -86,7 +86,7 @@ on:
       channel:
         description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
-        default: 1.26-strict/stable
+        default: 1.26/stable
       juju-channel:
         description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -83,6 +83,10 @@ on:
         description: Actions operator provider as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: microk8s
+      microk8s-addons:
+        description: Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.
+        type: string
+        default: "storage dns rbac"
       channel:
         description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
@@ -178,6 +182,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: ${{ inputs.provider }}
+          microk8s-addons: ${{ inputs.microk8s-addons }}
           channel: ${{ inputs.channel }}
           juju-channel: ${{ inputs.juju-channel }}
       - name: Enable microk8s registry

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -83,6 +83,14 @@ on:
         description: Actions operator provider as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: microk8s
+      channel:
+        description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: 1.26-strict/stable
+      juju-channel:
+        description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: 2.9/stable
       registry:
         type: string
         description: Registry to push the built images
@@ -170,6 +178,8 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: ${{ inputs.provider }}
+          channel: ${{ inputs.channel }}
+          juju-channel: ${{ inputs.juju-channel }}
       - name: Enable microk8s registry
         if: ${{ inputs.provider == 'microk8s' && github.event.pull_request.head.repo.fork }}
         run: |

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -31,7 +31,7 @@ on:
       integration-test-provider-channel:
         description: Actions operator provider channel for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
-        default: 1.26/stable
+        default: latest/stable
       integration-test-juju-channel:
         description: Actions operator juju channel for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -24,6 +24,14 @@ on:
         description: Actions operator provider for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: microk8s
+      integration-test-provider-channel:
+        description: Actions operator provider channel for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: 1.26-strict/stable
+      integration-test-juju-channel:
+        description: Actions operator juju channel for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: 2.9/stable
       integration-test-series:
         description: List of series to run the integration tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument
         type: string
@@ -86,6 +94,8 @@ jobs:
       modules: ${{ inputs.integration-test-modules }}
       pre-run-script: ${{ inputs.integration-test-pre-run-script }}
       provider: ${{ inputs.integration-test-provider }}
+      channel: ${{ inputs.integration-test-provider-channel }}
+      juju-channel: ${{ inputs.integration-test-juju-channel }}
       series: ${{ inputs.integration-test-series }}
       setup-devstack-swift: ${{ inputs.setup-devstack-swift }}
       trivy-fs-config: ${{ inputs.trivy-fs-config }}

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -24,6 +24,10 @@ on:
         description: Actions operator provider for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: microk8s
+      integration-test-microk8s-addons:
+        description: Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.
+        type: string
+        default: "storage dns rbac"
       integration-test-provider-channel:
         description: Actions operator provider channel for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
@@ -94,6 +98,7 @@ jobs:
       modules: ${{ inputs.integration-test-modules }}
       pre-run-script: ${{ inputs.integration-test-pre-run-script }}
       provider: ${{ inputs.integration-test-provider }}
+      microk8s-addons: ${{ inputs.integration-test-microk8s-addons }}
       channel: ${{ inputs.integration-test-provider-channel }}
       juju-channel: ${{ inputs.integration-test-juju-channel }}
       series: ${{ inputs.integration-test-series }}

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -27,7 +27,7 @@ on:
       integration-test-provider-channel:
         description: Actions operator provider channel for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
-        default: 1.26-strict/stable
+        default: 1.26/stable
       integration-test-juju-channel:
         description: Actions operator juju channel for the integration tests as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ More information about Trivy testing can be found [here](TRIVY.MD).
 | integration-test-extra-test-matrix | string | '{}' | Additional test matrices to run the integration test combinations |
 | integration-test-pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
 | integration-test-provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| integration-test-provider-channel | string | 1.26-strict/stable | Actions operator provider channel as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| integration-test-juju-channel | string | 2.9/stable | Actions operator juju channel as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | integration-test-series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
 | integration-test-modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |
 | setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for integration tests. |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following workflows are available:
 | modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |
 | pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
 | provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
-| channel | string | 1.26-strict/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| channel | string | 1.26/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | juju-channel | string | 2.9/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
 | setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for testing. |
@@ -68,7 +68,7 @@ More information about Trivy testing can be found [here](TRIVY.MD).
 | integration-test-extra-test-matrix | string | '{}' | Additional test matrices to run the integration test combinations |
 | integration-test-pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
 | integration-test-provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
-| integration-test-provider-channel | string | 1.26-strict/stable | Actions operator provider channel as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| integration-test-provider-channel | string | 1.26/stable | Actions operator provider channel as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | integration-test-juju-channel | string | 2.9/stable | Actions operator juju channel as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | integration-test-series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
 | integration-test-modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The following workflows are available:
 | modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |
 | pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
 | provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| channel | string | 1.26-strict/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| juju-channel | string | 2.9/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
 | setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for testing. |
 | trivy-fs-config | string | "" | Trivy YAML configuration for fs type |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following workflows are available:
 | pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
 | provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | microk8s-addons | string | "storage dns rbac" | Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled. |
-| channel | string | 1.26/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| channel | string | latest/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | juju-channel | string | 2.9/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
 | setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for testing. |
@@ -70,7 +70,7 @@ More information about Trivy testing can be found [here](TRIVY.MD).
 | integration-test-pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
 | integration-test-provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | integration-test-microk8s-addons | string | "storage dns rbac" | Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled. |
-| integration-test-provider-channel | string | 1.26/stable | Actions operator provider channel as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| integration-test-provider-channel | string | latest/stable | Actions operator provider channel as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | integration-test-juju-channel | string | 2.9/stable | Actions operator juju channel as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | integration-test-series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
 | integration-test-modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The following workflows are available:
 | modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |
 | pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
 | provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| microk8s-addons | string | "storage dns rbac" | Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled. |
 | channel | string | 1.26/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | juju-channel | string | 2.9/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
@@ -68,6 +69,7 @@ More information about Trivy testing can be found [here](TRIVY.MD).
 | integration-test-extra-test-matrix | string | '{}' | Additional test matrices to run the integration test combinations |
 | integration-test-pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
 | integration-test-provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| integration-test-microk8s-addons | string | "storage dns rbac" | Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled. |
 | integration-test-provider-channel | string | 1.26/stable | Actions operator provider channel as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | integration-test-juju-channel | string | 2.9/stable | Actions operator juju channel as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | integration-test-series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |


### PR DESCRIPTION
This will allow [microk8s-addons](https://github.com/charmed-kubernetes/actions-operator/tree/main/#microk8s-provider) such as `ingress` to be enabled when setting up the operator environment.