### PR TITLE
Integration/multi charm artifacts

### DIFF
--- a/.github/workflows/build_charms.yaml
+++ b/.github/workflows/build_charms.yaml
@@ -30,16 +30,16 @@ jobs:
       - name: Find charm paths
         working-directory: ${{ inputs.working-directory }}
         run: |
-          echo "CHARM_PATHS=$(find . -name metadata.yaml 2> /dev/null |
+          echo "CHARM_PATHS=$(find * -type f -name metadata.yaml 2> /dev/null |
           sed 's:[^/]*$::' |
           jq -Rsc '. / "\n" - [""]')" >> $GITHUB_ENV
       - name: Extract charm names
         working-directory: ${{ inputs.working-directory }}
         run: |
           echo "CHARM_NAMES=$(for path in $(jq -cr '.[]' ); do
-            echo "{\"name\":\"$(yq '.name' $path/metadata.yaml)\", \"path\":\"$path\}"
+            echo {\"name\":\"$(yq '.name' $path/metadata.yaml)\", \"path\":\"$path\"}
           done <<< $CHARM_PATHS |
-          jq -Rsc '.')" >> $GITHUB_ENV
+          jq -sc '.')" >> $GITHUB_ENV
   build-charms:
     name: Build and push charms
     runs-on: ${{ inputs.runs-on }}
@@ -62,5 +62,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: charm-artifacts
-          path: ${{ inputs.working-directory }}/${{ matrix.path }}/${{ env.CHARM_FILE }}
+          path: ${{ inputs.working-directory }}/${{ matrix.path }}${{ env.CHARM_FILE }}
           if-no-files-found: error

--- a/.github/workflows/build_charms.yaml
+++ b/.github/workflows/build_charms.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Find charm paths
         working-directory: ${{ inputs.working-directory }}
         run: |
-          echo "CHARM_PATHS=$(find . -name metadata.yaml 2> /dev/null) |
+          echo "CHARM_PATHS=$(find . -name metadata.yaml 2> /dev/null |
           sed 's:[^/]*$::' |
           jq -Rsc '. / "\n" - [""]')" >> $GITHUB_ENV
       - name: Extract charm names

--- a/.github/workflows/build_charms.yaml
+++ b/.github/workflows/build_charms.yaml
@@ -1,0 +1,66 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: Build Charms
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        type: string
+        description: Image runner for building the images
+        default: ubuntu-22.04
+      working-directory:
+        type: string
+        description: The working directory for jobs
+        default: "./"
+    outputs:
+      charms:
+        description: List of charms built
+        value: ${{ jobs.get-charms.outputs.charms }}
+
+jobs:
+  get-charm-names:
+    name: Get charms
+    runs-on: ${{ inputs.runs-on }}
+    outputs:
+      charms: ${{ env.CHARM_NAMES }}
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Find charm paths
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          echo "CHARM_PATHS=$(find . -name metadata.yaml 2> /dev/null) |
+          sed 's:[^/]*$::' |
+          jq -Rsc '. / "\n" - [""]')" >> $GITHUB_ENV
+      - name: Extract charm names
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          echo "CHARM_NAMES=$(for path in $(jq -cr '.[]' ); do
+            echo "{\"name\":\"$(yq '.name' $path/metadata.yaml)\", \"path\":\"$path\}"
+          done <<< $CHARM_PATHS |
+          jq -Rsc '.')" >> $GITHUB_ENV
+  build-charms:
+    name: Build and push charms
+    runs-on: ${{ inputs.runs-on }}
+    needs: [get-charm-names]
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.get-charm-names.outputs.charms) }}
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - uses: canonical/setup-lxd@v0.1.1
+      - name: Pack charm
+        if: ${{ !cancelled() }}
+        working-directory: ${{ inputs.working-directory }}/${{ matrix.path }}
+        run: |
+          sudo snap install charmcraft --classic --channel latest/stable
+          charmcraft pack -v
+          echo "CHARM_FILE=$(ls ${{matrix.name}}_*.charm)" >> $GITHUB_ENV
+      - name: Upload charm artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: charm-artifacts
+          path: ${{ inputs.working-directory }}/${{ matrix.path }}/${{ env.CHARM_FILE }}
+          if-no-files-found: error

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -271,7 +271,7 @@ jobs:
     name: Build and push charms from subdirectories
     needs: [get-runner-image, build-charm]
     uses: ./.github/workflows/build_charms.yaml
-    if: ${{ always() && needs.build-charm.outputs.charm-file == 'UNKNOWN' && !cancelled() }}
+#    if: ${{ always() && needs.build-charm.outputs.charm-file == 'UNKNOWN' && !cancelled() }}
     with:
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -202,21 +202,19 @@ jobs:
       trivy-image-config: ${{ inputs.trivy-image-config }}
       working-directory: ${{ inputs.working-directory }}
       build-args: ${{ inputs.image-build-args }}
