### PR TITLE
fix(perms): Don't create labels

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -385,6 +385,7 @@ jobs:
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          use-labels: false
   required_status_checks:
     name: Required Test Status Checks
     needs:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

New GHE has different set of perms that break our CI, this is a hotfix to comply with these.

### Rationale

We want our CI passing.

### Workflow Changes

Have the check libs action don't create any labels as it ties to elevated permissions that we now don't have.

### Checklist

- [x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
