### PR TITLE
Eliminate the fixed model from lxd integration tests

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -230,52 +230,39 @@ jobs:
       - name: Pre-run script
         if: ${{ inputs.pre-run-script != '' }}
         run: bash -xe ${{ inputs.pre-run-script }}
+      - name: Integration tests variable setting
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          echo "CHARM_NAME=$([ -f metadata.yaml ] && yq '.name' metadata.yaml || echo UNKNOWN)" >> $GITHUB_ENV
+          args=""
+          for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
+            if [ ${{ github.event.pull_request.head.repo.fork }} = "true" ]; then
+              args="${args} --${image_name}-image localhost:32000/${image_name}:latest"
+            else
+              args="${args} --${image_name}-image ${{ inputs.registry }}/${{ inputs.owner }}/${image_name}:${{ github.run_id }}"
+            fi
+          done
+          echo "ARGS=$args" >> $GITHUB_ENV
+          series=""
+          if [ ! -z ${{ matrix.series }} ]; then
+            series="--series ${{ matrix.series }}"
+          fi
+          echo "SERIES=$series" >> $GITHUB_ENV
+          module=""
+          if [ ! -z ${{ matrix.modules }} ]; then
+            module="-k ${{ matrix.modules }}"
+          fi
+          echo "MODULE=$module" >> $GITHUB_ENV
       - name: Run k8s integration tests
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'microk8s' }}
         run: |
-          echo "CHARM_NAME=$([ -f metadata.yaml ] && yq '.name' metadata.yaml || echo UNKNOWN)" >> $GITHUB_ENV
-          args=""
-          for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
-            if [ ${{ github.event.pull_request.head.repo.fork }} = "true" ]; then
-              args="${args} --${image_name}-image localhost:32000/${image_name}:latest"
-            else
-              args="${args} --${image_name}-image ${{ inputs.registry }}/${{ inputs.owner }}/${image_name}:${{ github.run_id }}"
-            fi
-          done
-
-          series=""
-          if [ ! -z ${{ matrix.series }} ]; then
-            series="--series ${{ matrix.series }}"
-          fi
-          module=""
-          if [ ! -z ${{ matrix.modules }} ]; then
-            module="-k ${{ matrix.modules }}"
-          fi
-          tox -e integration -- --model testing --keep-models $series $module $args ${{ inputs.extra-arguments }}
+          tox -e integration -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }}
       - name: Run lxd integration tests
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'lxd' }}
         run: |
-          echo "CHARM_NAME=$([ -f metadata.yaml ] && yq '.name' metadata.yaml || echo UNKNOWN)" >> $GITHUB_ENV
-          args=""
-          for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
-            if [ ${{ github.event.pull_request.head.repo.fork }} = "true" ]; then
-              args="${args} --${image_name}-image localhost:32000/${image_name}:latest"
-            else
-              args="${args} --${image_name}-image ${{ inputs.registry }}/${{ inputs.owner }}/${image_name}:${{ github.run_id }}"
-            fi
-          done
-
-          series=""
-          if [ ! -z ${{ matrix.series }} ]; then
-            series="--series ${{ matrix.series }}"
-          fi
-          module=""
-          if [ ! -z ${{ matrix.modules }} ]; then
-            module="-k ${{ matrix.modules }}"
-          fi
-          tox -e integration -- --keep-models $series $module $args ${{ inputs.extra-arguments }}
+          tox -e integration -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }}
         env:
           LXD_CONTROLLER: ${{ steps.lxd-controller.outputs.name }}
       - name: Tmate debugging session

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -255,7 +255,7 @@ jobs:
           if [ ! -z ${{ matrix.modules }} ]; then
             module="-k ${{ matrix.modules }}"
           fi
-          tox -e integration -- --model testing --keep-models $series $module $args ${{ inputs.extra-arguments }}
+          tox -e integration -- --keep-models $series $module $args ${{ inputs.extra-arguments }}
         env:
           LXD_CONTROLLER: ${{ steps.lxd-controller.outputs.name }}
       - name: Tmate debugging session

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -263,8 +263,6 @@ jobs:
         if: ${{ inputs.provider == 'lxd' }}
         run: |
           tox -e integration -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }}
-        env:
-          LXD_CONTROLLER: ${{ steps.lxd-controller.outputs.name }}
       - name: Tmate debugging session
         if: ${{ failure() && inputs.tmate-debug }}
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -230,6 +230,10 @@ jobs:
       - name: Pre-run script
         if: ${{ inputs.pre-run-script != '' }}
         run: bash -xe ${{ inputs.pre-run-script }}
