### PR TITLE
Add run on self-hosted runner as option for test.yaml

### DIFF
--- a/.github/workflows/auto_update_charm_libs.yaml
+++ b/.github/workflows/auto_update_charm_libs.yaml
@@ -32,8 +32,8 @@ jobs:
           branch-name: "chore/auto-libs"
           title: Update charm libraries
           body: |
-            Automated action to fetch latest version of charm libraries. The branch of this PR 
-            will be wiped during the next check. Unless you really know what you're doing, you 
+            Automated action to fetch latest version of charm libraries. The branch of this PR
+            will be wiped during the next check. Unless you really know what you're doing, you
             most likely don't want to push any commits to this branch.
           upsert: true
           ignore-no-changes: true

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -29,7 +29,7 @@ jobs:
                 repo: repo,
                 run_id: run_id,
             });
-            const matchArtifact = artifacts.data.artifacts.filter(artifact => 
+            const matchArtifact = artifacts.data.artifacts.filter(artifact =>
               artifact.name == '${{ env.ARTIFACT_NAME }}'
             )[0];
             const download = await github.rest.actions.downloadArtifact({

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ on:
 jobs:
   inclusive-naming-check:
     name: Inclusive naming
-    runs-on: [self-hosted, large]
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   inclusive-naming-check:
     name: Inclusive naming
-    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -66,7 +66,7 @@ jobs:
     uses: ./.github/workflows/get_runner_image.yaml
   shellcheck-lint:
     name: Shell scripts lint
-    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -130,7 +130,7 @@ jobs:
         run: shellcheck -f gcc ${{steps.gather.outputs.filepaths}}
   docker-lint:
     name: Dockerfile lint
-    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -147,7 +147,7 @@ jobs:
           dockerfile: "${{ steps.dockerfiles.outputs.found }}"
   metadata-lint:
     name: Lint metadata.yaml
-    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -165,7 +165,7 @@ jobs:
           check-jsonschema metadata.yaml --schemafile metadata.schema
   lint-and-unit-test:
     name: Lint and unit tests
-    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || needs.get-runner-image.outputs.runs-on }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || needs.get-runner-image.outputs.runs-on }}
     needs: get-runner-image
     defaults:
       run:
@@ -287,7 +287,7 @@ jobs:
           path: report.json
   draft-publish-docs:
     name: Draft publish docs
-    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -307,7 +307,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
   license-headers-check:
     name: Check license headers
-    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -326,7 +326,7 @@ jobs:
           config: .licenserc.yaml
   lib-check:
     name: Check libraries
-    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v3
       - name: Check libs
@@ -337,7 +337,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   required_status_checks:
     name: Required Test Status Checks
-    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
     needs:
       - draft-publish-docs
       - docker-lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,10 +15,9 @@ on:
         description: Whether to use self-hosted runners to run the jobs.
         default: false
 
-# TODO: Enable this after debugging.
-# concurrency:
-#   group: operator-workflows-${{ github.workflow }}-tests-${{ github.ref }}
-#   cancel-in-progress: true
+concurrency:
+  group: operator-workflows-${{ github.workflow }}-tests-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   inclusive-naming-check:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   inclusive-naming-check:
     name: Inclusive naming
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -66,7 +66,7 @@ jobs:
     uses: ./.github/workflows/get_runner_image.yaml
   shellcheck-lint:
     name: Shell scripts lint
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -130,7 +130,7 @@ jobs:
         run: shellcheck -f gcc ${{steps.gather.outputs.filepaths}}
   docker-lint:
     name: Dockerfile lint
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -147,7 +147,7 @@ jobs:
           dockerfile: "${{ steps.dockerfiles.outputs.found }}"
   metadata-lint:
     name: Lint metadata.yaml
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -165,7 +165,7 @@ jobs:
           check-jsonschema metadata.yaml --schemafile metadata.schema
   lint-and-unit-test:
     name: Lint and unit tests
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || needs.get-runner-image.outputs.runs-on }}
+    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || needs.get-runner-image.outputs.runs-on }}
     needs: get-runner-image
     defaults:
       run:
@@ -287,7 +287,7 @@ jobs:
           path: report.json
   draft-publish-docs:
     name: Draft publish docs
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -307,7 +307,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
   license-headers-check:
     name: Check license headers
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -326,7 +326,7 @@ jobs:
           config: .licenserc.yaml
   lib-check:
     name: Check libraries
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v3
       - name: Check libs
