### PR TITLE
Re-enable cancel-in-progress for test.yaml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ on:
 
 concurrency:
   group: operator-workflows-${{ github.workflow }}-tests-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   inclusive-naming-check:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ on:
         default: true
 
 concurrency:
-  group: operator-workflows-${{ github.workflow }}-tests-${{ github.ref }}
+  group: operator-workflows-${{ github.workflow }}-tests-${{ github.ref }}-self-hosted-${{ inputs.self-hosted-runner }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
After the cancellation issue is resolve the "cancel-in-progress" for test.yaml can be enabled.