### PR TITLE
Remove chaos testing

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,50 +10,6 @@ on:
         description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: latest/stable
-      chaos-app-kind:
-        type: string
-        description: Application kind
-        default: statefulset
-      chaos-app-label:
-        type: string
-        description: Label for chaos selection
-        default: ""
-      chaos-app-namespace:
-        type: string
-        description: Namespace of chaos tested application
-        default: testing
-      chaos-duration:
-        type: string
-        description: |
-          Duration of the chaos experiment (added to 600s for go test timeout)
-        default: 60
-      chaos-enabled:
-        type: boolean
-        description: Whether Chaos testing is enabled
-        default: false
-      chaos-experiments:
-        type: string
-        description: List of experiments to run
-        default: ""
-      chaos-interval:
-        type: string
-        description: Interval to attempt re-run of an experiment
-        default: 30
-      chaos-namespace:
-        type: string
-        description: Namespace to install Litmus Chaos
-        default: testing
-      chaos-status-delay:
-        type: string
-        description: Delay is the wait(sleep) time on every status retry
-        default: 5
-      chaos-status-duration:
-        type: string
-        description: |
-          Duration used for status check retries
-          Retry is chaos-duration/chaos-delay times and each retry
-          sleeps chaos-delay
-        default: 90
       extra-arguments:
         description: Additional arguments to pass to the integration test execution
         type: string
@@ -276,16 +232,6 @@ jobs:
     secrets: inherit
     with:
       channel: ${{ inputs.channel }}
-      chaos-app-kind: ${{ inputs.chaos-app-kind }}
-      chaos-app-label: ${{ inputs.chaos-app-label }}
-      chaos-app-namespace: ${{ inputs.chaos-app-namespace }}
-      chaos-duration: ${{ inputs.chaos-duration }}
-      chaos-enabled: ${{ inputs.chaos-enabled }}
-      chaos-experiments: ${{ inputs.chaos-experiments }}
-      chaos-interval: ${{ inputs.chaos-interval }}
-      chaos-namespace: ${{ inputs.chaos-namespace }}
-      chaos-status-delay: ${{ inputs.chaos-status-delay }}
-      chaos-status-duration: ${{ inputs.chaos-status-duration }}
       charm-file: ${{ needs.build-charm.outputs.charm-file }}
       extra-arguments: ${{ inputs.extra-arguments }}
       extra-test-matrix: ${{ inputs.extra-test-matrix }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -10,50 +10,6 @@ on:
         description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: latest/stable
-      chaos-app-kind:
-        type: string
-        description: Application kind
-        default: statefulset
-      chaos-app-label:
-        type: string
-        description: Label for chaos selection
-        default: ""
-      chaos-app-namespace:
-        type: string
-        description: Namespace of chaos tested application
-        default: testing
-      chaos-duration:
-        type: string
-        description: |
-          Duration of the chaos experiment (added to 600s for go test timeout)
-        default: 60
-      chaos-enabled:
-        type: boolean
-        description: Whether Chaos testing is enabled
-        default: false
-      chaos-experiments:
-        type: string
-        description: List of experiments to run
-        default: ""
-      chaos-interval:
-        type: string
-        description: Interval to attempt re-run of an experiment
-        default: 30
-      chaos-namespace:
-        type: string
-        description: Namespace to install Litmus Chaos
-        default: testing
-      chaos-status-delay:
-        type: string
-        description: Delay is the wait(sleep) time on every status retry
-        default: 5
-      chaos-status-duration:
-        type: string
-        description: |
-          Duration used for status check retries
-          Retry is chaos-duration/chaos-delay times and each retry
-          sleeps chaos-delay
-        default: 90
       charm-file:
         type: string
         description: Charm file
@@ -283,26 +239,6 @@ jobs:
         with:
           app: ${{ env.CHARM_NAME }}
           model: testing
-      - name: Setting up kubeconfig ENV for Github Chaos Action
-        if: ${{ inputs.chaos-enabled }}
-        run: echo "KUBE_CONFIG_DATA=$(sudo microk8s config | base64 -w 0)" >> $GITHUB_ENV
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-      - name: Run Litmus Chaos experiments
-        if: ${{ inputs.chaos-enabled }}
-        uses: merkata/github-chaos-actions@fix/oci-cli
-        env:
-          APP_KIND: ${{ inputs.chaos-app-kind }}
-          APP_LABEL: ${{ inputs.chaos-app-label }}
-          APP_NS: ${{ inputs.chaos-app-namespace }}
-          CHAOS_INTERVAL: ${{ inputs.chaos-interval }}
-          CHAOS_NAMESPACE: ${{ inputs.chaos-namespace }}
-          DELAY: ${{ inputs.chaos-status-delay }}
-          DURATION: ${{ inputs.chaos-status-duration }}
-          EXPERIMENT_NAME: ${{ inputs.chaos-experiments }}
-          INSTALL_LITMUS: true
-          TOTAL_CHAOS_DURATION: ${{ inputs.chaos-duration }}
-          KUBE_CONFIG_DATA: ${{ env.KUBE_CONFIG_DATA }}
       - name: Install k6s
         if: ${{ inputs.load-test-enabled }}
         run: sudo snap install k6

--- a/README.md
+++ b/README.md
@@ -21,18 +21,11 @@ The following workflows are available:
 
 * comment: Posts the content of the artifact specified as a comment in a PR. It needs to be triggered from a PR triggered workflow.
 
-* integration_test: Builds the existing Dockerfiles, if any, and executes the `integration` test target defined in the `tox.ini` file. The tox environment used can be changed with the `test-tox-env` input. This workflow also supports running addtional load and chaos tests. The following parameters are available for this workflow:
+* integration_test: Builds the existing Dockerfiles, if any, and executes the `integration` test target defined in the `tox.ini` file. The tox environment used can be changed with the `test-tox-env` input. The following parameters are available for this workflow:
 
 | Name | Type | Default | Description |
 |--------------------|----------|--------------------|-------------------|
 | channel | string | latest/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
-| chaos-enabled  | bool | false | Whether Chaos testing is enabled |
-| chaos-experiments | string | "" | List of experiments to run |
-| chaos-namespace | string | testing | Namespace to install Litmus Chaos |
-| chaos-app-namespace | string | testing | Namespace of chaos tested application |
-| chaos-app-label | string | "" | Label for chaos selection |
-| chaos-app-kind | string | statefulset | Application kind |
-| chaos-duration | string | 60 | Duration of the chaos experiment |
 | extra-arguments | string | "" | Additional arguments to pass to the integration test execution |
 | extra-test-matrix | string | '{}' | Additional test matrices to run the integration test combinations |
 | image-build-args | string | "" | List of build args to pass to the build image job |


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Chaos testing as not been proven useful in our current setups as few issues (none?) were specifically catched by that test. At the same time, it slows down the CI significantly, taking around 5mn to build the image for them alone, even if we disabled them. Even worse, we (often) have to retry chaos tests as they are still flaky.

Indico is the last repository to have them enabled.  
I propose to remove them for now and only reintroduce them when we can make sure that they are a net positive in our reliability assessment of our charms.

### Workflow Changes

Chaos testing is removed.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
