### PR TITLE
Add support for specifying tox environment name for integration test

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -103,10 +103,10 @@ on:
         description: Use setup-devstack-swift action to prepare a swift server for testing.
         type: boolean
         default: false
-      test-env-name-postfix:
-        description: Postfix to the tox environment name for the integration test. The tox environment name used must begins with "integration" and this input will be append at the end.
+      test-tox-env:
+        description: The tox environment name for the integration test.
         type: string
-        default: ""
+        default: "integration"
       tmate-debug:
         description: Use tmate debugging session on integration test failure.
         type: boolean
@@ -325,7 +325,7 @@ jobs:
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       series: ${{ inputs.series }}
       setup-devstack-swift: ${{ inputs.setup-devstack-swift }}
-      test-env-name-postfix: $${{ inputs.test-env-name-postfix }}
+      test-tox-env: $${{ inputs.test-tox-env }}
       tmate-debug: ${{ inputs.tmate-debug }}
       tmate-timeout: ${{ inputs.tmate-timeout }}
       trivy-fs-config: ${{ inputs.trivy-fs-config }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -325,7 +325,7 @@ jobs:
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       series: ${{ inputs.series }}
       setup-devstack-swift: ${{ inputs.setup-devstack-swift }}
-      test-tox-env: $${{ inputs.test-tox-env }}
+      test-tox-env: ${{ inputs.test-tox-env }}
       tmate-debug: ${{ inputs.tmate-debug }}
       tmate-timeout: ${{ inputs.tmate-timeout }}
       trivy-fs-config: ${{ inputs.trivy-fs-config }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -103,6 +103,10 @@ on:
         description: Use setup-devstack-swift action to prepare a swift server for testing.
         type: boolean
         default: false
+      test-env-name-postfix:
+        description: Postfix to the tox environment name for the integration test. The tox environment name used must begins with "integration" and this input will be append at the end.
+        type: string
+        default: ""
       tmate-debug:
         description: Use tmate debugging session on integration test failure.
         type: boolean
@@ -321,6 +325,7 @@ jobs:
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       series: ${{ inputs.series }}
       setup-devstack-swift: ${{ inputs.setup-devstack-swift }}
+      test-env-name-postfix: $${{ inputs.test-env-name-postfix }}
       tmate-debug: ${{ inputs.tmate-debug }}
       tmate-timeout: ${{ inputs.tmate-timeout }}
       trivy-fs-config: ${{ inputs.trivy-fs-config }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -117,6 +117,10 @@ on:
         description: Use setup-devstack-swift action to prepare a swift server for testing.
         type: boolean
         default: false
+      test-env-name-postfix:
+        description: Postfix to the tox environment name for the integration test. The tox environment name used must begins with "integration" and this input will be append at the end.
+        type: string
+        default: ""
       tmate-debug:
         description: Use tmate debugging session on integration test failure.
         type: boolean
@@ -247,12 +251,12 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'microk8s' }}
         run: |
-          tox -e integration -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
+          tox -e integration${{ inputs.test-env-name-postfix }} -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
       - name: Run lxd integration tests
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'lxd' }}
         run: |
-          tox -e integration -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
+          tox -e integration${{ inputs.test-env-name-postfix }} -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
       - name: Tmate debugging session
         if: ${{ failure() && inputs.tmate-debug }}
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -117,10 +117,10 @@ on:
         description: Use setup-devstack-swift action to prepare a swift server for testing.
         type: boolean
         default: false
-      test-env-name-postfix:
-        description: Postfix to the tox environment name for the integration test. The tox environment name used must begins with "integration" and this input will be append at the end.
+      test-tox-env:
+        description: The tox environment name for the integration test.
         type: string
-        default: ""
+        default: "integration"
       tmate-debug:
         description: Use tmate debugging session on integration test failure.
         type: boolean
@@ -251,12 +251,12 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'microk8s' }}
         run: |
-          tox -e integration${{ inputs.test-env-name-postfix }} -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
+          tox -e ${{ inputs.test-tox-env }} -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
       - name: Run lxd integration tests
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'lxd' }}
         run: |
-          tox -e integration${{ inputs.test-env-name-postfix }} -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
+          tox -e ${{ inputs.test-tox-env }} -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
       - name: Tmate debugging session
         if: ${{ failure() && inputs.tmate-debug }}
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -35,6 +35,7 @@ jobs:
       working-directory: "tests/workflows/integration/test-upload-charm/"
       trivy-image-config: "tests/workflows/integration/test-upload-charm/trivy.yaml"
       juju-channel: 3.1/stable
