### PR TITLE
Stop the Publish Charm workflow if no run-id could be retrieved

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -96,7 +96,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/commits/${GITHUB_SHA} \
             --jq '.commit.tree.sha')
-          # Get workflow from this specific tree id
+          # Get workflow run id from this specific tree id
           RUN_ID=$(gh api \
             --method GET \
             -H "Accept: application/vnd.github+json" \
@@ -110,6 +110,10 @@ jobs:
                     | select(.path == \".github/workflows/integration_test.yaml\")
                     | select(.head_commit.tree_id == \"$TREE_SHA\")
                   ] | max_by(.updated_at) | .id")
+          if [ -z "$RUN_ID" ]; then
+              echo "::error::No workflow run id found for specific tree id"
+              exit 1
+          fi
           echo "RUN_ID=$RUN_ID" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Raise an error in the publish-charm workflow if the `run-id` for the last workflow run on the specific tree sha could not be retrieved.

### Rationale

Currently, no error is thrown if the `run-id` could not be retrieved, which leads to the following command to retrieve the charm artifact (example from github-runner-operator):

```
gh run download -R canonical/github-runner-operator -n github-runner-charm
``` 

This will download the artifact from the last matching workflow in the repository, not necessarily the one matching the tree sha.

See also https://github.com/canonical/github-runner-operator/pull/168.


### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
