### PR TITLE
add argument to pick the microk8s channel

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -72,6 +72,10 @@ on:
         description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: 2.9/stable
+      microk8s-channel:
+        description: Actions operator microk8s channel as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: latest/stable
       load-test-enabled:
         type: boolean
         description: Whether load testing is enabled
@@ -310,6 +314,7 @@ jobs:
       extra-test-matrix: ${{ inputs.extra-test-matrix }}
       images: ${{ needs.all-images.outputs.images }}
       juju-channel: ${{ inputs.juju-channel }}
+      microk8s-channel: ${{ inputs.microk8s-channel }}
       load-test-enabled: ${{ inputs.load-test-enabled }}
       load-test-run-args: ${{ inputs.load-test-run-args }}
       modules: ${{ inputs.modules }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -74,6 +74,10 @@ on:
         description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: 2.9/stable
+      microk8s-channel:
+        description: Actions operator microk8s channel as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: latest/stable
       load-test-enabled:
         type: boolean
         description: Whether load testing is enabled
@@ -199,6 +203,7 @@ jobs:
           microk8s-addons: ${{ inputs.microk8s-addons }}
           channel: ${{ inputs.channel }}
           juju-channel: ${{ inputs.juju-channel }}
+          channel: ${{ inputs.microk8s-channel }}
       - name: Configure GHCR in microk8s
         if: ${{ inputs.provider == 'microk8s' }}
         run: |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The following workflows are available:
 | extra-test-matrix | string | '{}' | Additional test matrices to run the integration test combinations |
 | image-build-args | string | "" | List of build args to pass to the build image job |
 | juju-channel | string | 2.9/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| microk8s-channel | string | latest/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | load-test-enabled | bool | false | Whether load testing is enabled. If enabled, k6 will expect a load_tests/load-test.js file with the tests to run. |
 | load-test-run-args | string | "" | Command line arguments for the load test execution. |
 | modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Adds a new argument to be able to pick the microk8s channel

### Rationale

For juju 3.1 and above, a microk8s in strict confinement is required which is not installed by default.

### Workflow Changes

Adds a new argument to be able to pick the microk8s channel

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
