### PR TITLE
Debug info for bot approval PR

### DIFF
--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -11,6 +11,9 @@ jobs:
     name: Approve bot PR
     runs-on: [self-hosted, edge]
     steps:
+      - name: Show actor
+        run: |
+          echo ${{ github.actor }}
       - name: Approve bot PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Applicable spec: ISD115

### Overview

The approval does not seem to be working for renovate PRs, adding showing the GitHub actor to figure out why that is the case.

### Rationale

To get the workflow working

### Workflow Changes

Adds showing the GitHub actor as a step for the bot approval workflow

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
