### PR TITLE
feat: enable tmate debugging

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -103,6 +103,10 @@ on:
         description: Use setup-devstack-swift action to prepare a swift server for testing.
         type: boolean
         default: false
+      tmate-debugging:
+        description: Use tmate debugging session on failure.
+        type: boolean
+        default: false
       trivy-fs-config:
         type: string
         description: Trivy YAML configuration for fs testing that is checked in as part of the repo
@@ -240,6 +244,7 @@ jobs:
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       series: ${{ inputs.series }}
       setup-devstack-swift: ${{ inputs.setup-devstack-swift }}
+      tmate-debugging: ${{ inputs.tmate-debugging }}
       trivy-fs-config: ${{ inputs.trivy-fs-config }}
       trivy-fs-enabled: ${{ inputs.trivy-fs-enabled }}
       trivy-fs-ref: ${{ inputs.trivy-fs-ref }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -103,10 +103,14 @@ on:
         description: Use setup-devstack-swift action to prepare a swift server for testing.
         type: boolean
         default: false
-      tmate-debugging:
-        description: Use tmate debugging session on failure.
+      tmate-debug:
+        description: Use tmate debugging session on integration test failure.
         type: boolean
         default: false
+      tmate-timeout:
+        description: Timeout in minutes to keep tmate debugging session.
+        type: number
+        default: 30
       trivy-fs-config:
         type: string
         description: Trivy YAML configuration for fs testing that is checked in as part of the repo
@@ -244,7 +248,8 @@ jobs:
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       series: ${{ inputs.series }}
       setup-devstack-swift: ${{ inputs.setup-devstack-swift }}
-      tmate-debugging: ${{ inputs.tmate-debugging }}
+      tmate-debug: ${{ inputs.tmate-debug }}
+      tmate-timeout: ${{ inputs.tmate-timeout }}
       trivy-fs-config: ${{ inputs.trivy-fs-config }}
       trivy-fs-enabled: ${{ inputs.trivy-fs-enabled }}
       trivy-fs-ref: ${{ inputs.trivy-fs-ref }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -114,6 +114,10 @@ on:
         description: Use setup-devstack-swift action to prepare a swift server for testing.
         type: boolean
         default: false
+      tmate-debugging:
+        description: Use tmate debugging session on failure.
+        type: boolean
+        default: false
       trivy-fs-config:
         type: string
         description: Trivy YAML configuration for fs testing that is checked in as part of the repo
@@ -244,6 +248,10 @@ jobs:
             module="-k ${{ matrix.modules }}"
           fi
           tox -e integration -- --model testing --keep-models $series $module $args ${{ inputs.extra-arguments }}
+      - name: Tmate debugging session
+        if: ${{ failure() &&  }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30
       - name: Dump logs
         uses: canonical/charm-logdump-action@main
         if: failure()

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -249,7 +249,7 @@ jobs:
           fi
           tox -e integration -- --model testing --keep-models $series $module $args ${{ inputs.extra-arguments }}
       - name: Tmate debugging session
-        if: ${{ failure() &&  }}
+        if: ${{ failure() && inputs.tmate-debugging }}
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 30
       - name: Dump logs

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -114,10 +114,14 @@ on:
         description: Use setup-devstack-swift action to prepare a swift server for testing.
         type: boolean
         default: false
-      tmate-debugging:
-        description: Use tmate debugging session on failure.
+      tmate-debug:
+        description: Use tmate debugging session on integration test failure.
         type: boolean
         default: false
+      tmate-timeout:
+        description: Timeout in minutes to keep tmate debugging session.
+        type: number
+        default: 30
       trivy-fs-config:
         type: string
         description: Trivy YAML configuration for fs testing that is checked in as part of the repo
@@ -249,9 +253,9 @@ jobs:
           fi
           tox -e integration -- --model testing --keep-models $series $module $args ${{ inputs.extra-arguments }}
       - name: Tmate debugging session
-        if: ${{ failure() && inputs.tmate-debugging }}
+        if: ${{ failure() && inputs.tmate-debug }}
         uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 30
+        timeout-minutes: ${{ inputs.tmate-timeout }}
       - name: Dump logs
         uses: canonical/charm-logdump-action@main
         if: failure()

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following workflows are available:
 | juju-channel | string | 2.9/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
 | setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for testing. |
+| tmate-debugging | bool | false | Enable tmate debugging after integration test failure. |
 | trivy-fs-config | string | "" | Trivy YAML configuration for fs type |
 | trivy-fs-enabled | boolean | false | Whether Trivy testing of type fs is enabled |
 | trivy-fs-ref | string | "." | Target directory to do the Trivy testing |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ The following workflows are available:
 | juju-channel | string | 2.9/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
 | setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for testing. |
-| tmate-debugging | bool | false | Enable tmate debugging after integration test failure. |
+| tmate-debug | bool | false | Enable tmate debugging after integration test failure. |
+| tmate-timeout | number | 30 | Timeout in minutes to keep tmate debugging session. |
 | trivy-fs-config | string | "" | Trivy YAML configuration for fs type |
 | trivy-fs-enabled | boolean | false | Whether Trivy testing of type fs is enabled |
 | trivy-fs-ref | string | "." | Target directory to do the Trivy testing |


### PR DESCRIPTION
This PR enables the use of tmate debugging on integration test failure if `tmate-debug` has been enabled.

The motivation behind this PR is to reduce the number of branches called `debug-*` and also some problems caused when the user can get locked out of tmate and need to wait for timeout (6 hours) accidentally.

[Example of failing integration test w/ tmate timeout 5 min](https://github.com/canonical/jenkins-k8s-operator/actions/runs/5086686731/jobs/9141417604)
