### PR TITLE
Pass the inputs related to self-hosted runners through

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -298,6 +298,8 @@ jobs:
       microk8s-addons: ${{ inputs.microk8s-addons }}
       registry: ghcr.io
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
+      self-hosted-runner: ${{ inputs.self-hosted-runner }}
+      self-hosted-runner-label: ${{ inputs.self-hosted-runner-label }}
       series: ${{ inputs.series }}
       setup-devstack-swift: ${{ inputs.setup-devstack-swift }}
       test-tox-env: ${{ inputs.test-tox-env }}


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Pass the inputs `self-hosted-runner` and `self-hosted-runner-label`  to `integration_test_run` workflow.

### Rationale

Avoid the integration test always using the defaults `self-hosted-runner=true` and `self-hosted-runner-label=large`.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
