### PR TITLE
Build charm and enable reusing it during integration testing

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -223,7 +223,7 @@ jobs:
             args="${args} --${image_name}-image ${{ inputs.registry }}/${{ inputs.owner }}/${image_name}:${{ github.run_id }}"
           done
           if [ ! -z ${{ inputs.charm-file }} ]; then
-            args="${args} --charm-file ./${{ inputs.charm-file }}"
+            args="${args} --charm-file ${{ inputs.charm-file }}"
           fi
           echo "ARGS=$args" >> $GITHUB_ENV
           series=""

--- a/tests/workflows/integration/test-upload-charm/tests/integration/test_charm.py
+++ b/tests/workflows/integration/test-upload-charm/tests/integration/test_charm.py
@@ -20,7 +20,7 @@ async def test_build_and_deploy(ops_test: OpsTest, pytestconfig):
 
     await asyncio.gather(
         ops_test.model.deploy(
-            charm, resources=resources, application_name=app_name, series="jammy"
+            f"./{charm}", resources=resources, application_name=app_name, series="jammy"
         ),
         ops_test.model.wait_for_idle(
             apps=[app_name], status="active", raise_on_blocked=True, timeout=1000


### PR DESCRIPTION
Follow-up #162 

To use it within your tests, just fetch the `charm-file` arg now passed when running the tests
```
def pytest_addoption(parser):
    """Add test arguments."""
    parser.addoption("--charm-file", action="store")
```
```
charm = pytestconfig.getoption("--charm-file")
application = await ops_test.model.deploy(
    f"./{charm}",
    application_name=app_name,
    series="focal",
)
```