### PR TITLE
ignore upload-artifact if CHARM_FILE is unset or unknown

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -252,7 +252,7 @@ jobs:
           charmcraft pack -v
           echo "CHARM_FILE=$(ls $CHARM_NAME_*.charm || echo UNKNOWN)" >> $GITHUB_ENV
       - name: Upload charm artifact
-        if: ${{ !contains(['', 'UNKNOWN'], env.CHARM_FILE) && !cancelled() }}
+        if: ${{ !contains(fromJson('["", "UNKNOWN"]'), env.CHARM_FILE) && !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CHARM_NAME }}-charm

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -252,7 +252,7 @@ jobs:
           charmcraft pack -v
           echo "CHARM_FILE=$(ls $CHARM_NAME_*.charm || echo UNKNOWN)" >> $GITHUB_ENV
       - name: Upload charm artifact
-        if: ${{ env.CHARM_FILE != 'UNKNOWN' && !cancelled() }}
+        if: ${{ !contains(['', 'UNKNOWN'], env.CHARM_FILE) && !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CHARM_NAME }}-charm


### PR DESCRIPTION
### Overview

Do not upload the working directory as an artifact named `UNKNOWN-charm`

### Rationale

In cases where `env.CHARM_FILE` is unset (ie -- when CHARM_NAME is "UNKNOWN" because there is no charmcraft.yaml or metadata.yaml in the provided working-directory, the `CHARM_FILE` env file is unset because the `Pack charm` step will be skipped.  In this event, skip uploading the artifact. 

### Workflow Changes

the build-charm step of `integration_test` will be adjusted to have an empty `charm-file`
This can be valuable for repos that wish to test a bundle or a repo that wishes to test multiple charms within the same repo

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
