### PR TITLE
Add secret arguments to integration tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -62,7 +62,7 @@ on:
           Aditional mapping to lists of matrices to be applied on top of series and modules matrix in JSON format, i.e. '{"extras":["foo","bar"]}'.
           Each mapping will be injected into the matrix section of the integration-test.
         type: string
-        default: '{}'
+        default: "{}"
       image-build-args:
         description: |
           List of build args to pass to the build image job
@@ -133,7 +133,7 @@ on:
         description: If this is defined then its value will be added as a header to all of the ZAP requests
         type: string
       zap-auth-header-value:
-        description:  If this is defined then its value will be used as the header name to all of the ZAP requests
+        description: If this is defined then its value will be used as the header name to all of the ZAP requests
         type: string
       zap-before-command:
         description: Command to run before ZAP testing
@@ -147,14 +147,14 @@ on:
         description: Whether ZAP testing is enabled
         default: false
       zap-target:
-        description:  If this is not set, the unit IP address will be used as ZAP target
+        description: If this is not set, the unit IP address will be used as ZAP target
         type: string
       zap-target-port:
-        description:  ZAP target port
+        description: ZAP target port
         type: string
         default: 80
       zap-target-protocol:
-        description:  ZAP target protocol
+        description: ZAP target protocol
         type: string
         default: "http"
       zap-rules-file-name:
@@ -237,7 +237,7 @@ jobs:
           CHARMCRAFT_BASE=$(printf %s "$CHARMCRAFT_BASE"|jq -sRr @uri)
           CHARMCRAFT_CACHE_KEY_BASE="$WORKING_DIR/charmcraft-cache?name=$CHARM_NAME&bases=$CHARMCRAFT_BASE"
           echo "CHARMCRAFT_CACHE_KEY=$CHARMCRAFT_CACHE_KEY_BASE&date=$(date +%Y-%m-%d)" >> $GITHUB_ENV
-          echo 'CHARMCRAFT_CACHE_ALT_KEYS<<EOF' >> $GITHUB_ENV 
+          echo 'CHARMCRAFT_CACHE_ALT_KEYS<<EOF' >> $GITHUB_ENV
           for d in {1..2}
             do echo "$CHARMCRAFT_CACHE_KEY_BASE&date=$(date -d"-$d days" +%Y-%m-%d)" >> $GITHUB_ENV
           done
@@ -292,6 +292,7 @@ jobs:
     uses: ./.github/workflows/integration_test_run.yaml
     needs: [all-images, build-charm, get-runner-image]
     if: ${{ !failure() }}
+    secrets: inherit
     with:
       channel: ${{ inputs.channel }}
       chaos-app-kind: ${{ inputs.chaos-app-kind }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -65,7 +65,7 @@ on:
           Aditional mapping to lists of matrices to be applied on top of series and modules matrix in JSON format, i.e. '{"extras":["foo","bar"]}'.
           Each mapping will be injected into the matrix section of the integration-test.
         type: string
-        default: '{}'
+        default: "{}"
       images:
         description: Existing docker images
         type: string
@@ -144,7 +144,7 @@ on:
         description: If this is defined then its value will be added as a header to all of the ZAP requests
         type: string
       zap-auth-header-value:
-        description:  If this is defined then its value will be used as the header name to all of the ZAP requests
+        description: If this is defined then its value will be used as the header name to all of the ZAP requests
         type: string
       zap-before-command:
         description: Command to run before ZAP testing
@@ -158,14 +158,14 @@ on:
         description: Whether ZAP testing is enabled
         default: false
       zap-target:
-        description:  If this is not set, the unit IP address will be used as ZAP target
+        description: If this is not set, the unit IP address will be used as ZAP target
         type: string
       zap-target-port:
-        description:  ZAP target port
+        description: ZAP target port
         type: string
         default: 80
       zap-target-protocol:
-        description:  ZAP target protocol
+        description: ZAP target protocol
         type: string
         default: "http"
       zap-rules-file-name:
@@ -293,7 +293,7 @@ jobs:
         if: ${{ inputs.trivy-fs-enabled }}
         uses: aquasecurity/trivy-action@0.10.0
         with:
-          scan-type: 'fs'
+          scan-type: "fs"
           scan-ref: ${{ inputs.trivy-fs-ref }}
           trivy-config: ${{ inputs.trivy-fs-config }}
       - name: Set Zap target env for Github Zap Action to Juju Unit IP Address
@@ -311,10 +311,10 @@ jobs:
         if: ${{ inputs.zap-enabled }}
         uses: zaproxy/action-baseline@v0.8.2
         env:
-          ZAP_AUTH_HEADER:  ${{ inputs.zap-auth-header }}
-          ZAP_AUTH_HEADER_VALUE:  ${{ inputs.zap-auth-header-value  }}
+          ZAP_AUTH_HEADER: ${{ inputs.zap-auth-header }}
+          ZAP_AUTH_HEADER_VALUE: ${{ inputs.zap-auth-header-value  }}
         with:
-          issue_title: 'OWASP ZAP report'
+          issue_title: "OWASP ZAP report"
           fail_action: false
           target: ${{ inputs.zap-target-protocol }}://${{ env.ZAP_TARGET }}:${{ inputs.zap-target-port }}/
           cmd_options: ${{ inputs.zap-cmd-options }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -247,12 +247,12 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'microk8s' }}
         run: |