-  # build-rocks:
-  #   name: Build rock
-  #   uses: ./.github/workflows/build_rocks.yaml
-  #   needs: get-runner-image
-  #   with:
-  #     owner: ${{ github.repository_owner }}
-  #     registry: ghcr.io
-  #     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
-  #     trivy-image-config: ${{ inputs.trivy-image-config }}
-  #     working-directory: ${{ inputs.working-directory }}
+  build-rocks:
+    name: Build rock
+    uses: ./.github/workflows/build_rocks.yaml
+    needs: get-runner-image
+    with:
+      owner: ${{ github.repository_owner }}
+      registry: ghcr.io
+      runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
+      trivy-image-config: ${{ inputs.trivy-image-config }}
+      working-directory: ${{ inputs.working-directory }}
   all-images:
     name: Get rocks or Docker images
-    needs: 
-      - build-images
-  #    - build-rocks
+    needs: [build-images, build-rocks]
     runs-on: ubuntu-latest
     outputs:
       images: ${{ env.IMAGES }}
@@ -267,8 +265,8 @@ jobs:
           name: ${{ env.CHARM_NAME }}-images
           path: ${{ inputs.working-directory }}/${{ env.CHARM_NAME }}-images
           if-no-files-found: error
-  build-charms:
-    name: Build and push charms from subdirectories
+  build-multiple-charms:
+    name: Build and push multiple charms out of subdirectories
     needs: [get-runner-image, build-charm]
     if: ${{ needs.build-charm.outputs.charm-file == '' && !cancelled() }}
     uses: ./.github/workflows/build_charms.yaml
@@ -279,7 +277,7 @@ jobs:
   integration-test:
     name: Integration tests
     uses: ./.github/workflows/integration_test_run.yaml
-    needs: [all-images, build-charm, build-charms, get-runner-image]
+    needs: [all-images, build-charm, build-multiple-charms, get-runner-image]
     if: ${{ !failure() }}
     secrets: inherit
     with:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -202,19 +202,21 @@ jobs:
       trivy-image-config: ${{ inputs.trivy-image-config }}
       working-directory: ${{ inputs.working-directory }}
       build-args: ${{ inputs.image-build-args }}
-  build-rocks:
-    name: Build rock
-    uses: ./.github/workflows/build_rocks.yaml
-    needs: get-runner-image
-    with:
-      owner: ${{ github.repository_owner }}
-      registry: ghcr.io
-      runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
-      trivy-image-config: ${{ inputs.trivy-image-config }}
-      working-directory: ${{ inputs.working-directory }}
+  # build-rocks:
+  #   name: Build rock
+  #   uses: ./.github/workflows/build_rocks.yaml
+  #   needs: get-runner-image
+  #   with:
+  #     owner: ${{ github.repository_owner }}
+  #     registry: ghcr.io
+  #     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
+  #     trivy-image-config: ${{ inputs.trivy-image-config }}
+  #     working-directory: ${{ inputs.working-directory }}
   all-images:
     name: Get rocks or Docker images
