### PR TITLE
Revert to using the gh registry

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -64,7 +64,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push image
         uses: docker/build-push-action@v3
-        if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           context: .
           build-args: ${{ inputs.build-args }}

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -11,6 +11,14 @@ on:
           List of build args to pass to the build image job.
         type: string
         default: ""
+      owner:
+        type: string
+        description: Registry owner to push the built images
+        default: ""
+      registry:
+        type: string
+        description: Registry to push the built images
+        default: ""
       runs-on:
         type: string
         description: Image runner for building the images
@@ -48,36 +56,26 @@ jobs:
         image: ${{ fromJSON(needs.get-images.outputs.images) }}
     steps:
       - uses: actions/checkout@v3
-      # GitHub doesn't currently support pushing images in the Docker registry when opening a PR from a fork
-      # so an artifact is published instead
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build image as tarball
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
         uses: docker/build-push-action@v3
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           context: .
+          build-args: ${{ inputs.build-args }}
+          push: true
+          tags: ${{ inputs.registry }}/${{ inputs.owner }}/${{ matrix.image }}:${{ github.run_id }}
           file: ${{ inputs.working-directory }}/${{ matrix.image }}.Dockerfile
-          tags: ${{ matrix.image }}:latest
-          outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar
-      - name: Upload image artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.image }}
-          path: /tmp/${{ matrix.image }}.tar
       # Trivy requires an OCI type tar to run the scan
-      - name: Build image as tarball
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          file: ${{ inputs.working-directory }}/${{ matrix.image }}.Dockerfile
-          outputs: type=oci,dest=${{ matrix.image }}.tar
-      - name: Get tar image name
-        run: |
-          echo "IMAGE_TAR=${{ matrix.image }}.tar" >> $GITHUB_ENV
       - name: Run Github Trivy Image Action
         uses: aquasecurity/trivy-action@0.10.0
         with:
-          input: ${{ env.IMAGE_TAR }}
+          image-ref: ${{ inputs.registry }}/${{ inputs.owner }}/${{ matrix.image }}:${{ github.run_id }}
           trivy-config: ${{ inputs.trivy-image-config }}
           exit-code: '1'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -6,6 +6,14 @@ name: Build images
 on:
   workflow_call:
     inputs:
+      owner:
+        type: string
+        description: Registry owner to push the built images
+        default: ""
+      registry:
+        type: string
+        description: Registry to push the built images
+        default: ""
       runs-on:
         type: string
         description: Image runner for building the images
@@ -59,23 +67,16 @@ jobs:
       - name: Extract rock information
         run: |
           IMAGE_NAME=$(yq '.name' "${{ matrix.path }}/rockcraft.yaml")
+          IMAGE_REF=${{ inputs.registry }}/${{ inputs.owner }}/$IMAGE_NAME:${{ github.run_id }}
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
           echo "IMAGE_REF=$IMAGE_REF" >> $GITHUB_ENV
-      # GitHub doesn't currently support pushing images in the Docker registry when opening a PR from a fork
-      # so an artifact is published instead
-      - name: Build rock as tarball
+      - name: Upload rock to ghcr.io
         run: |