-          tox -e integration -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }}
+          tox -e integration -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
       - name: Run lxd integration tests
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'lxd' }}
         run: |
-          tox -e integration -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }}
+          tox -e integration -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
       - name: Tmate debugging session
         if: ${{ failure() && inputs.tmate-debug }}
         uses: mxschmitt/action-tmate@v3

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following secrets are available for this workflow:
 
 | Name | Description |
 |--------------------|-------------------|
-| INTERGRATION_TEST_ARGS | Additional arguments to pass to the integration test execution that contains secrets |
+| INTERGRATION_TEST_ARGS | Additional arguments to pass to the integration test execution that contain secrets |
 
 When running the integration tests, the following posargs will be automatically passed to the `integration` target:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ The following workflows are available:
 
 * test: executes the default tox targets defined in the `tox.ini` file and generates a plain text report. This requires the `lint`, `unit`, `static` and `coverage-report` `tox` environments to be included in the tox defaults. The following parameters are available for this workflow:
 
-
 | Name | Type | Default | Description |
 |--------------------|----------|--------------------|-------------------|
 | working-directory | string | "./" | Directory where jobs should be executed |
@@ -65,22 +64,32 @@ More information about OWASP ZAP testing can be found [here](OWASPZAP.md).
 
 More information about Trivy testing can be found [here](TRIVY.MD).
 
+The following secrets are available for this workflow:
+
+| Name | Description |
+|--------------------|-------------------|
+| INTERGRATION_TEST_ARGS | Additional arguments to pass to the integration test execution that contains secrets |
+
 When running the integration tests, the following posargs will be automatically passed to the `integration` target:
-- --charm-file [charm_file_name]: The name of the charm artifact generated prior to the integration tests run
-- --series [series]: As defined in the `series` configuration described option above
-- -k [module]: As defined in the `modules` configuration option described above
-- --keep-models
-- --model testing: Only for tests running on a microk8s substrate
-- One parameter per resource defined in the `metadata.yaml` of the charm, containing a reference to the built image
+
+* --charm-file [charm_file_name]: The name of the charm artifact generated prior to the integration tests run
+* --series [series]: As defined in the `series` configuration described option above
+* -k [module]: As defined in the `modules` configuration option described above
+* --keep-models
+* --model testing: Only for tests running on a microk8s substrate
+* One parameter per resource defined in the `metadata.yaml` of the charm, containing a reference to the built image
 
 For instance, for pytest you can leverage this by adding a conftest.py file
-```
+
+```python
 def pytest_addoption(parser):
     """Add test arguments."""
     parser.addoption("--charm-file", action="store")
 ```
+
 and then use the argument value
-```
+
+```python
 charm = pytestconfig.getoption("--charm-file")
 ```
 


### PR DESCRIPTION
There is no way to pass secrets to the tox integration test runs.
This PR enables using a secret named `INTEGRATION_TEST_ARGS` as extra arguments. 
