### PR TITLE
Let runner.debug trigger tmate

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -241,11 +241,11 @@ jobs:
         run: |
           tox -e ${{ inputs.test-tox-env }} -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
       - name: Tmate debugging session (self-hosted)
-        if: ${{ failure() && inputs.tmate-debug && inputs.self-hosted-runner }}
+        if: ${{ failure() && (inputs.tmate-debug || runner.debug) && inputs.self-hosted-runner }}
         uses: canonical/action-tmate@main
         timeout-minutes: ${{ inputs.tmate-timeout }}
       - name: Tmate debugging session (gh-hosted)
-        if: ${{ failure() && inputs.tmate-debug && !inputs.self-hosted-runner }}
+        if: ${{ failure() && (inputs.tmate-debug || runner.debug) && !inputs.self-hosted-runner }}
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: ${{ inputs.tmate-timeout }}
       - name: Dump logs

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ and then use the argument value
 charm = pytestconfig.getoption("--charm-file")
 ```
 
+tmate can be run on failed tests either by setting the `tmate-debug` input to 'true' or by re-running a job with the "Enable debug logging" checkbox checked.
+
 * publish_charm: Publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel).
 
 This workflow requires a `CHARMHUB_TOKEN` secret containing a charmhub token with package-manage and package-view permissions for the charm and the destination channel. See how to generate it [here](https://juju.is/docs/sdk/remote-env-auth) and a `REPO_ACCESS_TOKEN` secret containg a classic PAT with full repository permissions. See how to generate it [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).


### PR DESCRIPTION
### Overview

Enable a tmate session when a user enables debug logging on a rerun (which lets gh set the [runner.debug](https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context) variable). This way the user can simply enable the tmate session by clicking a checkbox instead of manipulating the workflow file. 

![Screenshot from 2024-02-19 12-51-42](https://github.com/canonical/operator-workflows/assets/4182921/3ff3855c-f432-4938-9c77-6f5e66f2de54)

Inspired by a comment from @Saviq .

### Rationale

Make debugging more user-friendly.

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
