### PR TITLE
Support publishing with charming-actions/upload-charm `tag-prefix`

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -14,6 +14,11 @@ on:
         type: string
         description: The working directory for jobs
         default: "./"
+      tag-prefix:
+        type: string
+        required: false
+        description: |
+          Tag prefix, useful when bundling multiple charms in the same repo.
 
 env:
   REGISTRY: ghcr.io
@@ -261,4 +266,5 @@ jobs:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           channel: ${{ inputs.channel }}
+          tag-prefix: ${{ inputs.tag-prefix }}
           upload-image: false


### PR DESCRIPTION
Support workflows passing the `tag-prefix` string

### Overview

Charm repos which have multiple charms in the repo, require multiple tags in that repo for every charm rev pushed to charmhub. The `charming-actions/upload-charm` action supports this tagger feature, but has an extra argument for when there are multiple charms produced by one repo - [`tag-prefix`](https://github.com/canonical/charming-actions/blob/ed9079c019254987f197a6f1300c483c2a6c16f0/upload-charm/action.yaml#L17-L20)

```yaml
  tag-prefix:
    required: false
    description: |
      Tag prefix, useful when bundling multiple charms in the same repo using a matrix.
```

### Rationale

Charms like `k8s` and `k8s-worker` live in the same repo (canonical/k8s-operator) and require this tagging to be separate

### Workflow Changes

Addition of new argument in the publish_charm workflow (`tag-prefix`)

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
