### PR TITLE
KU-52 Make the build-rocks job multiarch aware

### DIFF
--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -29,10 +29,17 @@ on:
         type: string
         description: The cache action can either be "save" or "restore".
         default: restore
+      multiarch-awareness:
+        type: boolean
+        description: Maintain the architecture labels on the container names
+        default: false
     outputs:
       images:
         description: List of images built
         value: ${{ jobs.get-rocks.outputs.images }}
+      rock-metas:
+        description: List of maps featuring the built {path, arch, image}
+        value: ${{ jobs.get-rocks.outputs.rock-metas }}
 
 jobs:
   get-rocks:
@@ -41,6 +48,7 @@ jobs:
     outputs:
       rock-paths: ${{ steps.gen-rock-paths-and-images.outputs.rock-paths }}
       images: "${{ steps.gen-rock-paths-and-images.outputs.images }}"
+      rock-metas: ${{ steps.gen-rock-paths-and-images.outputs.rock-metas }}
     steps:
       - name: Validate inputs
         run: |
@@ -55,24 +63,44 @@ jobs:
         with:
           script: |
             const path = require('path')
-            const workingDir = core.getInput('working-directory')
+            const inputs = ${{ toJSON(inputs) }}
+            const workingDir = inputs['working-directory']
+            const multiarch = inputs['multiarch-awareness']
             const rockcraftGlobber = await glob.create(
               path.join(workingDir, '**/rockcraft.yaml')
             )
             const rockPaths = []
             const images = []
+            const rockMetas = []
+            const defaultArch = 'amd64'
+            core.info(`Multiarch Awareness is ${multiarch ? "on" : "off" }`)
             for (const rockcraftFile of await rockcraftGlobber.glob()) {
               const rockPath = path.relative('.', path.dirname(rockcraftFile))
-              rockPaths.push(rockPath)
               core.info(`found rockcraft.yaml in ${rockPath}`)
               const fileHash = await glob.hashFiles(path.join(rockPath, '**'))
               const rockName = (
                 await exec.getExecOutput('yq', ['.name', rockcraftFile])
               ).stdout.trim()
-              const image = `${{ inputs.registry }}/${{ inputs.owner }}/${rockName}:${fileHash}`
-              core.info(`generate image name: ${image}`)
-              images.push(image)
+              const platforms = (
+                await exec.getExecOutput('yq', ['.platforms | keys', '-o=json', rockcraftFile])
+              ).stdout.trim()
+              if (multiarch && platforms) {
+                const arches = JSON.parse(platforms)
+                for (arch of arches) {
+                  const image = `${{ inputs.registry }}/${{ inputs.owner }}/${rockName}:${fileHash}-${arch}`
+                  core.info(`generate multi-arch image name: ${image}`)
+                  images.push(image)
+                  rockMetas.push({'path': rockPath, 'arch': arch, 'image': image})
+                }
+              } else {
+                const image = `${{ inputs.registry }}/${{ inputs.owner }}/${rockName}:${fileHash}`
+                core.info(`generate image name: ${image}`)
+                images.push(image)
+                rockMetas.push({'path': rockPath, 'arch': defaultArch, 'image': image})
+              }
+              rockPaths.push(rockPath)
             }
+            core.setOutput('rock-metas', JSON.stringify(rockMetas))
             core.setOutput('rock-paths', JSON.stringify(rockPaths))
             core.setOutput('images', JSON.stringify(images))
 
@@ -83,33 +111,39 @@ jobs:
       contents: read
       packages: write
     needs: [get-rocks]
-    if: ${{ needs.get-rocks.outputs.rock-paths != '[]' }}
+    if: ${{ needs.get-rocks.outputs.rock-metas != '[]' }}
     strategy:
       matrix:
-        path: ${{ fromJSON(needs.get-rocks.outputs.rock-paths) }}
+        rock: ${{ fromJSON(needs.get-rocks.outputs.rock-metas) }}
     steps:
       - uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
       - name: Extract rock information
         run: |