@@ -337,7 +337,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   required_status_checks:
     name: Required Test Status Checks
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
     needs:
       - draft-publish-docs
       - docker-lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
     uses: ./.github/workflows/get_runner_image.yaml
   shellcheck-lint:
     name: Shell scripts lint
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'xlarge'] || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -130,7 +130,7 @@ jobs:
         run: shellcheck -f gcc ${{steps.gather.outputs.filepaths}}
   docker-lint:
     name: Dockerfile lint
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -147,7 +147,7 @@ jobs:
           dockerfile: "${{ steps.dockerfiles.outputs.found }}"
   metadata-lint:
     name: Lint metadata.yaml
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'xlarge'] || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -165,7 +165,7 @@ jobs:
           check-jsonschema metadata.yaml --schemafile metadata.schema
   lint-and-unit-test:
     name: Lint and unit tests
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || needs.get-runner-image.outputs.runs-on }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'xlarge'] || needs.get-runner-image.outputs.runs-on }}
     needs: get-runner-image
     defaults:
       run:
@@ -287,7 +287,7 @@ jobs:
           path: report.json
   draft-publish-docs:
     name: Draft publish docs
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'xlarge'] || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -307,7 +307,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
   license-headers-check:
     name: Check license headers
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'xlarge'] || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -326,7 +326,7 @@ jobs:
           config: .licenserc.yaml
   lib-check:
     name: Check libraries
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'xlarge'] || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v3
       - name: Check libs
@@ -337,7 +337,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   required_status_checks:
     name: Required Test Status Checks
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'xlarge'] || 'ubuntu-22.04' }}
     needs:
       - draft-publish-docs
       - docker-lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ on:
 jobs:
   inclusive-naming-check:
     name: Inclusive naming
-    runs-on: [self-hosted, xlarge]
+    runs-on: [self-hosted, large]
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -67,7 +67,7 @@ jobs:
     uses: ./.github/workflows/get_runner_image.yaml
   shellcheck-lint:
     name: Shell scripts lint
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''xlarge'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -148,7 +148,7 @@ jobs:
           dockerfile: "${{ steps.dockerfiles.outputs.found }}"
   metadata-lint:
     name: Lint metadata.yaml
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''xlarge'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -166,7 +166,7 @@ jobs:
           check-jsonschema metadata.yaml --schemafile metadata.schema
   lint-and-unit-test:
     name: Lint and unit tests
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''xlarge'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
     needs: get-runner-image
     defaults:
       run:
@@ -288,7 +288,7 @@ jobs:
           path: report.json
   draft-publish-docs:
     name: Draft publish docs
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''xlarge'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -308,7 +308,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
   license-headers-check:
     name: Check license headers
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''xlarge'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -327,7 +327,7 @@ jobs:
           config: .licenserc.yaml
   lib-check:
     name: Check libraries
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''xlarge'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v3
       - name: Check libs
@@ -338,7 +338,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   required_status_checks:
     name: Required Test Status Checks
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''xlarge'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
     needs:
       - draft-publish-docs
       - docker-lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ on:
       self-hosted-runner:
         type: boolean
         description: Whether to use self-hosted runners to run the jobs.
-        default: false
+        default: true
 
 concurrency:
   group: operator-workflows-${{ github.workflow }}-tests-${{ github.ref }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,6 @@ on:
 
 concurrency:
   group: operator-workflows-${{ github.workflow }}-tests-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   inclusive-naming-check:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   inclusive-naming-check:
     name: Inclusive naming
-    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -66,7 +66,7 @@ jobs:
     uses: ./.github/workflows/get_runner_image.yaml
   shellcheck-lint:
     name: Shell scripts lint
-    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -130,7 +130,7 @@ jobs:
         run: shellcheck -f gcc ${{steps.gather.outputs.filepaths}}
   docker-lint:
     name: Dockerfile lint
-    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -147,7 +147,7 @@ jobs:
           dockerfile: "${{ steps.dockerfiles.outputs.found }}"
   metadata-lint:
     name: Lint metadata.yaml
-    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -165,7 +165,7 @@ jobs:
           check-jsonschema metadata.yaml --schemafile metadata.schema
   lint-and-unit-test:
     name: Lint and unit tests
-    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || needs.get-runner-image.outputs.runs-on }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || needs.get-runner-image.outputs.runs-on }}
     needs: get-runner-image
     defaults:
       run:
@@ -287,7 +287,7 @@ jobs:
           path: report.json
   draft-publish-docs:
     name: Draft publish docs
-    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -307,7 +307,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
   license-headers-check:
     name: Check license headers
-    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -326,7 +326,7 @@ jobs:
           config: .licenserc.yaml
   lib-check:
     name: Check libraries
