### PR TITLE
chore(github): Remove hotfix for perms

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -385,8 +385,6 @@ jobs:
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          use-labels: false
-          comment-on-pr: false
   required_status_checks:
     name: Required Test Status Checks
     needs:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Removes the hotfix as perms are fixed now.

### Rationale

Revert hotfix.

### Workflow Changes

Remove two inputs that were in place to not create labels and comments (which would fail) due to decreased permissions.

### Checklist

- [x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