-          IMAGE_NAME=$(yq '.name' "${{ matrix.path }}/rockcraft.yaml")
-          IMAGE_BASE=$(yq '.base' "${{ matrix.path }}/rockcraft.yaml")
-          IMAGE_BUILD_BASE=$(yq '.["build-base"] // .base' "${{ matrix.path }}/rockcraft.yaml")
-          IMAGE_REF=${{ inputs.registry }}/${{ inputs.owner }}/$IMAGE_NAME:${{ hashFiles(format('{0}/{1}', matrix.path, '**')) }}
-          INODE_NUM=$(ls -id ${{ matrix.path }} | cut -f 1 -d " ")
-          ROCKCRAFT_CONTAINER_NAME=rockcraft-$IMAGE_NAME-on-amd64-for-amd64-$INODE_NUM
+          IMAGE_ARCH="${{ matrix.rock.arch }}"
+          IMAGE_NAME=$(yq '.name' "${{ matrix.rock.path }}/rockcraft.yaml")
+          IMAGE_BASE=$(yq '.base' "${{ matrix.rock.path }}/rockcraft.yaml")
+          IMAGE_BUILD_BASE=$(yq '.["build-base"] // .base' "${{ matrix.rock.path }}/rockcraft.yaml")
+          IMAGE_REF=${{ matrix.rock.image }}
+          INODE_NUM=$(ls -id ${{ matrix.rock.path }} | cut -f 1 -d " ")
+          ROCKCRAFT_CONTAINER_NAME=rockcraft-$IMAGE_NAME-on-$IMAGE_ARCH-for-$IMAGE_ARCH-$INODE_NUM
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
           echo "IMAGE_BASE=$IMAGE_BASE" >> $GITHUB_ENV
           echo "IMAGE_BUILD_BASE=$IMAGE_BUILD_BASE" >> $GITHUB_ENV
           echo "IMAGE_REF=$IMAGE_REF" >> $GITHUB_ENV
+          echo "IMAGE_ARCH=$IMAGE_ARCH" >> $GITHUB_ENV
           echo "ROCKCRAFT_CONTAINER_NAME=$ROCKCRAFT_CONTAINER_NAME" >> $GITHUB_ENV
       - name: Generate rockcraft cache key
         run: |
-          ROCKCRAFT_PATH="${{ matrix.path }}"
+          ROCKCRAFT_PATH="${{ matrix.rock.path }}"
           ROCKCRAFT_PATH="${ROCKCRAFT_PATH%/}"
           ROCKCRAFT_CACHE_KEY_BASE="$ROCKCRAFT_PATH/rockcraft-cache?name=${{ env.IMAGE_NAME }}&base=${{ env.IMAGE_BUILD_BASE }}&build-base=${{ env.IMAGE_BUILD_BASE }}"
-          ROCK_CACHE_KEY_BASE="$ROCKCRAFT_PATH/${{ env.IMAGE_NAME }}.rock?filehash=${{ hashFiles(format('{0}/{1}', matrix.path, '**')) }}"
+          ROCK_CACHE_KEY_BASE="$ROCKCRAFT_PATH/${{ env.IMAGE_NAME }}.rock?filehash=${{ hashFiles(format('{0}/{1}', matrix.rock.path, '**')) }}"
+          if [ "${{ inputs.multiarch-awareness }}" == "true" ]; then
+            ROCKCRAFT_CACHE_KEY_BASE="${ROCKCRAFT_CACHE_KEY_BASE}&arch=${{ env.IMAGE_ARCH }}"
+            ROCK_CACHE_KEY_BASE="${ROCK_CACHE_KEY_BASE}&arch=${{ env.IMAGE_ARCH }}"
+          fi
           echo "ROCKCRAFT_CACHE_KEY=$ROCKCRAFT_CACHE_KEY_BASE&date=$(date +%Y-%m-%d)" >> $GITHUB_ENV
           echo 'ROCKCRAFT_CACHE_ALT_KEYS<<EOF' >> $GITHUB_ENV 
           for d in {1..2}
@@ -157,7 +191,7 @@ jobs:
         if: steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save'
         uses: canonical/craft-actions/rockcraft-pack@main
         with:
-          path: ${{ matrix.path }}
+          path: ${{ matrix.rock.path }}
       - name: Generate rockcraft container cache
         if: inputs.cache-action == 'save'
         run: |
