### PR TITLE
Add parameter to auto-update libs per working-directory

### DIFF
--- a/.github/workflows/auto_update_charm_libs.yaml
+++ b/.github/workflows/auto_update_charm_libs.yaml
@@ -4,6 +4,11 @@
 name: Auto-update Charm Libraries
 on:
   workflow_call:
+    inputs:
+      working-directory:
+        type: string
+        description: The working directory for jobs
+        default: "./"
 
 jobs:
   update-lib:
@@ -19,6 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
+        working-directory: ${{ inputs.working-directory }}
         run: |
           sudo snap install charmcraft --classic --channel latest/stable
           charmcraft fetch-lib


### PR DESCRIPTION
### Overview

Update charm libs in a repo's subdirectory.

### Rationale

Charm libs could be in a subdirectory, the action should take an argument to update a subdirectory's libs


### Workflow Changes

Adds working-directory to the auto_update_charm_libs.yaml


### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
