### PR TITLE
Use pagination in publish_charm

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -98,7 +98,7 @@ jobs:
             --jq '.commit.tree.sha')
           # Get workflow run id from this specific tree id, paginate until found
           TOTAL_COUNT=$(gh api \
-            --method GET  \
+            --method GET \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/canonical/github-runner-operator/actions/runs \
@@ -113,7 +113,9 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               /repos/canonical/github-runner-operator/actions/runs \
-              -f status=completed -f page=$PAGE -f per_page=$PER_PAGE \
+              -f page=$PAGE \
+              -f per_page=$PER_PAGE \
+              -f status=completed \
               -f event=pull_request \
               --jq "[
                   .workflow_runs[]

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -96,24 +96,43 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/commits/${GITHUB_SHA} \
             --jq '.commit.tree.sha')
-          # Get workflow run id from this specific tree id
-          RUN_ID=$(gh api \
-            --method GET \
+          # Get workflow run id from this specific tree id, paginate until found
+          TOTAL_COUNT=$(gh api \
+            --method GET  \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/actions/runs \
-            --paginate \
+            /repos/canonical/github-runner-operator/actions/runs \
             -f status=completed \
-            -f event=pull_request \
-            --jq "[
-                    .workflow_runs[]
-                    | select(.path == \".github/workflows/integration_test.yaml\")
-                    | select(.head_commit.tree_id == \"$TREE_SHA\")
-                  ] | max_by(.updated_at) | .id")
-          if [ -z "$RUN_ID" ]; then
-              echo "::error::No workflow run id found for specific tree id"
-              exit 1
-          fi
+            -f event=pull_request | jq ".total_count")
+          PER_PAGE=100
+          MAX_PAGES=$(( (TOTAL_COUNT + 99) / $PER_PAGE ))
+          PAGE=1
+          while true; do
+             RESULT=$( gh api \
+              --method GET \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/canonical/github-runner-operator/actions/runs \
+              -f status=completed -f page=$PAGE -f per_page=$PER_PAGE \
+              -f event=pull_request \
+              --jq "[
+                  .workflow_runs[]
+                  | select(.path == \".github/workflows/integration_test.yaml\")
+                  | select(.head_commit.tree_id == \"$TREE_SHA\")
+                ] | max_by(.updated_at) | .id" 
+              )
+           
+              if [[ -n $RESULT ]]; then
+                  RUN_ID=$RESULT
+                  break
+              fi
+              if [[ "PAGE" -eq "$MAX_PAGES" ]]; then
+                  echo "::error::No workflow run id found for specific tree id"
+                  exit 1
+              fi
+              ((PAGE++))
+          done
+
           echo "RUN_ID=$RUN_ID" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -102,7 +102,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/actions/runs \
-            -f path=.github/workflows/integration_test.yaml \
+            --paginate \
             -f status=completed \
             -f event=pull_request \
             --jq "[


### PR DESCRIPTION
### Overview

Use pagination to retrieve the correct run id for a workflow and remove invalid parameter.

### Rationale

Previously, only the last 30 workflow runs were fetched (across all workflows, the `path` parameter is not a valid query parameter for this [endpoint](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository)). This may not be sufficient if the run is too far back in history and has led to a failed publish to edge workflow [here](https://github.com/canonical/github-runner-operator/actions/runs/7607340074)/

Example output of list workflow runs without pagination: https://api.github.com/repositories/355601263/actions/runs?event=pull_request&path=.github%2Fworkflows%2Fintegration_test.yaml&status=completed&page=1


### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
