### PR TITLE
feat: add xml to license ignore

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -12,6 +12,7 @@ header:
     - '**/*.j2'
     - '**/*.md'
     - '**/*.txt'
+    - '**/*.xml'
     - '**/.codespellignore'
     - '**/.dockerignore'
     - '**/.flake8'


### PR DESCRIPTION
This PR adds `xml` files to the ignorelist. (Required for jenkins [PR](https://github.com/canonical/jenkins-k8s-operator/actions/runs/5109085024/jobs/9183520975?pr=2))