-    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v3
       - name: Check libs
@@ -337,7 +337,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   required_status_checks:
     name: Required Test Status Checks
-    runs-on: ${{ inputs.self-hosted-runner && "['self-hosted', 'large']" || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
     needs:
       - draft-publish-docs
       - docker-lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,10 @@ on:
         description: Whether to use self-hosted runners to run the jobs.
         default: false
 
-concurrency:
-  group: operator-workflows-${{ github.workflow }}-tests-${{ github.ref }}
-  cancel-in-progress: true
+# TODO: Enable this after debugging.
+# concurrency:
+#   group: operator-workflows-${{ github.workflow }}-tests-${{ github.ref }}
+#   cancel-in-progress: true
 
 jobs:
   inclusive-naming-check:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,11 @@ on:
       working-directory:
         type: string
         description: The working directory for jobs
-        default: './'
+        default: "./"
+      self-hosted-runner:
+        type: boolean
+        description: Whether to use self-hosted runners to run the jobs.
+        default: false
 
 concurrency:
   group: operator-workflows-${{ github.workflow }}-tests-${{ github.ref }}
@@ -18,7 +22,7 @@ concurrency:
 jobs:
   inclusive-naming-check:
     name: Inclusive naming
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -53,7 +57,7 @@ jobs:
           fail-on-error: "true"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
-          woke-args: '. -c /tmp/config.yml'
+          woke-args: ". -c /tmp/config.yml"
           filter-mode: nofilter
           workdir: ${{ inputs.working-directory }}
           woke-version: latest
@@ -62,7 +66,7 @@ jobs:
     uses: ./.github/workflows/get_runner_image.yaml
   shellcheck-lint:
     name: Shell scripts lint
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -126,7 +130,7 @@ jobs:
         run: shellcheck -f gcc ${{steps.gather.outputs.filepaths}}
   docker-lint:
     name: Dockerfile lint
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -143,7 +147,7 @@ jobs:
           dockerfile: "${{ steps.dockerfiles.outputs.found }}"
   metadata-lint:
     name: Lint metadata.yaml
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -161,7 +165,7 @@ jobs:
           check-jsonschema metadata.yaml --schemafile metadata.schema
   lint-and-unit-test:
     name: Lint and unit tests
-    runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
+    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || needs.get-runner-image.outputs.runs-on }}
     needs: get-runner-image
     defaults:
       run:
@@ -283,7 +287,7 @@ jobs:
           path: report.json
   draft-publish-docs:
     name: Draft publish docs
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -303,7 +307,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
   license-headers-check:
     name: Check license headers
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -322,7 +326,7 @@ jobs:
           config: .licenserc.yaml
   lib-check:
     name: Check libraries
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v3
       - name: Check libs
@@ -333,7 +337,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   required_status_checks:
     name: Required Test Status Checks
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.self-hosted-runner && 'self-hosted' || 'ubuntu-22.04' }}
     needs:
       - draft-publish-docs
       - docker-lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   inclusive-naming-check:
     name: Inclusive naming
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -66,7 +66,7 @@ jobs:
     uses: ./.github/workflows/get_runner_image.yaml
   shellcheck-lint:
     name: Shell scripts lint
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -147,7 +147,7 @@ jobs:
           dockerfile: "${{ steps.dockerfiles.outputs.found }}"
   metadata-lint:
     name: Lint metadata.yaml
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -165,7 +165,7 @@ jobs:
           check-jsonschema metadata.yaml --schemafile metadata.schema
   lint-and-unit-test:
     name: Lint and unit tests
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || needs.get-runner-image.outputs.runs-on }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || needs.get-runner-image.outputs.runs-on }}
     needs: get-runner-image
     defaults:
       run:
@@ -287,7 +287,7 @@ jobs:
           path: report.json
   draft-publish-docs:
     name: Draft publish docs
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -307,7 +307,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
   license-headers-check:
     name: Check license headers
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -326,7 +326,7 @@ jobs:
           config: .licenserc.yaml
   lib-check:
     name: Check libraries
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v3
       - name: Check libs
@@ -337,7 +337,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   required_status_checks:
     name: Required Test Status Checks
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, large]' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || 'ubuntu-22.04' }}
     needs:
       - draft-publish-docs
       - docker-lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   inclusive-naming-check:
     name: Inclusive naming
