### PR TITLE
Build charm and enable reusing it during integration testing

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -215,10 +215,31 @@ jobs:
             IMAGES='${{ needs.build-images.outputs.images }}'
           fi
           echo "IMAGES=$IMAGES" >> $GITHUB_ENV
+  build-charm:
+    name: Build and push charm
+    needs: get-runner-image
+    runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
+    outputs:
+      charm-file: ${{ env.CHARM_FILE }}
+    steps:
+      - name: Pack charm
+        if: ${{ !cancelled() }}
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          echo "CHARM_NAME=$([ -f metadata.yaml ] && yq '.name' metadata.yaml || echo UNKNOWN)" >> $GITHUB_ENV
+          charmcraft pack -v
+          echo "CHARM_FILE=$(ls ${{ env.CHARM_NAME }}_*.charm)" >> $GITHUB_ENV
+      - name: Upload charm artifact
+        if: ${{ env.CHARM_NAME != 'UNKNOWN' && !cancelled() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.CHARM_NAME }}-charm
+          path: ${{ inputs.working-directory }}/${{ env.CHARM_FILE }}
+          if-no-files-found: error
   integration-test:
     name: Integration tests
     uses: ./.github/workflows/integration_test_run.yaml
-    needs: [get-runner-image, all-images]
+    needs: [all-images, build-charm, get-runner-image]
     if: ${{ !failure() }}
     with:
       channel: ${{ inputs.channel }}
@@ -232,6 +253,7 @@ jobs:
       chaos-namespace: ${{ inputs.chaos-namespace }}
       chaos-status-delay: ${{ inputs.chaos-status-delay }}
       chaos-status-duration: ${{ inputs.chaos-status-duration }}
