### PR TITLE
Remove Android SDK to free up space in root

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -189,6 +189,8 @@ jobs:
     if: ${{ !failure() }}
     steps:
       - uses: actions/checkout@v4.1.0
+      - name: Remove Android SDK
+        run: sudo rm -rf /usr/local/lib/android
       - name: Setup Devstack Swift
         if: ${{ inputs.setup-devstack-swift }}
         id: setup-devstack-swift


### PR DESCRIPTION
### Overview

The GitHub hosted runners currently only have 18GB of free space in the root directory, which may be insufficient for some integration tests. Removing Android SDK to reclaim about 15GB in the root.

### Workflow Changes

None.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
