### PR TITLE
Do not require license header for config files

### DIFF
--- a/.github/files/.licenserc.yaml
+++ b/.github/files/.licenserc.yaml
@@ -23,6 +23,7 @@ header:
     - '.gitignore'
     - '.licenserc.yaml'
     - '.trivyignore'
+    - '.woke.yaml'
     - '.woke.yml'
     - 'CODEOWNERS'
     - 'icon.svg'

--- a/.github/files/.licenserc.yaml
+++ b/.github/files/.licenserc.yaml
@@ -29,4 +29,5 @@ header:
     - 'icon.svg'
     - 'LICENSE'
     - 'trivy.yaml'
+    - 'zap_rules.tsv'
   comment: on-failure


### PR DESCRIPTION
Do not require license header for .woke.yaml and zap config file