### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The following secrets are available for this workflow:
 
 | Name | Description |
 |--------------------|-------------------|
-| INTERGRATION_TEST_ARGS | Additional arguments to pass to the integration test execution that contain secrets |
+| INTEGRATION_TEST_ARGS | Additional arguments to pass to the integration test execution that contain secrets |
 
 When running the integration tests, the following posargs will be automatically passed to the `integration` target:
 


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Fix a typo in the readme

### Rationale

N/A

### Workflow Changes

N/A

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
