### PR TITLE
Align with charming-actions@2.5.0-rc

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@2.4.0
+        uses: canonical/charming-actions/release-charm@2.5.0-rc
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -79,7 +79,7 @@ jobs:
           rm -rf .* * || :
           cp -rp $TEMP_DIR/. .
           rm -rf $TEMP_DIR
-      - uses: canonical/charming-actions/release-libraries@2.4.0
+      - uses: canonical/charming-actions/release-libraries@2.5.0-rc
         name: Release libs
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
@@ -276,7 +276,7 @@ jobs:
       - name: Get charm file
         run: echo "CHARM_FILE=$(ls ${{ env.CHARM_NAME }}_*.charm)" >> $GITHUB_OUTPUT
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.4.0
+        uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           built-charm-path: ${{ env.CHARM_FILE }}
           credentials: ${{ secrets.CHARMHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -382,7 +382,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
       - name: Check libs
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: canonical/charming-actions/check-libraries@2.4.0
+        uses: canonical/charming-actions/check-libraries@2.5.0-rc
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Overview

Update the workflow to use charming-actions 2.5.0 (rc)

### Rationale

charming-actions 2.5.0 added support to read from `charmcraft.yaml` the metadata of a charm when `metadata.yaml` doesn't exist.  https://github.com/canonical/charming-actions/pull/132.  

Here is a list of all the [changes since 2.4.0](https://github.com/canonical/charming-actions/releases/tag/2.5.0-rc)

### Workflow Changes

This shouldn't change any existing workflows

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)


