### PR TITLE
Fix name of bot

### DIFF
--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Approve bot PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: contains(fromJSON('["renovate[bot]", "github-actions"]'), github.actor)
+        if: contains(fromJSON('["renovate[bot]", "github-actions[bot]"]'), github.actor)
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Applicable spec: ISD115

### Overview

I have been trying to find a PR for this but haven't been able to - based on the approval user and commit history on a few PRs I'm pretty sure the GitHub actions user also has the `...[bot]` suffix

### Rationale

To ensure that the workflow works

### Workflow Changes

Fix the name of the github actions bot

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
