### PR TITLE
add cancelled checks and timeouts for required status checks

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -267,7 +267,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - integration-test
-    if: always()
+    if: always() && !cancelled()
+    timeout-minutes: 5
     steps:
       - run: |
           [ '${{ needs.integration-test.result }}' = 'success' ] || (echo integration-test failed && false)

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -307,7 +307,7 @@ jobs:
           cmd_options: ${{ inputs.zap-cmd-options }}
           rules_file_name: ${{ inputs.zap-rules-file-name }}
       - name: Pack charm
-        if: ${{ always() && env.CHARM_NAME != 'UNKNOWN' }}
+        if: ${{ always() && env.CHARM_NAME != 'UNKNOWN' && !cancelled() }}
         working-directory: ${{ inputs.working-directory }}
         run: |
           # Not ideal, but the charm doesn't get always packed during the integration tests step
@@ -320,7 +320,7 @@ jobs:
           fi
           echo "CHARM_FILE=$(ls ${{ env.CHARM_NAME }}_*.charm)" >> $GITHUB_ENV
       - name: Upload charm artifact
-        if: ${{ always() && env.CHARM_NAME != 'UNKNOWN' }}
+        if: ${{ always() && env.CHARM_NAME != 'UNKNOWN' && !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.CHARM_NAME }}-charm

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -226,7 +226,7 @@ jobs:
               fi
           done
       - name: Export test report
-        if: always()
+        if: always() && !cancelled()
         uses: actions/github-script@v6
         with:
           script: |
@@ -280,7 +280,7 @@ jobs:
             fs.writeFileSync('report.json', json);
       - name: Upload coverage report
         uses: actions/upload-artifact@v3
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && !cancelled()
         with:
           name: report
           path: report.json
@@ -346,7 +346,8 @@ jobs:
       - metadata-lint
       - shellcheck-lint
       - license-headers-check
-    if: always()
+    if: always() && !cancelled()
+    timeout-minutes: 5
     steps:
       - run: |
           [ '${{ needs.draft-publish-docs.result }}' = 'success' ] || (echo draft-publish-docs failed && false)

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -44,7 +44,8 @@ jobs:
       working-directory: tests/workflows/integration/test-upload-charm/
   check:
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && !cancelled()
+    timeout-minutes: 5
     needs:
       - simple
       - integration


### PR DESCRIPTION
Based on https://github.com/orgs/community/discussions/26303 it seems that jobs with `always()` in the `if` can't be cancelled. Adding a cancelled check and a timeout for the short running jobs that check for the valid status