### PR TITLE
Setup LXD regardless of cache hits

### DIFF
--- a/.github/workflows/workflow_charmcraft_cache_test.yaml
+++ b/.github/workflows/workflow_charmcraft_cache_test.yaml
@@ -103,7 +103,6 @@ jobs:
           key: ${{ env.CHARMCRAFT_CACHE_KEY }}
           restore-keys: ${{ env.CHARMCRAFT_CACHE_ALT_KEYS }}
       - name: Setup lxd
-        if: steps.charmcraft-cache.outputs.cache-hit == 'true'
         run: |
           sudo groupadd --force --system lxd
           sudo usermod --append --groups lxd runner


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Setup LXD regardless of cache hits

### Rationale

When there's a cache miss, LXD is not setup and the charm can't be built. See https://github.com/canonical/operator-workflows/actions/runs/6034861139/job/16374274332?pr=185

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

