### PR TITLE
switch to use stable version of

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+Applicable spec: <link>
+
+### Overview
+
+<!-- A high level overview of the change -->
+
+### Rationale
+
+<!-- The reason the change is needed -->
+
+### Juju Events Changes
+
+<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
+
+### Module Changes
+
+<!-- Any high level changes to modules and why (Service, Observer, helper) -->
+
+### Library Changes
+
+<!-- Any changes to charm libraries -->
+
+### Checklist
+
+- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
+- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
+- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
+- [ ] The documentation is generated using `src-docs`
+- [ ] The documentation for charmhub is updated.
+- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
+
+<!-- Explanation for any unchecked items above -->

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -65,7 +65,7 @@ jobs:
         run: echo "docs_exist=$([[ -d docs ]] && echo 'True' || echo 'False')" >> $GITHUB_OUTPUT
       - name: Publish documentation
         if: steps.docs-exist.outputs.docs_exist == 'True'
-        uses: canonical/upload-charm-docs@main
+        uses: canonical/upload-charm-docs@stable
         with:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
@@ -83,7 +83,7 @@ jobs:
         run: echo "docs_exist=$([[ -d docs ]] && echo 'True' || echo 'False')" >> $GITHUB_OUTPUT
       - name: Publish documentation
         if: steps.docs-exist.outputs.docs_exist == 'True'
-        uses: canonical/upload-charm-docs@main
+        uses: canonical/upload-charm-docs@stable
         id: publishDocumentation
         with:
           discourse_host: discourse.charmhub.io

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -48,7 +48,7 @@ jobs:
         run: echo "docs_exist=$([[ -d docs ]] && echo 'True' || echo 'False')" >> $GITHUB_OUTPUT
       - name: Publish documentation
         if: steps.docs-exist.outputs.docs_exist == 'True'
-        uses: canonical/upload-charm-docs@main
+        uses: canonical/upload-charm-docs@stable
         with:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -304,7 +304,7 @@ jobs:
         run: echo "docs_exist=$([[ -d docs ]] && echo 'True' || echo 'False')" >> $GITHUB_OUTPUT
       - name: Publish documentation
         if: ${{ steps.docs-exist.outputs.docs_exist == 'True' && !github.event.pull_request.head.repo.fork }}
-        uses: canonical/upload-charm-docs@main
+        uses: canonical/upload-charm-docs@stable
         with:
           discourse_host: discourse.charmhub.io
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Changes the use of `upload-charm-docs` to use the `stable` branch instead of `main` which should be treated as `edge`. 

### Rationale

This will make the use of `upload-charm-docs` more predictable.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

This is not a charm so not all the items are applicable