### PR TITLE
fix(ISD-852): Remove duplicate chaos action build

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -267,16 +267,9 @@ jobs:
         run: echo "KUBE_CONFIG_DATA=$(sudo microk8s config | base64 -w 0)" >> $GITHUB_ENV
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-      - name: Setup Litmus
-        if: ${{ inputs.chaos-enabled }}
-        uses: merkata/github-chaos-actions@master
-        env:
-          APP_NS: ${{ inputs.chaos-app-namespace }}
-          CHAOS_NAMESPACE: ${{ inputs.chaos-namespace }}
-          INSTALL_LITMUS: true
       - name: Run Litmus Chaos experiments
         if: ${{ inputs.chaos-enabled }}
-        uses: merkata/github-chaos-actions@feat/run-multiple-scenarios
+        uses: merkata/github-chaos-actions@fix/oci-cli
         env:
           APP_KIND: ${{ inputs.chaos-app-kind }}
           APP_LABEL: ${{ inputs.chaos-app-label }}
@@ -286,6 +279,7 @@ jobs:
           DELAY: ${{ inputs.chaos-status-delay }}
           DURATION: ${{ inputs.chaos-status-duration }}
           EXPERIMENT_NAME: ${{ inputs.chaos-experiments }}
+          INSTALL_LITMUS: true
           TOTAL_CHAOS_DURATION: ${{ inputs.chaos-duration }}
           KUBE_CONFIG_DATA: ${{ env.KUBE_CONFIG_DATA }}
       - name: Install k6s


### PR DESCRIPTION
This fix removes calling github-chaos-actions twice, as the image responsible for the chaos experiments gets built twice. The logic in the `entrypoint.sh` can install litmus and run the experiments in one pass, thus saving build time and not needing to have two steps, one for setup and one for actually running the tests.

In addition, this PR addresses ISD-849 with pointing to a fix branch that installs the `oci-cli` python package the recommended way (via `pipx`) and the best practive way (via version pinning of the package).