### PR TITLE
Do not fail integration tests if charm artifact is not present

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -239,6 +239,7 @@ jobs:
       - name: Download charm artifact
         uses: actions/download-artifact@v3
         if: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: true
         with:
           name: ${{ env.CHARM_NAME }}-charm
           path: ${{ inputs.working-directory }}


### PR DESCRIPTION
Do not fail integration tests if charm artifact is not present to support running tests for repostiories not containing charms