### PR TITLE
add option for disabling upload-charm-docs

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -16,6 +16,10 @@ on:
         type: string
         description: 'Charmcraft Base Architecture'
         default: 'amd64'
+      doc-automation-disabled:
+        type: boolean
+        description: 'Whether to disable the documentation automation'
+        default: true
 
 jobs:
   get-runner-image:
@@ -85,7 +89,7 @@ jobs:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
-          dry_run: true
+          dry_run: ${{ inputs.doc-automation-disabled }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Show index page
         if: steps.docs-exist.outputs.docs_exist == 'True'

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The runner image will be set to the value of `bases[0].build-on[0]` in the `char
 | destination-channel | string | "" | Destination channel |
 | origin-channel | string | "" | Origin channel |
 | architecture | string | amd64 | Charm architecture |
+| doc-automation-disabled | boolean | true | Whether the documentation automation is disabled |
 
 The runner image will be set to the value of `bases[0].build-on[0]` in the `charmcraft.yaml` file, defaulting to ubuntu-22.04 if the file does not exist.
 


### PR DESCRIPTION
So that we can start to use upload-charm-docs on discourse and jenkins-k8s, adds an option to enable publishing the documentation to discourse