### PR TITLE
Fix integration test execution

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -254,7 +254,7 @@ jobs:
           for image in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
             args="${args} --$(echo $image | awk -F '/' '{print $NF}' | cut -d ':' -f 1)-image ${image}"
           done
-          charm_artifacts=(`find ${{ inputs.working-directory }} -maxdepth 1 -name "*.charm"`)
+          charm_artifacts=(`find . -maxdepth 1 -name "*.charm"`)
           if [ ! -e ${{ inputs.charm-file }} ]; then
             args="${args} --charm-file=${{ inputs.charm-file }}"
           elif [ ${#charm_artifacts[@]} -gt 0 ]; then


### PR DESCRIPTION
Applicable spec: N/A

### Overview

<!-- A high level overview of the change -->
Fix bug causing the integration tests to fail introduced by https://github.com/canonical/operator-workflows/pull/250

### Rationale

<!-- The reason the change is needed -->
N/A

### Workflow Changes

<!-- Any high level changes to workflows and why -->
N/A

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
