### PR TITLE
fix: docker load tarball

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -200,7 +200,7 @@ jobs:
         if: ${{ inputs.provider == 'microk8s' && github.event.pull_request.head.repo.fork }}
         run: |
           for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
-            docker import ${image_name}/${image_name}.tar localhost:32000/${image_name}:latest
+            docker load < ${image_name}/${image_name}.tar
             docker push localhost:32000/${image_name}:latest
           done
       - name: Configure GHCR in microk8s


### PR DESCRIPTION
This PR re-opens the [PR](https://github.com/canonical/operator-workflows/pull/132) with changed branch name due to invalid charmhub channel name.

See the failed [action](https://github.com/canonical/operator-workflows/actions/runs/4891145494/jobs/8732392665) for more detail:
