### PR TITLE
Make unit testing multiple working directories concurrent

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ on:
         type: string
 
 concurrency:
-  group: operator-workflows-${{ github.workflow }}-tests-${{ github.ref }}-self-hosted-${{ inputs.self-hosted-runner }}
+  group: operator-workflows-${{ github.workflow }}-${{ inputs.working-directory }}-tests-${{ github.ref }}-self-hosted-${{ inputs.self-hosted-runner }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Applicable spec: [<link>](https://github.com/canonical/operator-workflows/issues/219)

### Overview

Running the tests workflow from a matrix fails because the concurrency group key isn't unique and all but one of the tests is cancelled:

### Rationale

I'd like to be able to run multiple unit tests in parallel from my repo like this:

```yaml
name: Tests

on:
  pull_request:

jobs:
  unit-tests:
    strategy:
      matrix:
        charm: ["foo", "bar"]
    uses: canonical/operator-workflows/.github/workflows/test.yaml@main
    secrets: inherit
    with:
      self-hosted-runner:  false
      working-directory:  ./${{ matrix.charm }}/
```

### Workflow Changes

extend the group key to differentiate by working-directory

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
