### PR TITLE
Publish external images in the publish workflow

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -83,7 +83,7 @@ jobs:
         with:
           context: .
           file: ${{ inputs.working-directory }}/${{ matrix.image }}.Dockerfile
-          tags: localhost:32000/${{ matrix.image }}:latest
+          tags: localhost:32000/${{ matrix.image }}:${{ github.run_id }}
           outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar
       - name: Upload image artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Build rock as tarball
         if: ${{ github.event.pull_request.head.repo.fork }}
         run: |
-          skopeo copy oci-archive:$(ls "${{ matrix.path }}"/*.rock) docker-archive:./$IMAGE_NAME.tar:localhost:32000/$IMAGE_NAME:latest
+          skopeo copy oci-archive:$(ls "${{ matrix.path }}"/*.rock) docker-archive:./$IMAGE_NAME.tar:localhost:32000/$IMAGE_NAME:${{ github.run_id }}
           echo "IMAGE_TAR=/github/workspace/$IMAGE_NAME.tar" >> $GITHUB_ENV
       - name: Upload image artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Build rock as tarball
         if: ${{ github.event.pull_request.head.repo.fork }}
         run: |
-          skopeo copy oci-archive:$(ls "${{ matrix.path }}"/*.rock) docker-archive:./$IMAGE_NAME.tar:$IMAGE_NAME:${{ github.run_id }}
+          skopeo copy oci-archive:$(ls "${{ matrix.path }}"/*.rock) docker-archive:./$IMAGE_NAME.tar:localhost:32000/$IMAGE_NAME:latest
           echo "IMAGE_TAR=/github/workspace/$IMAGE_NAME.tar" >> $GITHUB_ENV
       - name: Upload image artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -201,7 +201,8 @@ jobs:
         run: |
           for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
             docker load < ${image_name}/${image_name}.tar
-            docker push localhost:32000/${image_name}:latest
+            docker tag ${image_name}:${{ github.run_id }} localhost:32000/${image_name}:${{ github.run_id }}
+            docker push localhost:32000/${image_name}:${{ github.run_id }}
           done
       - name: Configure GHCR in microk8s
         if: ${{ inputs.provider == 'microk8s' && !github.event.pull_request.head.repo.fork }}
@@ -229,7 +230,7 @@ jobs:
           args=""
           for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
             if [ ${{ github.event.pull_request.head.repo.fork }} = "true" ]; then
-              args="${args} --${image_name}-image localhost:32000/${image_name}:latest"
+              args="${args} --${image_name}-image localhost:32000/${image_name}:${{ github.run_id }}"
             else
               args="${args} --${image_name}-image ${{ inputs.registry }}/${{ inputs.owner }}/${image_name}:${{ github.run_id }}"
             fi

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -201,7 +201,7 @@ jobs:
         run: |
           for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
             docker load < ${image_name}/${image_name}.tar
-            docker push localhost:32000/${image_name}:latest
+            docker push localhost:32000/${image_name}:${{ github.run_id }}
           done
       - name: Configure GHCR in microk8s
         if: ${{ inputs.provider == 'microk8s' && !github.event.pull_request.head.repo.fork }}
@@ -229,7 +229,7 @@ jobs:
           args=""
           for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
             if [ ${{ github.event.pull_request.head.repo.fork }} = "true" ]; then
-              args="${args} --${image_name}-image localhost:32000/${image_name}:latest"
+              args="${args} --${image_name}-image localhost:32000/${image_name}:${{ github.run_id }}"
             else
               args="${args} --${image_name}-image ${{ inputs.registry }}/${{ inputs.owner }}/${image_name}:${{ github.run_id }}"
             fi

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -201,8 +201,7 @@ jobs:
         run: |
           for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
             docker load < ${image_name}/${image_name}.tar
-            docker tag ${image_name}:${{ github.run_id }} localhost:32000/${image_name}:${{ github.run_id }}
-            docker push localhost:32000/${image_name}:${{ github.run_id }}
+            docker push localhost:32000/${image_name}:latest
           done
       - name: Configure GHCR in microk8s
         if: ${{ inputs.provider == 'microk8s' && !github.event.pull_request.head.repo.fork }}
@@ -230,7 +229,7 @@ jobs:
           args=""
           for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
             if [ ${{ github.event.pull_request.head.repo.fork }} = "true" ]; then
-              args="${args} --${image_name}-image localhost:32000/${image_name}:${{ github.run_id }}"
+              args="${args} --${image_name}-image localhost:32000/${image_name}:latest"
             else
               args="${args} --${image_name}-image ${{ inputs.registry }}/${{ inputs.owner }}/${image_name}:${{ github.run_id }}"
             fi

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -84,7 +84,7 @@ jobs:
           echo "External Images: $IMAGES"
           echo "IMAGES=$IMAGES" >> $GITHUB_ENV
   publish-external-images:
-    name: Push Externam Images to Charmhub
+    name: Push External Images to Charmhub
     runs-on: ubuntu:latest
     needs: [ lookup-external-images ]
     if: ${{ needs.lookup-external-images.outputs.images != '[]' }}

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -63,6 +63,52 @@ jobs:
           docker pull $image
           imageId=$(docker images $image --format "{{.ID}}")
           charmcraft upload-resource $charmName ${{ matrix.image }}-image --image=$imageId --verbosity=trace
+  lookup-external-images:
+    name: Lookup External Images
+    runs-on: ubuntu:latest
+    outputs:
+      images: ${{ env.IMAGES }}
+    steps:
+      - uses: actions/checkout@v3
+      - if: inputs.working-directory != './'
+        name: Change directory
+        run: |
+          TEMP_DIR=$(mktemp -d)
+          cp -rp ${{inputs.working-directory}}/. $TEMP_DIR
+          rm -rf .* * || :
+          cp -rp $TEMP_DIR/. .
+          rm -rf $TEMP_DIR
+      - name: Extract External Images
+        run: |
+          IMAGES=$(yq -c '.resources | to_entries | map(select(.value.type == "oci-image" and .value."upstream-source")) | map(.key)' metadata.yaml)
+          echo "External Images: $IMAGES"
+          echo "IMAGES=$IMAGES" >> $GITHUB_ENV
+  publish-external-images:
+    name: Push Externam Images to Charmhub
+    needs: [ lookup-external-images ]
+    if: ${{ needs.lookup-external-images.outputs.images != '[]' }}
+    strategy:
+      matrix:
+        image: ${{ fromJSON(needs.lookup-external-images.outputs.images) }}
+    steps:
+      - uses: actions/checkout@v3
+      - if: inputs.working-directory != './'
+        name: Change directory
+        run: |
+          TEMP_DIR=$(mktemp -d)
+          cp -rp ${{inputs.working-directory}}/. $TEMP_DIR
+          rm -rf .* * || :
+          cp -rp $TEMP_DIR/. .
+          rm -rf $TEMP_DIR
+      - name: Publish image
+        env:
+          CHARMCRAFT_AUTH:  ${{ secrets.CHARMHUB_TOKEN }}
+        run: |
+          image=${{ matrix.image }}
+          charmName=$(yq '.name' metadata.yaml)
+          docker pull $image
+          imageId=$(docker images $image --format "{{.ID}}")
+          charmcraft upload-resource $charmName ${{ matrix.image }}-image --image=$imageId --verbosity=trace
   publish-charm:
     name: Publish charm to ${{ inputs.channel }}
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -85,6 +85,7 @@ jobs:
           echo "IMAGES=$IMAGES" >> $GITHUB_ENV
   publish-external-images:
     name: Push Externam Images to Charmhub
+    runs-on: ubuntu:latest
     needs: [ lookup-external-images ]
     if: ${{ needs.lookup-external-images.outputs.images != '[]' }}
     strategy:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ More information about OWASP ZAP testing can be found [here](OWASPZAP.md).
 
 More information about Trivy testing can be found [here](TRIVY.MD).
 
-* test_and_publish_charm: Builds and publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel).  The following parameters are available for this workflow:
+* test_and_publish_charm: Builds and publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel). External OCI image resources (resources with `upstream-source` defined) will also be downloaded from the upstream source and uploaded to the Charmhub. The following parameters are available for this workflow:
 
 | Name | Type | Default | Description |
 |--------------------|----------|--------------------|-------------------|

--- a/tests/workflows/integration/test-upload-charm/metadata.yaml
+++ b/tests/workflows/integration/test-upload-charm/metadata.yaml
@@ -19,3 +19,8 @@ resources:
   test-image:
     type: oci-image
     description: Test image
+  external-image:
+    type: oci-image
+    description: Test external image
+    auto-fetch: true
+    upstream-source: ubuntu:latest

--- a/tests/workflows/integration/test-upload-charm/tests/integration/test_charm.py
+++ b/tests/workflows/integration/test-upload-charm/tests/integration/test_charm.py
@@ -16,7 +16,10 @@ async def test_build_and_deploy(ops_test: OpsTest, pytestconfig):
     app_name = "test"
     assert ops_test.model
     charm = await ops_test.build_charm(".")
-    resources = {"test-image": pytestconfig.getoption("--test-image")}
+    resources = {
+        "test-image": pytestconfig.getoption("--test-image"),
+        "external-image": "ubuntu:latest"
+    }
 
     await asyncio.gather(
         ops_test.model.deploy(

--- a/tests/workflows/integration/test-upload-charm/tests/integration/test_charm.py
+++ b/tests/workflows/integration/test-upload-charm/tests/integration/test_charm.py
@@ -16,10 +16,7 @@ async def test_build_and_deploy(ops_test: OpsTest, pytestconfig):
     app_name = "test"
     assert ops_test.model
     charm = await ops_test.build_charm(".")
-    resources = {
-        "test-image": pytestconfig.getoption("--test-image"),
-        "external-image": "ubuntu:latest"
-    }
+    resources = {"test-image": pytestconfig.getoption("--test-image")}
 
     await asyncio.gather(
         ops_test.model.deploy(


### PR DESCRIPTION
Current publish workflow only uploads images built by the integration workflow to CharmHub.
This pull request adds a new step in the publish workflow to upload any OCI-image resources with `upstream-source` to CharmHub before publish the new charm version.