### PR TITLE
Proposal/Discussion: Add explicit write permission to build_rocks job

### DIFF
--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -79,6 +79,9 @@ jobs:
   build-rocks:
     name: Build rock
     runs-on: ${{ inputs.runs-on }}
+    permissions:
+      contents: read
+      packages: write
     needs: [get-rocks]
     if: ${{ needs.get-rocks.outputs.rock-paths != '[]' }}
     strategy:


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- To run the integration tests, ROCK images are built and published to the GitHub Container Registry.
- Package permissions are set to allow any action from the repository and specific team.
- This is not enough to allow external contributors to run the action and when they do the Integration test fails with "writing blob: initiating layer upload to /v2/canonical/synapse-nginx/blobs/uploads/ in ghcr.io: denied: installation not allowed to Write organization package" message.
- One way of fixing this, as suggested in MM by @cbartz , is to modify the default permissions granted to GITHUB_TOKEN in the specific job that needs it. Read more about it in "[Assigning permissions to jobs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)".
- So, the GITHUb_TOKEN for this job would have write permission to package, being able to upload images and then proceed with the integration test.

### Rationale

Make checks pass to PRs from external contributors.
Reference: https://github.com/canonical/synapse-operator/pull/69
<!-- The reason the change is needed -->

### Workflow Changes

No change in the workflow itself but changes the permission of the build_rocks job.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
