### PR TITLE
Revert "Add license header for charm libs"

### DIFF
--- a/.github/files/.licenserc.yaml
+++ b/.github/files/.licenserc.yaml
@@ -1,45 +1,35 @@
 header:
-  - license:
-      spdx-id: Apache-2.0
-      copyright-owner: Canonical Ltd.
-      content: |
-        Copyright [year] [owner]
-        Licensed under the Apache2.0. See LICENSE file in charm source for details.
-      paths:
-        - 'lib/**'
-      comment: on-failure
-  - license:
-      spdx-id: Apache-2.0
-      copyright-owner: Canonical Ltd.
-      content: |
-        Copyright [year] [owner]
-        See LICENSE file for licensing details.
-      paths:
-        - '**'
-      paths-ignore:
-        - '.github/**'
-        - 'lib/**'
-        - '**/.gitkeep'
-        - '**/*.cfg'
-        - '**/*.conf'
-        - '**/*.j2'
-        - '**/*.json'
-        - '**/*.md'
-        - '**/*.rule'
-        - '**/*.tmpl'
-        - '**/*.txt'
-        - '.codespellignore'
-        - '.dockerignore'
-        - '.flake8'
-        - '.jujuignore'
-        - '.gitignore'
-        - '.licenserc.yaml'
-        - '.trivyignore'
-        - '.woke.yaml'
-        - '.woke.yml'
-        - 'CODEOWNERS'
-        - 'icon.svg'
-        - 'LICENSE'
-        - 'trivy.yaml'
-        - 'zap_rules.tsv'
-      comment: on-failure
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: Canonical Ltd.
+    content: |
+      Copyright [year] [owner]
+      See LICENSE file for licensing details.
+  paths:
+    - '**'
+  paths-ignore:
+    - '.github/**'
+    - '**/.gitkeep'
+    - '**/*.cfg'
+    - '**/*.conf'
+    - '**/*.j2'
+    - '**/*.json'
+    - '**/*.md'
+    - '**/*.rule'
+    - '**/*.tmpl'
+    - '**/*.txt'
+    - '.codespellignore'
+    - '.dockerignore'
+    - '.flake8'
+    - '.jujuignore'
+    - '.gitignore'
+    - '.licenserc.yaml'
+    - '.trivyignore'
+    - '.woke.yaml'
+    - '.woke.yml'
+    - 'CODEOWNERS'
+    - 'icon.svg'
+    - 'LICENSE'
+    - 'trivy.yaml'
+    - 'zap_rules.tsv'
+  comment: on-failure


### PR DESCRIPTION
Reverts canonical/operator-workflows#127

https://github.com/apache/skywalking/issues/10746