### PR TITLE
docs: add self-hosted-runner to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following workflows are available:
 | Name | Type | Default | Description |
 |--------------------|----------|--------------------|-------------------|
 | working-directory | string | "./" | Directory where jobs should be executed |
+| self-hosted-runner | bool | true | Whether self-hosted-runner should be enabled |
 
 * comment: Posts the content of the artifact specified as a comment in a PR. It needs to be triggered from a PR triggered workflow.
 


### PR DESCRIPTION
This PR adds docs about self-hosted-runner to the README.md