### PR TITLE
Fix name of the renovate bot actor

### DIFF
--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Approve bot PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: contains(fromJSON('["renovate", "github-actions"]'), github.actor)
+        if: contains(fromJSON('["renovate[bot]", "github-actions"]'), github.actor)
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -11,6 +11,9 @@ jobs:
     name: Approve bot PR
     runs-on: [self-hosted, edge]
     steps:
+      - name: Show actor
+        run: |
+          echo ${{ github.actor }}
       - name: Approve bot PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Applicable spec: ISD115

### Overview

Fixes the name of the renovate bot actor

### Rationale

Resolves an issue where the renovate bot actor name was incorrect

### Workflow Changes

Fixes the name of the renovate bot actor

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
