### PR TITLE
Remove repo hardcoding

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -101,7 +101,7 @@ jobs:
             --method GET \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/canonical/github-runner-operator/actions/runs \
+            /repos/${{ github.repository }}/actions/runs \
             -f status=completed \
             -f event=pull_request | jq ".total_count")
           PER_PAGE=100
@@ -112,7 +112,7 @@ jobs:
               --method GET \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/canonical/github-runner-operator/actions/runs \
+              /repos/${{ github.repository }}/actions/runs \
               -f page=$PAGE \
               -f per_page=$PER_PAGE \
               -f status=completed \


### PR DESCRIPTION
### Overview

Follow-up on https://github.com/canonical/operator-workflows/pull/241 . Remove the hardcoded value `github-runner-operator` for the repo.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
