### PR TITLE
fix: woke

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,6 +55,7 @@ jobs:
             ' $woke_file /tmp/config.yml | tee /tmp/merged.yml
             mv /tmp/merged.yml /tmp/config.yml
           fi
+          sleep 300
       - name: Run inclusive naming check
         uses: canonical/inclusive-naming@main
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           repository: canonical/Inclusive-naming
           path: ${{ inputs.working-directory }}
-      - name: Copy files to tmp working directory
+      - name: Copy files to tmp directory
         run: |
           pwd
           cp -r . /tmp
@@ -38,7 +38,7 @@ jobs:
       - name: Merge configuration files
         run: |
           pwd
-          ls
+          ls -la
           # Combine all entries and replace matching elements by
           # .name in .rules for the ones in .woke.yaml
           woke_file=""

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
           repository: canonical/Inclusive-naming
           path: ${{ inputs.working-directory }}
       - name: Copy files to tmp working directory
-        run: cp -rp . /tmp
+        run: cp -r . /tmp
       - uses: actions/checkout@v3
       - name: Merge configuration files
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,25 +30,24 @@ jobs:
         with:
           repository: canonical/Inclusive-naming
           path: ${{ inputs.working-directory }}
-      - name: Copy files to tmp directory
-        run: |
-          pwd
-          cp -r . /tmp
+      - run: mv * /tmp
       - uses: actions/checkout@v3
       - name: Merge configuration files
         run: |
           pwd
           ls -la
-          sleep 120
           # Combine all entries and replace matching elements by
           # .name in .rules for the ones in .woke.yaml
           woke_file=""
           if [ -f .woke.yaml ]; then
             woke_file=".woke.yaml"
+            cat $woke_file
           elif [ -f .woke.yml ]; then
             woke_file=".woke.yml"
           fi
           if [ ! -z "$woke_file" ]; then
