### PR TITLE
Change the --charm-file option format in integration tests

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -223,7 +223,7 @@ jobs:
             args="${args} --$(echo $image | awk -F '/' '{print $NF}' | cut -d ':' -f 1)-image ${image}"
           done
           if [ ! -z ${{ inputs.charm-file }} ]; then
-            args="${args} --charm-file ${{ inputs.charm-file }}"
+            args="${args} --charm-file=${{ inputs.charm-file }}"
           fi
           echo "ARGS=$args" >> $GITHUB_ENV
           series=""

--- a/tests/workflows/integration/test-rock/metadata.yaml
+++ b/tests/workflows/integration/test-rock/metadata.yaml
@@ -5,10 +5,10 @@ name: integration-test-charm-1
 display-name: Some Charm
 summary: A simple charm for testing 
 description: A simple charm for testing.
-docs: ""
+docs: "http://example.com"
 maintainers: [""]
-issues: ""
-source: ""
+issues: "http://example.com"
+source: "http://example.com"
 charmhub:
   api-url: https://api.staging.charmhub.io
   storage-url: https://storage.staging.snapcraftcontent.com

--- a/tests/workflows/integration/test-upload-charm/metadata.yaml
+++ b/tests/workflows/integration/test-upload-charm/metadata.yaml
@@ -5,10 +5,10 @@ name: test-upload
 display-name: Test Upload Charm
 summary: A simple charm for testing charm uploads.
 description: A simple charm for testing charm uploads.
-docs: ""
+docs: "https://example.com"
 maintainers: [""]
-issues: ""
-source: ""
+issues: "https://example.com"
+source: "https://example.com"
 charmhub:
   api-url: https://api.staging.charmhub.io
   storage-url: https://storage.staging.snapcraftcontent.com


### PR DESCRIPTION
Under certain circumstances, pytest may incorrectly interpret the value of the `--charm-file` option as the positional argument `[file_or_dir]` of the pytest command line arguments. This error results in the pytest test root directory shifting from `./tests` to `.`. To prevent this issue, modify the format of the `--charm-file` option.