### PR TITLE
Exclude additional files from license checks

### DIFF
--- a/.github/files/.licenserc.yaml
+++ b/.github/files/.licenserc.yaml
@@ -40,6 +40,7 @@ header:
       - 'CODEOWNERS'
       - 'icon.svg'
       - 'LICENSE'
+      - 'pyproject.toml'
       - 'trivy.yaml'
       - 'zap_rules.tsv'
       - 'lib/**'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -25,6 +25,4 @@ header:
     - '**/icon.svg'
     - '**/LICENSE'
     - '**/trivy.yaml'
-    - 'pyproject.toml'
-    - 'zap_rules.tsv'
   comment: on-failure


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Fix license scanning configuration

### Rationale

Follow up https://github.com/canonical/operator-workflows/pull/193

### Workflow Changes

N/A

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
