### PR TITLE
Support canonical tmate action

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -273,8 +273,12 @@ jobs:
         if: ${{ inputs.provider == 'lxd' }}
         run: |
           tox -e ${{ inputs.test-tox-env }} -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
-      - name: Tmate debugging session
-        if: ${{ failure() && inputs.tmate-debug }}
+      - name: Tmate debugging session (self-hosted)
+        if: ${{ failure() && inputs.tmate-debug && inputs.self-hosted-runner }}
+        uses: canonical/action-tmate@main
+        timeout-minutes: ${{ inputs.tmate-timeout }}
+      - name: Tmate debugging session (gh-hosted)
+        if: ${{ failure() && inputs.tmate-debug && !inputs.self-hosted-runner }}
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: ${{ inputs.tmate-timeout }}
       - name: Dump logs


### PR DESCRIPTION


### Overview

Add support for https://github.com/canonical/action-tmate/

### Rationale

Support for ssh debugging with self-hosted runners.


### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