+      - name: Save lxd controller name
+        id: lxd-controller
+        # The `CONTROLLER_NAME` envvar is set by this action
+        run: echo "name=$CONTROLLER_NAME" >> $GITHUB_OUTPUT
       - name: Run integration tests
         working-directory: ${{ inputs.working-directory }}
         run: |
@@ -252,6 +256,8 @@ jobs:
             module="-k ${{ matrix.modules }}"
           fi
           tox -e integration -- --model testing --keep-models $series $module $args ${{ inputs.extra-arguments }}
+        env:
+          LXD_CONTROLLER: ${{ steps.lxd-controller.outputs.name }}
       - name: Tmate debugging session
         if: ${{ failure() && inputs.tmate-debug }}
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -230,12 +230,32 @@ jobs:
       - name: Pre-run script
         if: ${{ inputs.pre-run-script != '' }}
         run: bash -xe ${{ inputs.pre-run-script }}
-      - name: Save lxd controller name
-        id: lxd-controller
-        # The `CONTROLLER_NAME` envvar is set by this action
-        run: echo "name=$CONTROLLER_NAME" >> $GITHUB_OUTPUT
-      - name: Run integration tests
+      - name: Run k8s integration tests
         working-directory: ${{ inputs.working-directory }}
+        if: ${{ inputs.provider == 'microk8s' }}
+        run: |
+          echo "CHARM_NAME=$([ -f metadata.yaml ] && yq '.name' metadata.yaml || echo UNKNOWN)" >> $GITHUB_ENV
+          args=""
+          for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
+            if [ ${{ github.event.pull_request.head.repo.fork }} = "true" ]; then
+              args="${args} --${image_name}-image localhost:32000/${image_name}:latest"
+            else
+              args="${args} --${image_name}-image ${{ inputs.registry }}/${{ inputs.owner }}/${image_name}:${{ github.run_id }}"
+            fi
+          done
+
+          series=""
+          if [ ! -z ${{ matrix.series }} ]; then
+            series="--series ${{ matrix.series }}"
+          fi
+          module=""
+          if [ ! -z ${{ matrix.modules }} ]; then
+            module="-k ${{ matrix.modules }}"
+          fi
+          tox -e integration -- --model testing --keep-models $series $module $args ${{ inputs.extra-arguments }}
+      - name: Run lxd integration tests
+        working-directory: ${{ inputs.working-directory }}
+        if: ${{ inputs.provider == 'lxd' }}
         run: |
           echo "CHARM_NAME=$([ -f metadata.yaml ] && yq '.name' metadata.yaml || echo UNKNOWN)" >> $GITHUB_ENV
           args=""

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -273,16 +273,9 @@ jobs:
         run: echo "KUBE_CONFIG_DATA=$(sudo microk8s config | base64 -w 0)" >> $GITHUB_ENV
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-      - name: Setup Litmus
-        if: ${{ inputs.chaos-enabled }}
-        uses: merkata/github-chaos-actions@master
-        env:
-          APP_NS: ${{ inputs.chaos-app-namespace }}
-          CHAOS_NAMESPACE: ${{ inputs.chaos-namespace }}
-          INSTALL_LITMUS: true
       - name: Run Litmus Chaos experiments
         if: ${{ inputs.chaos-enabled }}
-        uses: merkata/github-chaos-actions@feat/run-multiple-scenarios
+        uses: merkata/github-chaos-actions@fix/oci-cli
         env:
           APP_KIND: ${{ inputs.chaos-app-kind }}
           APP_LABEL: ${{ inputs.chaos-app-label }}
@@ -292,6 +285,7 @@ jobs:
           DELAY: ${{ inputs.chaos-status-delay }}
           DURATION: ${{ inputs.chaos-status-duration }}
           EXPERIMENT_NAME: ${{ inputs.chaos-experiments }}
+          INSTALL_LITMUS: true
           TOTAL_CHAOS_DURATION: ${{ inputs.chaos-duration }}
           KUBE_CONFIG_DATA: ${{ env.KUBE_CONFIG_DATA }}
       - name: Install k6s


### PR DESCRIPTION
Having the model "testing" as the fixed model name causes problems with the integration tests when lxd is the provider. Since for this tests it is not useful to have a fixed model name, I'd attempt to remove it for lxd in order for the tests to pass.