### PR TITLE
remove branch input which is deprecated

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -51,7 +51,6 @@ jobs:
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          base_branch: main
   publish-docs:
     if: ${{ github.event.inputs.destination-channel }} == 'latest/stable'
     name: Publish docs
@@ -71,7 +70,6 @@ jobs:
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          base_branch: main
       - name: Show index page
         if: steps.docs-exist.outputs.docs_exist == 'True'
         run: echo '${{ steps.publishDocumentation.outputs.index_url }}'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -331,7 +331,6 @@ jobs:
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          base_branch: main
   lib-check:
     name: Check libraries
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Now that `upload-charm-docs` has been updated with https://github.com/canonical/upload-charm-docs/pull/137, this removes the deprecated branch name input