### PR TITLE
Only upload images declared in metadata.yaml in the publish workflow

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -174,12 +174,25 @@ jobs:
         env:
           CHARMCRAFT_AUTH:  ${{ secrets.CHARMHUB_TOKEN }}
         run: |
-          charmName=$(yq -e '.name' metadata.yaml)
-          for image in $(cat ${{ env.CHARM_NAME }}-images)
-          do
+          charm=$(yq -e '.name' metadata.yaml)
+          declare -a resources
+          declare -a images
+
+          for resource in $(yq -er '.resources | with_entries(select(.value.type=="oci-image")) | keys | join(" ")' metadata.yaml); do
+            resources+=("$resource")
+          done
+
+          for image in $(cat ${{ env.CHARM_NAME }}-images); do
+            images+=("$image")
+          done
+          
+          for image in "${images[@]}"; do
             docker pull $image
-            imageId=$(docker images $image --format "{{.ID}}")
-            charmcraft upload-resource $charmName $(echo $image | awk -F '/' '{print $NF}' | cut -d ':' -f 1)-image --image=$imageId --verbosity=brief
+            image_id=$(docker images $image --format "{{.ID}}")
+            resource=$(echo $image | awk -F '/' '{print $NF}' | cut -d ':' -f 1)-image
+            if [[ " ${resources[@]} " =~ " $resource " ]]; then
+              charmcraft upload-resource $charm $resource --image=$image_id --verbosity=brief
+            fi
           done
   publish-charm:
     name: Publish charm to ${{ inputs.channel }}

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -169,7 +169,6 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         with:
           name: ${{ env.CHARM_NAME }}-images
-          path: ${{ inputs.working-directory }}
       - name: Publish image
         env:
           CHARMCRAFT_AUTH:  ${{ secrets.CHARMHUB_TOKEN }}
@@ -187,10 +186,10 @@ jobs:
           done
           
           for image in "${images[@]}"; do
-            docker pull $image
-            image_id=$(docker images $image --format "{{.ID}}")
             resource=$(echo $image | awk -F '/' '{print $NF}' | cut -d ':' -f 1)-image
             if [[ " ${resources[@]} " =~ " $resource " ]]; then
+              docker pull $image
+              image_id=$(docker images $image --format "{{.ID}}")
               charmcraft upload-resource $charm $resource --image=$image_id --verbosity=brief
             fi
           done


### PR DESCRIPTION
### Overview

The current publish workflow uploads all images from the integration workflow to charmhub. This isn't suitable when charms use some images solely for integration testing.

### Workflow Changes

Modify the publish workflow to upload only the image resources specified in the `metadata.yaml`.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