@@ -197,7 +231,7 @@ jobs:
             --method DELETE \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/actions/caches?key=$(printf %s "${{ env.ROCKC_CACHE_KEY }}"|jq -sRr @uri) || :
+            /repos/${{ github.repository }}/actions/caches?key=$(printf %s "${{ env.ROCK_CACHE_KEY }}"|jq -sRr @uri) || :
           for key in $(echo $ROCK_CACHE_ALT_KEYS)
             do gh api \
               --method DELETE \
@@ -214,7 +248,7 @@ jobs:
       - name: Upload rock to ghcr.io
         if: steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save'
         run: |
-          skopeo --insecure-policy copy oci-archive:$(ls "${{ matrix.path }}"/*.rock) docker://$IMAGE_REF --dest-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}"
+          skopeo --insecure-policy copy oci-archive:$(ls "${{ matrix.rock.path }}"/*.rock) docker://$IMAGE_REF --dest-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}"
       - name: Run Github Trivy Image Action
         uses: aquasecurity/trivy-action@0.16.1
         if: steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save'

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -38,7 +38,7 @@ on:
         description: List of images built
         value: ${{ jobs.get-rocks.outputs.images }}
       rock-metas:
-        description: List of maps featuring the built {path, arch, image}
+        description: List of maps featuring the built {name, version, path, arch, image}
         value: ${{ jobs.get-rocks.outputs.rock-metas }}
 
 jobs:
@@ -122,7 +122,7 @@ jobs:
       - name: Extract rock information
         run: |
           IMAGE_ARCH="${{ matrix.rock.arch }}"
-          IMAGE_NAME=$(yq '.name' "${{ matrix.rock.path }}/rockcraft.yaml")
+          IMAGE_NAME="${{ matrix.rock.name }}"
           IMAGE_BASE=$(yq '.base' "${{ matrix.rock.path }}/rockcraft.yaml")
           IMAGE_BUILD_BASE=$(yq '.["build-base"] // .base' "${{ matrix.rock.path }}/rockcraft.yaml")
           IMAGE_REF=${{ matrix.rock.image }}

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -78,9 +78,9 @@ jobs:
               const rockPath = path.relative('.', path.dirname(rockcraftFile))
               core.info(`found rockcraft.yaml in ${rockPath}`)
               const fileHash = await glob.hashFiles(path.join(rockPath, '**'))
-              const rockName = (
-                await exec.getExecOutput('yq', ['.name', rockcraftFile])
-              ).stdout.trim()
+              const [rockName, rockVersion] = (
+                await exec.getExecOutput('yq', ['.name,.version', rockcraftFile])
+              ).stdout.trim().split("\n")
               const platforms = (
                 await exec.getExecOutput('yq', ['.platforms | keys', '-o=json', rockcraftFile])
               ).stdout.trim()
@@ -90,13 +90,13 @@ jobs:
                   const image = `${{ inputs.registry }}/${{ inputs.owner }}/${rockName}:${fileHash}-${arch}`
                   core.info(`generate multi-arch image name: ${image}`)
                   images.push(image)
-                  rockMetas.push({'path': rockPath, 'arch': arch, 'image': image})
+                  rockMetas.push({name: rockName, version: rockVersion, path: rockPath, arch: arch, image: image})
                 }
               } else {
                 const image = `${{ inputs.registry }}/${{ inputs.owner }}/${rockName}:${fileHash}`
                 core.info(`generate image name: ${image}`)
                 images.push(image)
-                rockMetas.push({'path': rockPath, 'arch': defaultArch, 'image': image})
+                rockMetas.push({name: rockName, version: rockVersion, path: rockPath, arch: defaultArch, image: image})
               }
               rockPaths.push(rockPath)
             }


### PR DESCRIPTION
Updates the `build-rocks` job to be aware of the potential for a `rockcraft.yaml` to have multiple platforms.  It doesn't actually try to build those images yet appropriately on the correct architecture, but it makes it possible to distinctly identify those images when the `canonical/craft-actions/rockcraft-pack` grows the ability to build specific architectures