+            echo "$woke_file"
+            cat "$woke_file"
             yq eval-all '
             (
               . as $item ireduce ({}; . *+ $item) | .rules | unique_by(.name)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,10 +30,10 @@ jobs:
         with:
           repository: canonical/Inclusive-naming
           path: ${{ inputs.working-directory }}
-      - run: |
-          ls -la
-          mv ./* /tmp/
-          ls -la /tmp
+      - name: Make tmp directory in $HOME and move inclusive naming files.
+        run: |
+          mkdir ~/tmp
+          mv ./* ~/tmp
       - uses: actions/checkout@v3
       - name: Merge configuration files
         run: |
@@ -46,13 +46,12 @@ jobs:
           elif [ -f .woke.yml ]; then
             woke_file=".woke.yml"
           fi
-          sleep 300
           if [ ! -z "$woke_file" ]; then
             cat $woke_file | sudo yq eval-all '
             (
               . as $item ireduce ({}; . *+ $item) | .rules | unique_by(.name)
             ) as $mergedArray | . as $item ireduce ({}; . *+ $item) | .rules = $mergedArray
-            ' /tmp/config.yml - | tee /tmp/merged.yml
+            ' ~/config.yml - | tee /tmp/merged.yml
             mv /tmp/merged.yml /tmp/config.yml
           fi
       - name: Run inclusive naming check

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,10 @@ jobs:
         with:
           repository: canonical/Inclusive-naming
           path: ${{ inputs.working-directory }}
-      - run: mv ./* /tmp/
+      - run: |
+          ls -la
+          mv ./* /tmp/
+          ls -la /tmp
       - uses: actions/checkout@v3
       - name: Merge configuration files
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,10 +31,14 @@ jobs:
           repository: canonical/Inclusive-naming
           path: ${{ inputs.working-directory }}
       - name: Copy files to tmp working directory
-        run: cp -r . /tmp
+        run: |
+          pwd
+          cp -r . /tmp
       - uses: actions/checkout@v3
       - name: Merge configuration files
         run: |
+          pwd
+          ls
           # Combine all entries and replace matching elements by
           # .name in .rules for the ones in .woke.yaml
           woke_file=""
@@ -61,10 +65,6 @@ jobs:
           filter-mode: nofilter
           workdir: ${{ inputs.working-directory }}
           woke-version: latest
-      - name: Tmate debugging session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 30
   get-runner-image:
     name: Get runner image
     uses: ./.github/workflows/get_runner_image.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
           fi
           sleep 300
           if [ ! -z "$woke_file" ]; then
-            cat $woke_file | yq eval-all '
+            cat $woke_file | sudo yq eval-all '
             (
               . as $item ireduce ({}; . *+ $item) | .rules | unique_by(.name)
             ) as $mergedArray | . as $item ireduce ({}; . *+ $item) | .rules = $mergedArray

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           repository: canonical/Inclusive-naming
           path: ${{ inputs.working-directory }}
-      - run: mv * /tmp
+      - run: cp -R * /tmp
       - uses: actions/checkout@v3
       - name: Merge configuration files
         run: |
@@ -46,13 +46,11 @@ jobs:
             woke_file=".woke.yml"
           fi
           if [ ! -z "$woke_file" ]; then
-            echo "$woke_file"
-            cat "$woke_file"
-            yq eval-all '
+            cat $woke_file | yq eval-all '
             (
               . as $item ireduce ({}; . *+ $item) | .rules | unique_by(.name)
             ) as $mergedArray | . as $item ireduce ({}; . *+ $item) | .rules = $mergedArray
-            ' $woke_file /tmp/config.yml | tee /tmp/merged.yml
+            ' /tmp/config.yml - | tee /tmp/merged.yml
             mv /tmp/merged.yml /tmp/config.yml
           fi
           sleep 300

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           repository: canonical/Inclusive-naming
           path: ${{ inputs.working-directory }}
-      - run: cp -R * /tmp
+      - run: mv ./* /tmp/
       - uses: actions/checkout@v3
       - name: Merge configuration files
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,6 +46,7 @@ jobs:
           elif [ -f .woke.yml ]; then
             woke_file=".woke.yml"
           fi
+          sleep 300
           if [ ! -z "$woke_file" ]; then
             cat $woke_file | yq eval-all '
             (

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,10 @@ jobs:
         with:
           repository: canonical/Inclusive-naming
           path: ${{ inputs.working-directory }}
-      - run: mv * /tmp
+      - name: Copy files to tmp working directory
+        run: |
+          mv * /tmp
+          mv .* /tmp
       - uses: actions/checkout@v3
       - name: Merge configuration files
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,6 +62,7 @@ jobs:
           workdir: ${{ inputs.working-directory }}
           woke-version: latest
       - name: Tmate debugging session
+        if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 30
   get-runner-image:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
             woke_file=".woke.yml"
           fi
           if [ ! -z "$woke_file" ]; then
-            cat $woke_file | sudo yq eval-all '
+            cat $woke_file | yq eval-all '
             (
               . as $item ireduce ({}; . *+ $item) | .rules | unique_by(.name)
             ) as $mergedArray | . as $item ireduce ({}; . *+ $item) | .rules = $mergedArray

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,6 +61,9 @@ jobs:
           filter-mode: nofilter
           workdir: ${{ inputs.working-directory }}
           woke-version: latest
+      - name: Tmate debugging session
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30
   get-runner-image:
     name: Get runner image
     uses: ./.github/workflows/get_runner_image.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,8 +34,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Merge configuration files
         run: |
-          pwd
-          ls -la
           # Combine all entries and replace matching elements by
           # .name in .rules for the ones in .woke.yaml
           woke_file=""
@@ -53,7 +51,6 @@ jobs:
             ' /tmp/config.yml - | tee /tmp/merged.yml
             mv /tmp/merged.yml /tmp/config.yml
           fi
-          sleep 300
       - name: Run inclusive naming check
         uses: canonical/inclusive-naming@main
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,9 +31,7 @@ jobs:
           repository: canonical/Inclusive-naming
           path: ${{ inputs.working-directory }}
       - name: Copy files to tmp working directory
-        run: |
-          mv * /tmp
-          mv .* /tmp
+        run: cp -rp . /tmp
       - uses: actions/checkout@v3
       - name: Merge configuration files
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,6 @@ jobs:
           woke_file=""
           if [ -f .woke.yaml ]; then
             woke_file=".woke.yaml"
-            cat $woke_file
           elif [ -f .woke.yml ]; then
             woke_file=".woke.yml"
           fi
@@ -51,7 +50,7 @@ jobs:
             (
               . as $item ireduce ({}; . *+ $item) | .rules | unique_by(.name)
             ) as $mergedArray | . as $item ireduce ({}; . *+ $item) | .rules = $mergedArray
-            ' ~/tmp/config.yml - | tee /tmp/merged.yml
+            ' - ~/tmp/config.yml | tee /tmp/merged.yml
             mv /tmp/merged.yml /tmp/config.yml
           fi
       - name: Run inclusive naming check

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,7 @@ jobs:
             (
               . as $item ireduce ({}; . *+ $item) | .rules | unique_by(.name)
             ) as $mergedArray | . as $item ireduce ({}; . *+ $item) | .rules = $mergedArray
-            ' ~/config.yml - | tee /tmp/merged.yml
+            ' ~/tmp/config.yml - | tee /tmp/merged.yml
             mv /tmp/merged.yml /tmp/config.yml
           fi
       - name: Run inclusive naming check

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,7 @@ jobs:
         run: |
           pwd
           ls -la
+          sleep 120
           # Combine all entries and replace matching elements by
           # .name in .rules for the ones in .woke.yaml
           woke_file=""


### PR DESCRIPTION
This PR fixes the inaccessible paths to woke configuration files.
The issues were caused by:
- Self hosted [runner path]([runner path](https://github.com/canonical/github-runner-operator/blob/ff2e6d8b49a1f01d00def014b38dcaeeb8f63023/src/runner.py#L56C26-L56C52)) `/opt/github-runner/_work/<repo>/<repo>` being different to Github runner path `/home/github-runner/work/<repo>/<repo>`
- yq having [strict confinement](https://github.com/mikefarah/yq/issues/148)