-    runs-on: ${{ inputs.self-hosted-runner && '[self-hosted, xlarge]' || 'ubuntu-22.04' }}
+    runs-on: [self-hosted, xlarge]
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
     uses: ./.github/workflows/get_runner_image.yaml
   shellcheck-lint:
     name: Shell scripts lint
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'xlarge'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''xlarge'']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -130,7 +130,7 @@ jobs:
         run: shellcheck -f gcc ${{steps.gather.outputs.filepaths}}
   docker-lint:
     name: Dockerfile lint
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'large'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -147,7 +147,7 @@ jobs:
           dockerfile: "${{ steps.dockerfiles.outputs.found }}"
   metadata-lint:
     name: Lint metadata.yaml
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'xlarge'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''xlarge'']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -165,7 +165,7 @@ jobs:
           check-jsonschema metadata.yaml --schemafile metadata.schema
   lint-and-unit-test:
     name: Lint and unit tests
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'xlarge'] || needs.get-runner-image.outputs.runs-on }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''xlarge'']') || 'ubuntu-22.04' }}
     needs: get-runner-image
     defaults:
       run:
@@ -287,7 +287,7 @@ jobs:
           path: report.json
   draft-publish-docs:
     name: Draft publish docs
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'xlarge'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''xlarge'']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -307,7 +307,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
   license-headers-check:
     name: Check license headers
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'xlarge'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''xlarge'']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -326,7 +326,7 @@ jobs:
           config: .licenserc.yaml
   lib-check:
     name: Check libraries
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'xlarge'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''xlarge'']') || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v3
       - name: Check libs
@@ -337,7 +337,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   required_status_checks:
     name: Required Test Status Checks
-    runs-on: ${{ inputs.self-hosted-runner && ['self-hosted', 'xlarge'] || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''xlarge'']') || 'ubuntu-22.04' }}
     needs:
       - draft-publish-docs
       - docker-lint

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -8,24 +8,28 @@ on:
 
 jobs:
   simple:
+    strategy:
+      matrix:
+        self-hosted-runner: [true, false]
     uses: ./.github/workflows/test.yaml
     secrets: inherit
     with:
-      working-directory: 'tests/workflows/integration/test-upload-charm/'
+      working-directory: "tests/workflows/integration/test-upload-charm/"
+      self-hosted-runner: ${{ matrix.version }
   integration:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit
     with:
-      working-directory: 'tests/workflows/integration/test-upload-charm/'
-      trivy-image-config: 'tests/workflows/integration/test-upload-charm/trivy.yaml'
+      working-directory: "tests/workflows/integration/test-upload-charm/"
+      trivy-image-config: "tests/workflows/integration/test-upload-charm/trivy.yaml"
   integration-rock:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit
     needs:
       - integration
     with:
-      working-directory: 'tests/workflows/integration/test-rock/'
-      trivy-image-config: 'tests/workflows/integration/test-rock/trivy.yaml'
+      working-directory: "tests/workflows/integration/test-rock/"
+      trivy-image-config: "tests/workflows/integration/test-rock/trivy.yaml"
   publish:
     if: ${{ !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/publish_charm.yaml

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   simple:
     strategy:
+      max-parallel: 1
       matrix:
         self-hosted-runner: [true, false]
     uses: ./.github/workflows/test.yaml

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -6,6 +6,7 @@ name: Workflow test
 on:
   pull_request:
 
+
 jobs:
   simple:
     strategy:

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -12,6 +12,7 @@ jobs:
     secrets: inherit
     with:
       working-directory: "tests/workflows/integration/test-upload-charm/"
+      self-hosted-runner: false
   simple-self-hosted:
     uses: ./.github/workflows/test.yaml
     secrets: inherit

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -6,18 +6,18 @@ name: Workflow test
 on:
   pull_request:
 
-
 jobs:
   simple:
-    strategy:
-      max-parallel: 1
-      matrix:
-        self-hosted-runner: [true, false]
     uses: ./.github/workflows/test.yaml
     secrets: inherit
     with:
       working-directory: "tests/workflows/integration/test-upload-charm/"
-      self-hosted-runner: ${{ matrix.self-hosted-runner}
+  simple-self-hosted:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+    with:
+      working-directory: "tests/workflows/integration/test-upload-charm/"
+      self-hosted-runner: true
   integration:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -15,7 +15,7 @@ jobs:
     secrets: inherit
     with:
       working-directory: "tests/workflows/integration/test-upload-charm/"
-      self-hosted-runner: ${{ matrix.version }
+      self-hosted-runner: ${{ matrix.self-hosted-runner}
   integration:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit


### PR DESCRIPTION
Add input called `self-hosted-runner` for test.yaml, when set to true the workflow will be run on self-hosted runners.