+      provider: lxd
       test-tox-env: "integration-juju3.1"
   integration-rock:
     uses: ./.github/workflows/integration_test.yaml

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -33,7 +33,7 @@ jobs:
       working-directory: "tests/workflows/integration/test-upload-charm/"
       trivy-image-config: "tests/workflows/integration/test-upload-charm/trivy.yaml"
       juju-channel: 3.1/stable
-      test-env-name-postfix: "-juju3.1"
+      test-tox-env: "integration-juju3.1"
   integration-rock:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -57,12 +57,16 @@ jobs:
     timeout-minutes: 5
     needs:
       - simple
+      - simple-self-hosted
       - integration
+      - integration-juju3
       - integration-rock
       - publish
     steps:
       - run: |
           [ '${{ needs.simple.result }}' = 'success' ] || (echo simple failed && false)
+          [ '${{ needs.simple-self-hosted.result }}' = 'success' ] || (echo simple-self-hosted failed && false)
           [ '${{ needs.integration.result }}' = 'success' ] || (echo integration failed && false)
+          [ '${{ needs.integration-juju3.result }}' = 'success' ] || (echo integration-juju3 failed && false)
           [ '${{ needs.integration-rock.result }}' = 'success' ] || (echo integration-rock failed && false)
           [ '${{ needs.publish.result }}' != 'failure' ] || (echo publish failed && false)

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -26,6 +26,14 @@ jobs:
     with:
       working-directory: "tests/workflows/integration/test-upload-charm/"
       trivy-image-config: "tests/workflows/integration/test-upload-charm/trivy.yaml"
+  integration-juju3:
+    uses: ./.github/workflows/integration_test.yaml
+    secrets: inherit
+    with:
+      working-directory: "tests/workflows/integration/test-upload-charm/"
+      trivy-image-config: "tests/workflows/integration/test-upload-charm/trivy.yaml"
+      juju-channel: 3.1/stable
+      test-env-name-postfix: "-juju3.1"
   integration-rock:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -29,6 +29,8 @@ jobs:
   integration-juju3:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit
+    needs:
+      - integration
     with:
       working-directory: "tests/workflows/integration/test-upload-charm/"
       trivy-image-config: "tests/workflows/integration/test-upload-charm/trivy.yaml"
@@ -38,7 +40,7 @@ jobs:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit
     needs:
-      - integration
+      - integration-juju3
     with:
       working-directory: "tests/workflows/integration/test-rock/"
       trivy-image-config: "tests/workflows/integration/test-rock/trivy.yaml"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following workflows are available:
 
 * comment: Posts the content of the artifact specified as a comment in a PR. It needs to be triggered from a PR triggered workflow.
 
-* integration_test: Builds the existing Dockerfiles, if any, and executes the `integration` test target defined in the `tox.ini` file. This workflow also supports running addtional load and chaos tests. The following parameters are available for this workflow:
+* integration_test: Builds the existing Dockerfiles, if any, and executes the `integration` test target defined in the `tox.ini` file. The tox environment used can be changed with the `test-tox-env` input. This workflow also supports running addtional load and chaos tests. The following parameters are available for this workflow:
 
 | Name | Type | Default | Description |
 |--------------------|----------|--------------------|-------------------|
@@ -45,6 +45,7 @@ The following workflows are available:
 | microk8s-addons | string | "dns ingress rbac storage" | Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled. |
 | series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
 | setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for testing. |
+| test-tox-env | string| "integration" | The tox environment name for the integration test. |
 | tmate-debug | bool | false | Enable tmate debugging after integration test failure. |
 | tmate-timeout | number | 30 | Timeout in minutes to keep tmate debugging session. |
 | trivy-fs-config | string | "" | Trivy YAML configuration for fs type |

--- a/tests/workflows/integration/test-upload-charm/tox.ini
+++ b/tests/workflows/integration/test-upload-charm/tox.ini
@@ -111,3 +111,14 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+
+[testenv:integration-juju3.1]
+description = Run integration tests
+deps =
+    juju==3.1.2.0
+    pytest
+    pytest-operator
+    pytest-asyncio
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
### Overview

Allow the tox environment executed for integration test to be specified via input.

### Rationale

Charms, such as `github-runner`, needs to be tested on different juju version which requires different tox environment as the python jujulib needs to be different version for 2.9 and 3.x: https://github.com/canonical/github-runner-operator/blob/main/tox.ini

This change will enable `github-runner` to use the integration test workflow.

### Workflow Changes

Add input called `test_tox_env` for specifying the tox env name in `integration_test.yaml` and `integration_test_run.yaml`. The input defaults to "integration" for backward compatiablity.


### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