-          skopeo copy oci-archive:$(ls "${{ matrix.path }}"/*.rock) docker-archive:./$IMAGE_NAME.tar:$IMAGE_NAME:latest
-          echo "IMAGE_TAR=/github/workspace/$IMAGE_NAME.tar" >> $GITHUB_ENV
-      - name: Upload image artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.IMAGE_NAME }}
-          path: ${{ env.IMAGE_NAME }}.tar
+          skopeo --insecure-policy copy oci-archive:$(ls "${{ matrix.path }}"/*.rock) docker://$IMAGE_REF --dest-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}"
       - name: Run Github Trivy Image Action
         uses: aquasecurity/trivy-action@0.10.0
         with:
-          input: ${{ env.IMAGE_TAR }}
+          image-ref: ${{ env.IMAGE_REF }}
           trivy-config: ${{ inputs.trivy-image-config }}
           exit-code: '1'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -6,6 +6,10 @@ name: Integration tests
 on:
   workflow_call:
     inputs:
+      channel:
+        description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: latest/stable
       chaos-app-kind:
         type: string
         description: Application kind
@@ -61,9 +65,13 @@ on:
         default: '{}'
       image-build-args:
         description: |
-          List of build args to pass to the build image job.
+          List of build args to pass to the build image job
         type: string
         default: ""
+      juju-channel:
+        description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: 2.9/stable
       load-test-enabled:
         type: boolean
         description: Whether load testing is enabled
@@ -86,15 +94,7 @@ on:
       microk8s-addons:
         description: Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.
         type: string
-        default: "dns ingress rbac registry storage"
-      channel:
-        description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
-        type: string
-        default: latest/stable
-      juju-channel:
-        description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
-        type: string
-        default: 2.9/stable
+        default: "dns ingress rbac storage"
       series:
         description: List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument
         type: string
@@ -165,6 +165,10 @@ on:
         description: Pushed images
         value: ${{ jobs.all-images.outputs.images }}
 
+env:
+  REGISTRY: ghcr.io
+  OWNER: ${{ github.repository_owner }}
+
 concurrency:
   group: operator-workflows-${{ github.workflow }}-integration-tests-${{ github.ref }}
   cancel-in-progress: true
@@ -180,6 +184,8 @@ jobs:
     uses: ./.github/workflows/build_images.yaml
     needs: get-runner-image
     with:
+      owner: ${{ github.repository_owner }}
+      registry: ghcr.io
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       trivy-image-config: ${{ inputs.trivy-image-config }}
       working-directory: ${{ inputs.working-directory }}
@@ -189,6 +195,8 @@ jobs:
     uses: ./.github/workflows/build_rocks.yaml
     needs: get-runner-image
     with:
+      owner: ${{ github.repository_owner }}
+      registry: ghcr.io
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       trivy-image-config: ${{ inputs.trivy-image-config }}
       working-directory: ${{ inputs.working-directory }}
@@ -213,6 +221,7 @@ jobs:
     needs: [get-runner-image, all-images]
     if: ${{ !failure() }}
     with:
+      channel: ${{ inputs.channel }}
       chaos-app-kind: ${{ inputs.chaos-app-kind }}
       chaos-app-label: ${{ inputs.chaos-app-label }}
       chaos-app-namespace: ${{ inputs.chaos-app-namespace }}
@@ -226,14 +235,15 @@ jobs:
       extra-arguments: ${{ inputs.extra-arguments }}
       extra-test-matrix: ${{ inputs.extra-test-matrix }}
       images: ${{ needs.all-images.outputs.images }}
+      juju-channel: ${{ inputs.juju-channel }}
       load-test-enabled: ${{ inputs.load-test-enabled }}
       load-test-run-args: ${{ inputs.load-test-run-args }}
       modules: ${{ inputs.modules }}
+      owner: ${{ github.repository_owner }}
       pre-run-script: ${{ inputs.pre-run-script }}
       provider: ${{ inputs.provider }}
       microk8s-addons: ${{ inputs.microk8s-addons }}
-      channel: ${{ inputs.channel }}
-      juju-channel: ${{ inputs.juju-channel }}
+      registry: ghcr.io
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       series: ${{ inputs.series }}
       setup-devstack-swift: ${{ inputs.setup-devstack-swift }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -199,6 +199,7 @@ jobs:
           for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
             docker load < ${image_name}/${image_name}.tar
             docker tag ${image_name}:latest localhost:32000/${image_name}:latest
+            docker images ls
             docker push localhost:32000/${image_name}:latest
           done
       - name: Pre-run script
@@ -227,6 +228,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'microk8s' }}
         run: |
+          sudo microk8s ctr images ls
           tox -e integration -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }}
       - name: Run lxd integration tests
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -6,6 +6,10 @@ name: Run integration tests
 on:
   workflow_call:
     inputs:
+      channel:
+        description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: latest/stable
       chaos-app-kind:
         type: string
         description: Application kind
@@ -63,6 +67,10 @@ on:
         description: Existing docker images
         type: string
         default: '[""]'
+      juju-channel:
+        description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: 2.9/stable
       load-test-enabled:
         type: boolean
         description: Whether load testing is enabled
@@ -75,6 +83,10 @@ on:
         description: List of testing modules to run the tests in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument
         type: string
         default: '[""]'
+      owner:
+        type: string
+        description: Registry owner to push the built images
+        default: ""
       pre-run-script:
         description: Path to the bash script to be run before the integration tests
         type: string
@@ -85,15 +97,11 @@ on:
       microk8s-addons:
         description: Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.
         type: string
-        default: "dns ingress rbac registry storage"
-      channel:
-        description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
+        default: "dns ingress rbac storage"
+      registry:
         type: string
-        default: latest/stable
-      juju-channel:
-        description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
-        type: string
-        default: 2.9/stable
+        description: Registry to push the built images
+        default: ""
       runs-on:
         type: string
         description: Image runner for building the images
@@ -188,20 +196,18 @@ jobs:
           microk8s-addons: ${{ inputs.microk8s-addons }}
           channel: ${{ inputs.channel }}
           juju-channel: ${{ inputs.juju-channel }}
-      - name: Download all artifacts
-        uses: actions/download-artifact@v3
-        with:
-          path: ${{ inputs.working-directory }}
-      - name: Import images
-        if: ${{ inputs.provider == 'microk8s' }}
-        working-directory: ${{ inputs.working-directory }}
+      - name: Configure GHCR in microk8s
+        if: ${{ inputs.provider == 'microk8s' && !github.event.pull_request.head.repo.fork }}
         run: |
-          for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
-            docker load < ${image_name}/${image_name}.tar
-            docker tag ${image_name}:latest localhost:32000/${image_name}:latest
-            docker images ls
-            docker push localhost:32000/${image_name}:latest
-          done
+          # Adding authentication for ghcr.io for containerd as per https://microk8s.io/docs/registry-private
+          # Note: containerd has to be restarted for the changes to take effect
+          # (https://github.com/containerd/cri/blob/master/docs/registry.md)
+          sudo su -c 'echo "
+          [plugins.\"io.containerd.grpc.v1.cri\".registry.configs.\"ghcr.io\".auth]
+          username = \"${{ github.actor }}\"
+          password = \"${{ secrets.GITHUB_TOKEN }}\"
+          " >> /var/snap/microk8s/current/args/containerd-template.toml'
+          sudo su -c 'systemctl restart snap.microk8s.daemon-containerd.service && microk8s status --wait-ready'
       - name: Pre-run script
         if: ${{ inputs.pre-run-script != '' }}
         run: bash -xe ${{ inputs.pre-run-script }}
@@ -211,7 +217,7 @@ jobs:
           echo "CHARM_NAME=$([ -f metadata.yaml ] && yq '.name' metadata.yaml || echo UNKNOWN)" >> $GITHUB_ENV
           args=""
           for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
-            args="${args} --${image_name}-image localhost:32000/${image_name}:latest"
+            args="${args} --${image_name}-image ${{ inputs.registry }}/${{ inputs.owner }}/${image_name}:${{ github.run_id }}"
           done
           echo "ARGS=$args" >> $GITHUB_ENV
           series=""
@@ -228,7 +234,6 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'microk8s' }}
         run: |
-          sudo microk8s ctr images ls
           tox -e integration -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }}
       - name: Run lxd integration tests
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -197,7 +197,7 @@ jobs:
           channel: ${{ inputs.channel }}
           juju-channel: ${{ inputs.juju-channel }}
       - name: Configure GHCR in microk8s
-        if: ${{ inputs.provider == 'microk8s' && !github.event.pull_request.head.repo.fork }}
+        if: ${{ inputs.provider == 'microk8s' }}
         run: |
           # Adding authentication for ghcr.io for containerd as per https://microk8s.io/docs/registry-private
           # Note: containerd has to be restarted for the changes to take effect

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -15,6 +15,10 @@ on:
         description: The working directory for jobs
         default: "./"
 
+env:
+  REGISTRY: ghcr.io
+  OWNER: ${{ github.repository_owner }}
+
 jobs:
   branch-up-to-date-check-enabled:
     runs-on: ubuntu-22.04
@@ -141,26 +145,20 @@ jobs:
       - name: Install charmcraft and docker
         run: |
           sudo snap install charmcraft --classic
-          sudo snap install docker
-      - name: Download image artifacts
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          gh run download ${{ needs.get-run-id.outputs.run-id }} -R ${{ github.repository }} -n ${{ matrix.image }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Download image artifacts
-        uses: actions/download-artifact@v3
-        if: ${{ github.event_name == 'pull_request' }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
         with:
-          name: ${{ matrix.image }}
-          path: ${{ inputs.working-directory }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish image
         env:
           CHARMCRAFT_AUTH:  ${{ secrets.CHARMHUB_TOKEN }}
         run: |
           charmName=$(yq -e '.name' metadata.yaml)
-          cat ${{ matrix.image }}.tar | docker import - ${{ matrix.image }}:latest
-          imageId=$(docker images ${{ matrix.image }}:latest --format "{{.ID}}")
+          image=${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:$${{ needs.get-run-id.outputs.run-id }}
+          docker pull $image
+          imageId=$(docker images $image --format "{{.ID}}")
           charmcraft upload-resource $charmName ${{ matrix.image }}-image --image=$imageId --verbosity=brief
   publish-charm:
     name: Publish charm to ${{ inputs.channel }}

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -156,7 +156,7 @@ jobs:
           CHARMCRAFT_AUTH:  ${{ secrets.CHARMHUB_TOKEN }}
         run: |
           charmName=$(yq -e '.name' metadata.yaml)
-          image=${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:$${{ needs.get-run-id.outputs.run-id }}
+          image=${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ needs.get-run-id.outputs.run-id }}
           docker pull $image
           imageId=$(docker images $image --format "{{.ID}}")
           charmcraft upload-resource $charmName ${{ matrix.image }}-image --image=$imageId --verbosity=brief

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -107,6 +107,11 @@ jobs:
             -f event=pull_request \
             --jq  '[.workflow_runs[] | select(.path == ".github/workflows/integration_test.yaml")] | max_by(.updated_at)')
           echo "RUN_ID=$RUN_ID" >> $GITHUB_ENV
+      - name: Get current run id
+        if: ${{ github.event_name == 'push' }}
+        shell: bash  
+        run: |
+          echo "RUN_ID=${{ github.run_id }}" >> $GITHUB_ENV
   get-images:
     name: Get images
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -108,7 +108,7 @@ jobs:
             --jq  '[.workflow_runs[] | select(.path == ".github/workflows/integration_test.yaml")] | max_by(.updated_at)')
           echo "RUN_ID=$RUN_ID" >> $GITHUB_ENV
       - name: Get current run id
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'pull_request' }}
         shell: bash  
         run: |
           echo "RUN_ID=${{ github.run_id }}" >> $GITHUB_ENV
@@ -147,7 +147,7 @@ jobs:
           rm -rf .* * || :
           cp -rp $TEMP_DIR/. .
           rm -rf $TEMP_DIR
-      - name: Install charmcraft and docker
+      - name: Install charmcraft
         run: |
           sudo snap install charmcraft --classic
       - name: Log in to the Container registry

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following workflows are available:
 
 | Name | Type | Default | Description |
 |--------------------|----------|--------------------|-------------------|
+| channel | string | latest/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | chaos-enabled  | bool | false | Whether Chaos testing is enabled |
 | chaos-experiments | string | "" | List of experiments to run |
 | chaos-namespace | string | testing | Namespace to install Litmus Chaos |
@@ -32,14 +33,14 @@ The following workflows are available:
 | chaos-duration | string | 60 | Duration of the chaos experiment |
 | extra-arguments | string | "" | Additional arguments to pass to the integration test execution |
 | extra-test-matrix | string | '{}' | Additional test matrices to run the integration test combinations |
+| image-build-args | string | "" | List of build args to pass to the build image job |
+| juju-channel | string | 2.9/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | load-test-enabled | bool | false | Whether load testing is enabled. If enabled, k6 will expect a load_tests/load-test.js file with the tests to run. |
 | load-test-run-args | string | "" | Command line arguments for the load test execution. |
 | modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |
 | pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
 | provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
-| microk8s-addons | string | "dns ingress rbac registry storage" | Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled. |
-| channel | string | latest/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
-| juju-channel | string | 2.9/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| microk8s-addons | string | "dns ingress rbac storage" | Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled. |
 | series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
 | setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for testing. |
 | tmate-debug | bool | false | Enable tmate debugging after integration test failure. |


### PR DESCRIPTION
Use the GH registry to share the images. This drops support for running some CI checks from forks, which  is planned for future updates