### PR TITLE
Add inputs for unit test for selection the self-hosted runner

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,21 +27,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  runs-on-labels:
-    runs-on: ['self-hosted', 'small']
-    outputs:
-      labels: ${{ steps.labels.outputs.LABELS }}
-    steps:
-      - id: labels
-        run: |
-          if ${{ inputs.self-hosted-runner }}; then
-            echo "LABELS=['self-hosted', '${{ inputs.self-hosted-runner-label }}']" >> "$GITHUB_OUTPUT"
-          else
-            echo "LABELS=['ubuntu-22.04']" >> "$GITHUB_OUTPUT"
-          fi
   inclusive-naming-check:
     name: Inclusive naming
-    needs: runs-on-labels
     runs-on: >-
       ${{
         inputs.self-hosted-runner &&
@@ -91,8 +78,12 @@ jobs:
     uses: ./.github/workflows/get_runner_image.yaml
   shellcheck-lint:
     name: Shell scripts lint
-    needs: runs-on-labels
-    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
+    runs-on: >-
+      ${{
+        inputs.self-hosted-runner &&
+        fromJson(format('[''self-hosted'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
+        'ubuntu-22.04'
+      }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -156,8 +147,12 @@ jobs:
         run: shellcheck -f gcc ${{steps.gather.outputs.filepaths}}
   docker-lint:
     name: Dockerfile lint
-    needs: runs-on-labels
-    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
+    runs-on: >-
+      ${{
+        inputs.self-hosted-runner &&
+        fromJson(format('[''self-hosted'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
+        'ubuntu-22.04'
+      }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -174,8 +169,12 @@ jobs:
           dockerfile: "${{ steps.dockerfiles.outputs.found }}"
   metadata-lint:
     name: Lint metadata.yaml
-    needs: runs-on-labels
-    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
+    runs-on: >-
+      ${{
+        inputs.self-hosted-runner &&
+        fromJson(format('[''self-hosted'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
+        'ubuntu-22.04'
+      }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -193,10 +192,13 @@ jobs:
           check-jsonschema metadata.yaml --schemafile metadata.schema
   lint-and-unit-test:
     name: Lint and unit tests
-    needs: 
-      - runs-on-labels
-      - get-runner-image
-    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
+    needs: get-runner-image
+    runs-on: >-
+      ${{
+        inputs.self-hosted-runner &&
+        fromJson(format('[''self-hosted'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
+        'ubuntu-22.04'
+      }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -320,8 +322,12 @@ jobs:
           path: report.json
   draft-publish-docs:
     name: Draft publish docs
-    needs: runs-on-labels
-    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
+    runs-on: >-
+      ${{
+        inputs.self-hosted-runner &&
+        fromJson(format('[''self-hosted'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
+        'ubuntu-22.04'
+      }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -341,8 +347,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
   license-headers-check:
     name: Check license headers
-    needs: runs-on-labels
-    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
+    runs-on: >-
+      ${{
+        inputs.self-hosted-runner &&
+        fromJson(format('[''self-hosted'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
+        'ubuntu-22.04'
+      }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -361,8 +371,12 @@ jobs:
           config: .licenserc.yaml
   lib-check:
     name: Check libraries
-    needs: runs-on-labels
-    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
+    runs-on: >-
+      ${{
+        inputs.self-hosted-runner &&
+        fromJson(format('[''self-hosted'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
+        'ubuntu-22.04'
+      }}
     steps:
       - uses: actions/checkout@v4.0.0
       - name: Check libs
@@ -374,7 +388,6 @@ jobs:
   required_status_checks:
     name: Required Test Status Checks
     needs:
-      - runs-on-labels
       - draft-publish-docs
       - docker-lint
       - inclusive-naming-check
@@ -383,7 +396,12 @@ jobs:
       - metadata-lint
       - shellcheck-lint
       - license-headers-check
-    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
+    runs-on: >-
+      ${{
+        inputs.self-hosted-runner &&
+        fromJson(format('[''self-hosted'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
+        'ubuntu-22.04'
+      }}
     if: always() && !cancelled()
     timeout-minutes: 5
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   inclusive-naming-check:
     name: Inclusive naming
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -73,7 +73,7 @@ jobs:
     uses: ./.github/workflows/get_runner_image.yaml
   shellcheck-lint:
     name: Shell scripts lint
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -137,7 +137,7 @@ jobs:
         run: shellcheck -f gcc ${{steps.gather.outputs.filepaths}}
   docker-lint:
     name: Dockerfile lint
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -154,7 +154,7 @@ jobs:
           dockerfile: "${{ steps.dockerfiles.outputs.found }}"
   metadata-lint:
     name: Lint metadata.yaml
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -172,7 +172,7 @@ jobs:
           check-jsonschema metadata.yaml --schemafile metadata.schema
   lint-and-unit-test:
     name: Lint and unit tests
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
     needs: get-runner-image
     defaults:
       run:
@@ -297,7 +297,7 @@ jobs:
           path: report.json
   draft-publish-docs:
     name: Draft publish docs
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -317,7 +317,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
   license-headers-check:
     name: Check license headers
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -336,7 +336,7 @@ jobs:
           config: .licenserc.yaml
   lib-check:
     name: Check libraries
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v4.0.0
       - name: Check libs
@@ -347,7 +347,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   required_status_checks:
     name: Required Test Status Checks
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
     needs:
       - draft-publish-docs
       - docker-lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,10 @@ on:
         type: boolean
         description: Whether to use self-hosted runners to run the jobs.
         default: true
+      self-hosted-runner-label:
+        type: string
+        description: Label for selecting the self-hosted runners.
+        default: "large"
       pre-run-script:
         description: Path to the bash script to be run before the integration tests
         type: string
@@ -25,7 +29,7 @@ concurrency:
 jobs:
   inclusive-naming-check:
     name: Inclusive naming
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -69,7 +73,7 @@ jobs:
     uses: ./.github/workflows/get_runner_image.yaml
   shellcheck-lint:
     name: Shell scripts lint
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -133,7 +137,7 @@ jobs:
         run: shellcheck -f gcc ${{steps.gather.outputs.filepaths}}
   docker-lint:
     name: Dockerfile lint
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -150,7 +154,7 @@ jobs:
           dockerfile: "${{ steps.dockerfiles.outputs.found }}"
   metadata-lint:
     name: Lint metadata.yaml
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -168,7 +172,7 @@ jobs:
           check-jsonschema metadata.yaml --schemafile metadata.schema
   lint-and-unit-test:
     name: Lint and unit tests
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
     needs: get-runner-image
     defaults:
       run:
@@ -293,7 +297,7 @@ jobs:
           path: report.json
   draft-publish-docs:
     name: Draft publish docs
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -313,7 +317,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
   license-headers-check:
     name: Check license headers
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -332,7 +336,7 @@ jobs:
           config: .licenserc.yaml
   lib-check:
     name: Check libraries
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v4.0.0
       - name: Check libs
@@ -343,7 +347,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   required_status_checks:
     name: Required Test Status Checks
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', ''large'']') || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', 'inputs.self-hosted-runner-label']') || 'ubuntu-22.04' }}
     needs:
       - draft-publish-docs
       - docker-lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,9 +27,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  runs-on-labels:
+    runs-on: ['self-hosted', 'small']
+    outputs:
+      labels: ${{ steps.labels.outputs.LABELS }}
+    steps:
+      - id: labels
+        run: |
+          if ${{ inputs.self-hosted-runner }}; then
+            echo "LABELS=['self-hosted', '${{ inputs.self-hosted-runner-label }}']" >> "$GITHUB_OUTPUT"
+          else
+            echo "LABELS=ubuntu-22.04" >> "$GITHUB_OUTPUT"
+          fi
   inclusive-naming-check:
     name: Inclusive naming
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
+    needs: runs-on-labels
+    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -73,7 +86,8 @@ jobs:
     uses: ./.github/workflows/get_runner_image.yaml
   shellcheck-lint:
     name: Shell scripts lint
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
+    needs: runs-on-labels
+    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -137,7 +151,8 @@ jobs:
         run: shellcheck -f gcc ${{steps.gather.outputs.filepaths}}
   docker-lint:
     name: Dockerfile lint
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
+    needs: runs-on-labels
+    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -154,7 +169,8 @@ jobs:
           dockerfile: "${{ steps.dockerfiles.outputs.found }}"
   metadata-lint:
     name: Lint metadata.yaml
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
+    needs: runs-on-labels
+    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -172,8 +188,10 @@ jobs:
           check-jsonschema metadata.yaml --schemafile metadata.schema
   lint-and-unit-test:
     name: Lint and unit tests
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
-    needs: get-runner-image
+    needs: 
+      - runs-on-labels
+      - get-runner-image
+    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -297,7 +315,8 @@ jobs:
           path: report.json
   draft-publish-docs:
     name: Draft publish docs
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
+    needs: runs-on-labels
+    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -317,7 +336,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
   license-headers-check:
     name: Check license headers
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
+    needs: runs-on-labels
+    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -336,7 +356,8 @@ jobs:
           config: .licenserc.yaml
   lib-check:
     name: Check libraries
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
+    needs: runs-on-labels
+    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
     steps:
       - uses: actions/checkout@v4.0.0
       - name: Check libs
@@ -347,8 +368,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   required_status_checks:
     name: Required Test Status Checks
-    runs-on: ${{ inputs.self-hosted-runner && fromJson('[''self-hosted'', inputs.self-hosted-runner-label]') || 'ubuntu-22.04' }}
     needs:
+      - runs-on-labels
       - draft-publish-docs
       - docker-lint
       - inclusive-naming-check
@@ -357,6 +378,7 @@ jobs:
       - metadata-lint
       - shellcheck-lint
       - license-headers-check
+    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
     if: always() && !cancelled()
     timeout-minutes: 5
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,7 @@ jobs:
   inclusive-naming-check:
     name: Inclusive naming
     needs: runs-on-labels
-    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
+    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -87,7 +87,7 @@ jobs:
   shellcheck-lint:
     name: Shell scripts lint
     needs: runs-on-labels
-    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
+    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -152,7 +152,7 @@ jobs:
   docker-lint:
     name: Dockerfile lint
     needs: runs-on-labels
-    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
+    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -170,7 +170,7 @@ jobs:
   metadata-lint:
     name: Lint metadata.yaml
     needs: runs-on-labels
-    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
+    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -191,7 +191,7 @@ jobs:
     needs: 
       - runs-on-labels
       - get-runner-image
-    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
+    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -316,7 +316,7 @@ jobs:
   draft-publish-docs:
     name: Draft publish docs
     needs: runs-on-labels
-    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
+    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -337,7 +337,7 @@ jobs:
   license-headers-check:
     name: Check license headers
     needs: runs-on-labels
-    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
+    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -357,7 +357,7 @@ jobs:
   lib-check:
     name: Check libraries
     needs: runs-on-labels
-    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
+    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
     steps:
       - uses: actions/checkout@v4.0.0
       - name: Check libs
@@ -378,7 +378,7 @@ jobs:
       - metadata-lint
       - shellcheck-lint
       - license-headers-check
-    runs-on: ${{ needs.runs-on-labels.outputs.labels }}
+    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
     if: always() && !cancelled()
     timeout-minutes: 5
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,12 @@ jobs:
   inclusive-naming-check:
     name: Inclusive naming
     needs: runs-on-labels
-    runs-on: ${{ fromJson(needs.runs-on-labels.outputs.labels) }}
+    runs-on: >-
+      ${{
+        inputs.self-hosted-runner &&
+        fromJson(format('[''self-hosted'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
+        'ubuntu-22.04'
+      }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
           if ${{ inputs.self-hosted-runner }}; then
             echo "LABELS=['self-hosted', '${{ inputs.self-hosted-runner-label }}']" >> "$GITHUB_OUTPUT"
           else
-            echo "LABELS=ubuntu-22.04" >> "$GITHUB_OUTPUT"
+            echo "LABELS=['ubuntu-22.04']" >> "$GITHUB_OUTPUT"
           fi
   inclusive-naming-check:
     name: Inclusive naming

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -19,6 +19,7 @@ jobs:
     with:
       working-directory: "tests/workflows/integration/test-upload-charm/"
       self-hosted-runner: true
+      self-hosted-runner-label: "edge"
   integration:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following workflows are available:
 |--------------------|----------|--------------------|-------------------|
 | working-directory | string | "./" | Directory where jobs should be executed |
 | self-hosted-runner | bool | true | Whether self-hosted-runner should be enabled |
+| self-hosted-runner-label| string | large | Label used to select the self-hosted runner if enabled |
 | pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
 
 * comment: Posts the content of the artifact specified as a comment in a PR. It needs to be triggered from a PR triggered workflow.


### PR DESCRIPTION
Applicable spec: NA

### Overview

Add input to unit test workflow for selecting self-hosted runners by label.

### Rationale

Needed for using different version of self-hosted runners.

### Workflow Changes

One new input for unit test workflow added.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)