### PR TITLE
Get ROCK image right tag considering the latest merged rock files

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -90,19 +90,14 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         shell: bash  
         run: |
-          # Get commit info
-          TREE_SHA=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/commits/${GITHUB_SHA} \
-             --jq '.commit.tree.sha')
+          # Get workflow from this specific SHA
           RUN_ID=$(gh api \
             --method GET \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/actions/runs \
             -f path=.github/workflows/integration_test.yaml \
-            -f tree_id=$TREE_SHA \
+            -f head_sha=${GITHUB_SHA} \
             -f status=completed \
             -f event=pull_request \
             --jq  '[.workflow_runs[] | select(.path == ".github/workflows/integration_test.yaml")] | max_by(.updated_at) | .id')

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -90,17 +90,26 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         shell: bash  
         run: |
-          # Get workflow from this specific SHA
+          # Get commit info
+          TREE_SHA=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/commits/${GITHUB_SHA} \
+            --jq '.commit.tree.sha')
+          # Get workflow from this specific tree id
           RUN_ID=$(gh api \
             --method GET \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/actions/runs \
             -f path=.github/workflows/integration_test.yaml \
-            -f head_sha=${GITHUB_SHA} \
             -f status=completed \
             -f event=pull_request \
-            --jq  '[.workflow_runs[] | select(.path == ".github/workflows/integration_test.yaml")] | max_by(.updated_at) | .id')
+            --jq "[
+                    .workflow_runs[]
+                    | select(.path == \".github/workflows/integration_test.yaml\")
+                    | select(.head_commit.tree_id == \"$TREE_SHA\")
+                  ] | max_by(.updated_at) | .id")
           echo "RUN_ID=$RUN_ID" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

What happened in Synapse:

24 Nov: I submitted a WIP PR that changes the ROCK images https://github.com/canonical/synapse-operator/pull/111
27 Nov: Publish to Edge workflow sucessfully ran with merged changes (update jsonschema)
27 Nov: I refreshed Synapse charm in production to apply the fix regarding nginx pebble ready event (23 Nov) + this last one regarding jsonschema
For my huge surprise: Synapse image is running the latest Synapse version as was changed in the WIP PR

### Rationale

Make publish charm get the latest image from the latest merged PR and not the latest uploaded.

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
