### PR TITLE
feat(ci): Add PR from template-files changes

### DIFF
--- a/.github/workflows/pr_from_template_files.yaml
+++ b/.github/workflows/pr_from_template_files.yaml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches:
+      - feature/template-files
+    paths:
+      # support managing renovate.json for now
+      - 'renovate.json'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  create-pr-from-template-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: pull-request
+        run: |
+          gh pr create --title "Changes in template files" --body "Syncing changes on changed template files for the repo."
+
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr_from_template_files.yaml
+++ b/.github/workflows/pr_from_template_files.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 on:
   push:
     branches:


### PR DESCRIPTION
Applicable spec: n/a

### Overview

This change allows us to raise a PR whenever there is a change in feature/template-files, which is a branch managed by terraform. We are currently starting out with this, so for the time being only the central management of renovate.json is supported.

### Rationale

When terraform pushes changes to the branch, we want to have a PR to review and merge them (as opposed to terraform having the permissions to push the changes to main directly without a review). Hence there needs to be an action that triggers a PR.

### Workflow Changes

There are no changes, this step can be adopted across repos with including the file.
### Checklist

- [x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
