### PR TITLE
feat: ignore xml files in license

### DIFF
--- a/.github/files/.licenserc.yaml
+++ b/.github/files/.licenserc.yaml
@@ -27,6 +27,7 @@ header:
       - '**/*.rule'
       - '**/*.tmpl'
       - '**/*.txt'
+      - '**/*.xml'
       - '.codespellignore'
       - '.dockerignore'
       - '.flake8'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -12,6 +12,7 @@ header:
     - '**/*.j2'
     - '**/*.md'
     - '**/*.txt'
+    - '**/*.xml'
     - '**/.codespellignore'
     - '**/.dockerignore'
     - '**/.flake8'


### PR DESCRIPTION
This PR addes xml to ignore files. The previous PR did not add to the `licenserc.yaml` referred by the workflow. Sorry about that!