### PR TITLE
Use repository scoped token for charm libs auto-update

### DIFF
--- a/.github/workflows/auto_update_charm_libs.yaml
+++ b/.github/workflows/auto_update_charm_libs.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4.2.3
         id: cpr
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REPO_SCOPED_TOKEN }}
           commit-message: "chore: update charm libraries"
           committer: "Github Actions <github-actions@github.com>"
           author: "Github Actions <github-actions@github.com>"


### PR DESCRIPTION
Follow up #128 
 A repository scoped token is needed for the PRs to trigger the on_pull_request workflows https://github.com/peter-evans/create-pull-request/issues/48