### PR TITLE
Exclude license check for json files

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -10,6 +10,7 @@ header:
   paths-ignore:
     - '.github/files/**'
     - '**/*.j2'
+    - '**/*.json'
     - '**/*.md'
     - '**/*.txt'
     - '**/*.xml'


### PR DESCRIPTION
Do not check for license header in *.json files