### PR TITLE
Add configurable publish docs step on publish workflow

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -14,6 +14,10 @@ on:
         type: string
         description: The working directory for jobs
         default: "./"
+      doc-automation-disabled:
+        type: boolean
+        description: 'Whether to disable the documentation automation'
+        default: true
 
 env:
   REGISTRY: ghcr.io
@@ -55,6 +59,28 @@ jobs:
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
           dry_run: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+  publish-docs:
+    if: ${{ github.event.inputs.destination-channel }} == 'latest/stable'
+    name: Publish docs
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Search for docs folder
+        id: docs-exist
+        run: echo "docs_exist=$([[ -d docs ]] && echo 'True' || echo 'False')" >> $GITHUB_OUTPUT
+      - name: Publish documentation
+        if: steps.docs-exist.outputs.docs_exist == 'True'
+        uses: canonical/discourse-gatekeeper@stable
+        id: publishDocumentation
+        with:
+          discourse_host: discourse.charmhub.io
+          discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
+          discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
+          dry_run: ${{ inputs.doc-automation-disabled }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Show index page
+        if: steps.docs-exist.outputs.docs_exist == 'True'
+        run: echo '${{ steps.publishDocumentation.outputs.index_url }}'
   get-runner-image:
     name: Get runner image
     uses: ./.github/workflows/get_runner_image.yaml


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Add configurable publish docs step on publish workflow

### Rationale

<!-- The reason the change is needed -->
Enable docs publishing whenever a charm is published to any channel

### Workflow Changes

<!-- Any high level changes to workflows and why -->
New job in publish_charm.yaml

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