+      charm-file: ${{ needs.build-charm.outputs.charm-file }}
       extra-arguments: ${{ inputs.extra-arguments }}
       extra-test-matrix: ${{ inputs.extra-test-matrix }}
       images: ${{ needs.all-images.outputs.images }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -229,6 +229,7 @@ jobs:
         run: |
           sudo snap install charmcraft --classic --channel latest/stable
           echo "CHARM_NAME=$([ -f metadata.yaml ] && yq '.name' metadata.yaml || echo UNKNOWN)" >> $GITHUB_ENV
+          sudo lxd init --auto
           charmcraft pack -v
           echo "CHARM_FILE=$(ls ${{ env.CHARM_NAME }}_*.charm)" >> $GITHUB_ENV
       - name: Upload charm artifact

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -231,7 +231,7 @@ jobs:
           sudo snap install charmcraft --classic --channel latest/stable
           echo "CHARM_NAME=$([ -f metadata.yaml ] && yq '.name' metadata.yaml || echo UNKNOWN)" >> $GITHUB_ENV
           charmcraft pack -v
-          echo "CHARM_FILE=$(ls ${{ env.CHARM_NAME }}_*.charm)" >> $GITHUB_ENV
+          echo "CHARM_FILE=$(ls $CHARM_NAME_*.charm)" >> $GITHUB_ENV
       - name: Upload charm artifact
         if: ${{ env.CHARM_NAME != 'UNKNOWN' && !cancelled() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -223,7 +223,7 @@ jobs:
       charm-file: ${{ env.CHARM_FILE }}
     steps:
       - uses: actions/checkout@v3
-      - uses: canonical/setup-lxd@0.1.1
+      - uses: canonical/setup-lxd
       - name: Pack charm
         if: ${{ !cancelled() }}
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -223,7 +223,7 @@ jobs:
       charm-file: ${{ env.CHARM_FILE }}
     steps:
       - uses: actions/checkout@v3
-      - uses: canonical/setup-lxd
+      - uses: canonical/setup-lxd@v0.1.1
       - name: Pack charm
         if: ${{ !cancelled() }}
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -223,13 +223,13 @@ jobs:
       charm-file: ${{ env.CHARM_FILE }}
     steps:
       - uses: actions/checkout@v3
+      - uses: canonical/setup-lxd@0.1.1
       - name: Pack charm
         if: ${{ !cancelled() }}
         working-directory: ${{ inputs.working-directory }}
         run: |
           sudo snap install charmcraft --classic --channel latest/stable
           echo "CHARM_NAME=$([ -f metadata.yaml ] && yq '.name' metadata.yaml || echo UNKNOWN)" >> $GITHUB_ENV
-          sudo lxd init --auto
           charmcraft pack -v
           echo "CHARM_FILE=$(ls ${{ env.CHARM_NAME }}_*.charm)" >> $GITHUB_ENV
       - name: Upload charm artifact

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -222,10 +222,12 @@ jobs:
     outputs:
       charm-file: ${{ env.CHARM_FILE }}
     steps:
+      - uses: actions/checkout@v3
       - name: Pack charm
         if: ${{ !cancelled() }}
         working-directory: ${{ inputs.working-directory }}
         run: |
+          sudo snap install charmcraft --classic --channel latest/stable
           echo "CHARM_NAME=$([ -f metadata.yaml ] && yq '.name' metadata.yaml || echo UNKNOWN)" >> $GITHUB_ENV
           charmcraft pack -v
           echo "CHARM_FILE=$(ls ${{ env.CHARM_NAME }}_*.charm)" >> $GITHUB_ENV

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -54,6 +54,9 @@ on:
           Retry is chaos-duration/chaos-delay times and each retry
           sleeps chaos-delay
         default: 90
+      charm-file:
+        type: string
+        description: Charm file
       extra-arguments:
         description: Additional arguments to pass to the integration test execution
         type: string
@@ -219,6 +222,9 @@ jobs:
           for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
             args="${args} --${image_name}-image ${{ inputs.registry }}/${{ inputs.owner }}/${image_name}:${{ github.run_id }}"
           done
+          if [ ! -z ${{ inputs.charm-file }} ]; then
+            ARGS="--charm-file ./${{ inputs.charm-file }}"
+          fi
           echo "ARGS=$args" >> $GITHUB_ENV
           series=""
           if [ ! -z ${{ matrix.series }} ]; then
@@ -230,6 +236,12 @@ jobs:
             module="-k ${{ matrix.modules }}"
           fi
           echo "MODULE=$module" >> $GITHUB_ENV
+      - name: Download charm artifact
+        uses: actions/download-artifact@v3
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          name: ${{ env.CHARM_NAME }}-charm
+          path: ${{ inputs.working-directory }}
       - name: Run k8s integration tests
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'microk8s' }}
@@ -306,23 +318,3 @@ jobs:
           target: ${{ inputs.zap-target-protocol }}://${{ env.ZAP_TARGET }}:${{ inputs.zap-target-port }}/
           cmd_options: ${{ inputs.zap-cmd-options }}
           rules_file_name: ${{ inputs.zap-rules-file-name }}
-      - name: Pack charm
-        if: ${{ always() && env.CHARM_NAME != 'UNKNOWN' && !cancelled() }}
-        working-directory: ${{ inputs.working-directory }}
-        run: |
-          # Not ideal, but the charm doesn't get always packed during the integration tests step
-          CURRENT_CHARM_PATH=$(find .tox/integration/tmp/pytest -name *.charm)
-          if [ -z "$CURRENT_CHARM_PATH" ]; then
-            mv $CURRENT_CHARM_PATH .
-          fi
-          if [ -z "$CHARM_FILE" ]; then
-            charmcraft pack
-          fi
-          echo "CHARM_FILE=$(ls ${{ env.CHARM_NAME }}_*.charm)" >> $GITHUB_ENV
-      - name: Upload charm artifact
-        if: ${{ always() && env.CHARM_NAME != 'UNKNOWN' && !cancelled() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.CHARM_NAME }}-charm
-          path: ${{ inputs.working-directory }}/${{ env.CHARM_FILE }}
-          if-no-files-found: error

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -223,7 +223,7 @@ jobs:
             args="${args} --${image_name}-image ${{ inputs.registry }}/${{ inputs.owner }}/${image_name}:${{ github.run_id }}"
           done
           if [ ! -z ${{ inputs.charm-file }} ]; then
-            ARGS="--charm-file ./${{ inputs.charm-file }}"
+            args="${args} --charm-file ./${{ inputs.charm-file }}"
           fi
           echo "ARGS=$args" >> $GITHUB_ENV
           series=""

--- a/tests/workflows/integration/test-upload-charm/tests/conftest.py
+++ b/tests/workflows/integration/test-upload-charm/tests/conftest.py
@@ -6,4 +6,5 @@
 
 def pytest_addoption(parser):
     """Add test arguments."""
+    parser.addoption("--charm-file", action="store")
     parser.addoption("--test-image", action="store")

--- a/tests/workflows/integration/test-upload-charm/tests/integration/test_charm.py
+++ b/tests/workflows/integration/test-upload-charm/tests/integration/test_charm.py
@@ -15,7 +15,7 @@ async def test_build_and_deploy(ops_test: OpsTest, pytestconfig):
     """
     app_name = "test"
     assert ops_test.model
-    charm = await ops_test.build_charm(".")
+    charm = pytestconfig.getoption("--charm-file")
     resources = {"test-image": pytestconfig.getoption("--test-image")}
 
     await asyncio.gather(


### PR DESCRIPTION
* Avoids pushing multiple artifacts when integration tests run in parallel
* Speeds up the pipeline by increasing parallelization
* Speeds up reruns on failed integration tests
* The built artifact is always the tested one

To use it within your tests, just fetch the `charm-file` arg now passed when running the tests
```
def pytest_addoption(parser):
    """Add test arguments."""
    parser.addoption("--charm-file", action="store")
```
```
charm = pytestconfig.getoption("--charm-file")
application = await ops_test.model.deploy(
    charm,
    application_name=app_name,
    series="focal",
)
```