-    needs: [build-images, build-rocks]
+    needs: 
+      - build-images
+  #    - build-rocks
     runs-on: ubuntu-latest
     outputs:
       images: ${{ env.IMAGES }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -250,7 +250,7 @@ jobs:
         if: ${{ env.CHARM_NAME != 'UNKNOWN' && !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.CHARM_NAME }}-charm
+          name: charm-artifacts
           path: ${{ inputs.working-directory }}/${{ env.CHARM_FILE }}
           if-no-files-found: error
       - name: Save image names for charm OCI resources
@@ -265,11 +265,19 @@ jobs:
           name: ${{ env.CHARM_NAME }}-images
           path: ${{ inputs.working-directory }}/${{ env.CHARM_NAME }}-images
           if-no-files-found: error
+  build-charms:
+    name: Build and push charms from subdirectories
+    needs: [get-runner-image, build-charm]
+    uses: ./.github/workflows/build_charms.yaml
+    if: ${{ always() && needs.build-charm.outputs.charm-file == 'UNKNOWN' && !cancelled() }}
+    with:
+      runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
+      working-directory: ${{ inputs.working-directory }}
 
   integration-test:
     name: Integration tests
     uses: ./.github/workflows/integration_test_run.yaml
-    needs: [all-images, build-charm, get-runner-image]
+    needs: [all-images, build-charm, build-charms, get-runner-image]
     if: ${{ !failure() }}
     secrets: inherit
     with:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -270,8 +270,8 @@ jobs:
   build-charms:
     name: Build and push charms from subdirectories
     needs: [get-runner-image, build-charm]
+    if: ${{ needs.build-charm.outputs.charm-file == '' && !cancelled() }}
     uses: ./.github/workflows/build_charms.yaml
-#    if: ${{ always() && needs.build-charm.outputs.charm-file == 'UNKNOWN' && !cancelled() }}
     with:
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -242,9 +242,6 @@ jobs:
           for image in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
             args="${args} --$(echo $image | awk -F '/' '{print $NF}' | cut -d ':' -f 1)-image ${image}"
           done
-          if [ ! -z ${{ inputs.charm-file }} ]; then
-            args="${args} --charm-file=${{ inputs.charm-file }}"
-          fi
           echo "ARGS=$args" >> $GITHUB_ENV
           series=""
           if [ ! -z ${{ matrix.series }} ]; then
@@ -261,8 +258,16 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true
         with:
-          name: ${{ env.CHARM_NAME }}-charm
-          path: ${{ inputs.working-directory }}
+          name: charm-artifacts
+          path: ${{ inputs.working-directory }}/_charms
+      - name: Add charm-file arguments
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          args=${{ env.ARGS }}
+          for charm in $(ls _charms/*.charm); do
+            args="${args} --charm-file=${charm}"
+          done
+          echo "ARGS=$args" >> $GITHUB_ENV
       - name: Run k8s integration tests
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'microk8s' }}
@@ -279,7 +284,7 @@ jobs:
         timeout-minutes: ${{ inputs.tmate-timeout }}
       - name: Dump logs
         uses: canonical/charm-logdump-action@main
-        if: failure()
+        if: ${{ failure() && inputs.provider == 'microk8s' && env.CHARM_NAME != 'UNKNOWN' }}
         with:
           app: ${{ env.CHARM_NAME }}
           model: testing
@@ -317,7 +322,7 @@ jobs:
           scan-ref: ${{ inputs.trivy-fs-ref }}
           trivy-config: ${{ inputs.trivy-fs-config }}
       - name: Set Zap target env for Github Zap Action to Juju Unit IP Address
-        if: ${{ inputs.zap-enabled && inputs.zap-target == '' }}
+        if: ${{ inputs.zap-enabled && inputs.zap-target == '' && env.CHARM_NAME != 'UNKNOWN' }}
         run: echo "ZAP_TARGET=$(juju show-unit ${{ env.CHARM_NAME }}/0 --format=json | jq -r '.["${{ env.CHARM_NAME }}/0"]["address"]')" >> $GITHUB_ENV
       - name: Set Zap target env for Github Zap Action to zap-target value
         if: ${{ inputs.zap-enabled && inputs.zap-target != '' }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -259,12 +259,11 @@ jobs:
         continue-on-error: true
         with:
           name: charm-artifacts
-          path: ${{ inputs.working-directory }}/_charms
       - name: Add charm-file arguments
         working-directory: ${{ inputs.working-directory }}
         run: |
           args=${{ env.ARGS }}
-          for charm in $(ls _charms/*.charm); do
+          for charm in $(ls *.charm); do
             args="${args} --charm-file=${charm}"
           done
           echo "ARGS=$args" >> $GITHUB_ENV

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -218,14 +218,14 @@ jobs:
       - name: Download charm artifact
         if: ${{ github.event_name == 'push' }}
         run: |
-          gh run download ${{ needs.get-run-id.outputs.run-id }} -R ${{ github.repository }} -n ${{ env.CHARM_NAME }}-charm
+          gh run download ${{ needs.get-run-id.outputs.run-id }} -R ${{ github.repository }} -n charm-artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Download charm artifact (for testing)
         uses: actions/download-artifact@v3
         if: ${{ github.event_name == 'pull_request' }}
         with:
-          name: ${{ env.CHARM_NAME }}-charm
+          name: charm-artifacts
           path: ${{ inputs.working-directory }}
       - name: Get charm file
         run: echo "CHARM_FILE=$(ls ${{ env.CHARM_NAME }}_*.charm)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Overview

Support building multiple charms from the same repository and test with a single integration build.

### Rationale

Some charm repos may hold multiple charms and need to have their integration testing run with a single commit change.  It's possible to define multiple integration-tests with different working-directories -- but without these changes its not possible to build both charms and run under one integration tests run. 

These changes allow the charms to build, then artifact the charm files in parallel with a matrix run of `charmcraft pack` for each of those sub-directories, then share a single integration-test-run for them all together

### Workflow Changes

The major shift is to store all charm file artifacts in an artifact named `charm-artifact`.  This is a file store which multiple files can be pushed to in each of the matrix runs, then pulled by the single integration-run.  This replaces the previous technique to store each charm in its own `${{ charm.name}}-image` artifact.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
