### PR TITLE
Upload charm artifact only if charm is present

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -245,9 +245,9 @@ jobs:
         run: |
           sudo snap install charmcraft --classic --channel latest/stable
           charmcraft pack -v
-          echo "CHARM_FILE=$(ls $CHARM_NAME_*.charm)" >> $GITHUB_ENV
+          echo "CHARM_FILE=$(ls $CHARM_NAME_*.charm || echo UNKNOWN)" >> $GITHUB_ENV
       - name: Upload charm artifact
-        if: ${{ env.CHARM_NAME != 'UNKNOWN' && !cancelled() }}
+        if: ${{ env.CHARM_FILE != 'UNKNOWN' && !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.CHARM_NAME }}-charm


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Only upload the charm artifact in the `build-charm` job of the `Integration Tests` workflow if the charm exists.

### Rationale

If the `Pack Charm` steps fail, the environment variable `CHARM_FILE` will be empty, resulting in an artifact path of `.//`, meaning that the entire repository will be uploaded as an artifact. This cannot be recovered by rerunning the `build-charm` job, as all files from previous runs will be preserved. It can cause the `publish-charm` job of the `Publish Charm` workflow to fail when it tries to download the charm artifact, and then fails because the files it is trying to unpack already exist.


See: 
- Failed `build-charm` job: https://github.com/canonical/github-runner-operator/actions/runs/7192163838/job/19588083170#step:6:4 and respective artifact (after rerunning `build-charm`) https://github.com/canonical/github-runner-operator/suites/18999950245/artifacts/1111865207
- Failed `publish-charm` job: https://github.com/canonical/github-runner-operator/actions/runs/7192986358/job/19590537932#step:5:10

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
