### PR TITLE
Update readme to include args passed to the integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ When running the integration tests, the following posargs will be automatically 
 - --model testing: Only for tests running on a microk8s substrate
 - One parameter per resource defined in the `metadata.yaml` of the charm, containing a reference to the built image
 
+For instance, for pytest you can leverage this by adding a conftest.py file
+```
+def pytest_addoption(parser):
+    """Add test arguments."""
+    parser.addoption("--charm-file", action="store")
+```
+and then use the argument value
+```
+charm = pytestconfig.getoption("--charm-file")
+```
+
 * publish_charm: Publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel).  The following parameters are available for this workflow:
 
 | Name | Type | Default | Description |

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ More information about OWASP ZAP testing can be found [here](OWASPZAP.md).
 
 More information about Trivy testing can be found [here](TRIVY.MD).
 
+When writing integration tests, the following posargs will be automatically passed to the `integration` target:
+- --charm-file: The name of the charm artifact generated prior to the integration tests run
+- One parameter per resource defined in the `metadata.yaml` of the charm, containing a reference to the built image
+
 * publish_charm: Publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel).  The following parameters are available for this workflow:
 
 | Name | Type | Default | Description |

--- a/README.md
+++ b/README.md
@@ -65,8 +65,12 @@ More information about OWASP ZAP testing can be found [here](OWASPZAP.md).
 
 More information about Trivy testing can be found [here](TRIVY.MD).
 
-When writing integration tests, the following posargs will be automatically passed to the `integration` target:
-- --charm-file: The name of the charm artifact generated prior to the integration tests run
+When running the integration tests, the following posargs will be automatically passed to the `integration` target:
+- --charm-file [charm_file_name]: The name of the charm artifact generated prior to the integration tests run
+- --series [series]: As defined in the `series` configuration described option above
+- -k [module]: As defined in the `modules` configuration option described above
+- --keep-models
+- --model testing: Only for tests running on a microk8s substrate
 - One parameter per resource defined in the `metadata.yaml` of the charm, containing a reference to the built image
 
 * publish_charm: Publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel).  The following parameters are available for this workflow:


### PR DESCRIPTION
Include in the readme the posargs automatically passed to the `integration` target