### PR TITLE
Download and list any charm artifact when running the integration tests

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -247,8 +247,14 @@ jobs:
           for image in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
             args="${args} --$(echo $image | awk -F '/' '{print $NF}' | cut -d ':' -f 1)-image ${image}"
           done
+          charms_artifacts=(`find ${{ inputs.working-directory }} -maxdepth 1 -name "*.charm"`)
           if [ ! -z ${{ inputs.charm-file }} ]; then
             args="${args} --charm-file=${{ inputs.charm-file }}"
+          elif [ ${#charms_artifacts[@]} -gt 0 ]; then
+            # iterate across any local *.charm files
+            for charm in "${charms_artifacts[@]}"; do
+              args="${args} --charm-file=${charm}"
+            done
           fi
           echo "ARGS=$args" >> $GITHUB_ENV
           series=""
@@ -266,8 +272,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true
         with:
-          name: ${{ env.CHARM_NAME }}-charm
           path: ${{ inputs.working-directory }}
+          pattern: '*-charm'
+          merge-multiple: true
       - name: Run k8s integration tests
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'microk8s' }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -234,6 +234,14 @@ jobs:
       - name: Pre-run script
         if: ${{ inputs.pre-run-script != '' }}
         run: bash -xe ${{ inputs.pre-run-script }}
+      - name: Download charm artifact
+        uses: actions/download-artifact@v4
+        if: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: true
+        with:
+          path: ${{ inputs.working-directory }}
+          pattern: '*-charm'
+          merge-multiple: true
       - name: Integration tests variable setting
         working-directory: ${{ inputs.working-directory }}
         run: |
@@ -267,14 +275,6 @@ jobs:
             module="-k ${{ matrix.modules }}"
           fi
           echo "MODULE=$module" >> $GITHUB_ENV
-      - name: Download charm artifact
-        uses: actions/download-artifact@v4
-        if: ${{ github.event_name == 'pull_request' }}
-        continue-on-error: true
-        with:
-          path: ${{ inputs.working-directory }}
-          pattern: '*-charm'
-          merge-multiple: true
       - name: Run k8s integration tests
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'microk8s' }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -255,12 +255,12 @@ jobs:
           for image in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
             args="${args} --$(echo $image | awk -F '/' '{print $NF}' | cut -d ':' -f 1)-image ${image}"
           done
-          charms_artifacts=(`find ${{ inputs.working-directory }} -maxdepth 1 -name "*.charm"`)
+          charm_artifacts=(`find ${{ inputs.working-directory }} -maxdepth 1 -name "*.charm"`)
           if [ ! -e ${{ inputs.charm-file }} ]; then
             args="${args} --charm-file=${{ inputs.charm-file }}"
-          elif [ ${#charms_artifacts[@]} -gt 0 ]; then
+          elif [ ${#charm_artifacts[@]} -gt 0 ]; then
             # iterate across any local *.charm files
-            for charm in "${charms_artifacts[@]}"; do
+            for charm in "${charm_artifacts[@]}"; do
               args="${args} --charm-file=${charm}"
             done
           fi

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -256,7 +256,7 @@ jobs:
             args="${args} --$(echo $image | awk -F '/' '{print $NF}' | cut -d ':' -f 1)-image ${image}"
           done
           charms_artifacts=(`find ${{ inputs.working-directory }} -maxdepth 1 -name "*.charm"`)
-          if [ ! -z ${{ inputs.charm-file }} ]; then
+          if [ ! -e ${{ inputs.charm-file }} ]; then
             args="${args} --charm-file=${{ inputs.charm-file }}"
           elif [ ${#charms_artifacts[@]} -gt 0 ]; then
             # iterate across any local *.charm files

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -236,7 +236,6 @@ jobs:
         run: bash -xe ${{ inputs.pre-run-script }}
       - name: Download charm artifact
         uses: actions/download-artifact@v4
-        if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true
         with:
           path: ${{ inputs.working-directory }}


### PR DESCRIPTION
### Overview

Use all charm artifacts for a given pull-request in the integration test.

### Rationale

The current workflow requires that to test with a given charm artifact, there should be only one and it should be in the `charm-file` input.  That's fine for repos with a single charm, but when the repo contains multiple charms -- the tox command args should contain multiple `--charm-file` arguments.  

### Workflow Changes

the `Download charm artifact` step is changed to download all artifacts that match the `*-charm` pattern and merge into them into working-directory. (See [download-artifact](https://github.com/actions/download-artifact?tab=readme-ov-file#download-multiple-filtered-artifacts-to-the-same-directory) for details)

If the `input.charm-file` doesn't exist in the working-directory, look for all the charms downloaded  as `charm_artifacts` and add those to the args.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

