### PR TITLE
Allow the use of rockcraft pulled and built from source to build rock images.

### DIFF
--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -25,10 +25,6 @@ on:
         type: string
         description: The working directory for jobs
         default: "./"
-      cache-action:
-        type: string
-        description: The cache action can either be "save" or "restore".
-        default: restore
       rockcraft-ref:
         description: Used in conjunction with rockcraft_repo to pull and build rockcraft from source instead of using snapstore version.
         type: string
@@ -131,11 +127,6 @@ jobs:
         with:
           path: ./rockcraft*.snap
           key: ${{ steps.restore-rockcraft.outputs.cache-primary-key }}
-      - uses: actions/upload-artifact@v4
-        if: inputs.rockcraft-repository != ''
-        with:
-          name: rockcraft-snap
-          path: "rockcraft*.snap"
       - name: Install Rockcraft
         if: inputs.rockcraft-repository != ''
         run: sudo snap install --dangerous --classic rockcraft*.snap
@@ -158,49 +149,8 @@ jobs:
           echo "IMAGE_BUILD_BASE=$IMAGE_BUILD_BASE" >> $GITHUB_ENV
           echo "IMAGE_REF=$IMAGE_REF" >> $GITHUB_ENV
           echo "ROCKCRAFT_CONTAINER_NAME=$ROCKCRAFT_CONTAINER_NAME" >> $GITHUB_ENV
-      - name: Generate rockcraft cache key
-        run: |
-          ROCKCRAFT_PATH="${{ matrix.path }}"
-          ROCKCRAFT_PATH="${ROCKCRAFT_PATH%/}"
-          ROCKCRAFT_CACHE_KEY_BASE="$ROCKCRAFT_PATH/rockcraft-cache?name=${{ env.IMAGE_NAME }}&base=${{ env.IMAGE_BUILD_BASE }}&build-base=${{ env.IMAGE_BUILD_BASE }}"
-          ROCK_CACHE_KEY_BASE="$ROCKCRAFT_PATH/${{ env.IMAGE_NAME }}.rock?filehash=${{ hashFiles(format('{0}/{1}', matrix.path, '**')) }}"
-          echo "ROCKCRAFT_CACHE_KEY=$ROCKCRAFT_CACHE_KEY_BASE&date=$(date +%Y-%m-%d)" >> $GITHUB_ENV
-          echo 'ROCKCRAFT_CACHE_ALT_KEYS<<EOF' >> $GITHUB_ENV 
-          for d in {1..2}
-            do echo "$ROCKCRAFT_CACHE_KEY_BASE&date=$(date -d"-$d days" +%Y-%m-%d)" >> $GITHUB_ENV
-          done
-          echo 'EOF' >> $GITHUB_ENV
-          echo "ROCK_CACHE_KEY=$ROCK_CACHE_KEY_BASE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
-          echo 'ROCK_CACHE_ALT_KEYS<<EOF' >> $GITHUB_ENV 
-          for d in {1..2}
-            do echo "$ROCK_CACHE_KEY_BASE&date=$(date -d"-$d days" +%Y-%m-%d)" >> $GITHUB_ENV
-          done
-          echo 'EOF' >> $GITHUB_ENV
-      - name: Restore rock cache
-        if: inputs.cache-action == 'restore'
-        uses: actions/cache/restore@v4.0.0
-        id: rock-cache
-        with:
-          path: ~/.rock-cache
-          key: ${{ env.ROCK_CACHE_KEY }}
-          restore-keys: ${{ env.ROCK_CACHE_ALT_KEYS }}
-      - name: Restore rockcraft container cache
-        if: steps.rock-cache.outputs.cache-hit != 'true' && inputs.cache-action == 'restore'
-        uses: actions/cache/restore@v4.0.0
-        id: rockcraft-cache
-        with:
-          path: ~/.rockcraft-cache/
-          key: ${{ env.ROCKCRAFT_CACHE_KEY }}
-          restore-keys: ${{ env.ROCKCRAFT_CACHE_ALT_KEYS }}
-      - name: Import rockcraft container cache
-        if: steps.rockcraft-cache.outputs.cache-hit == 'true'
-        working-directory: ${{ inputs.working-directory }}
-        run: |
-          sudo lxc project create rockcraft -c features.images=false -c features.profiles=false
-          sudo lxc --project rockcraft import ~/.rockcraft-cache/${{ env.IMAGE_NAME }}.tar ${{ env.ROCKCRAFT_CONTAINER_NAME }}
-          find . -exec touch '{}' ';'
       - name: Build rock
-        if: (steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save') && inputs.rockcraft-repository == ''
+        if: inputs.rockcraft-repository == ''
         uses: canonical/craft-actions/rockcraft-pack@main
         with:
           path: ${{ matrix.path }}
@@ -209,59 +159,6 @@ jobs:
         env:
           ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
         run: rockcraft pack --verbosity trace
-      - name: Generate rockcraft container cache
-        if: inputs.cache-action == 'save'
-        run: |
-          mkdir -p ~/.rockcraft-cache
-          mkdir -p ~/.rock-cache
-          touch ~/.rock-cache/.gitkeep
-          sudo lxc --project rockcraft export ${{ env.ROCKCRAFT_CONTAINER_NAME }} --compression none ~/.rockcraft-cache/${{ env.IMAGE_NAME }}.tar
-      - name: Delete rockcraft container cache
-        if: inputs.cache-action == 'save'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            --method DELETE \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/actions/caches?key=$(printf %s "${{ env.ROCKCRAFT_CACHE_KEY }}"|jq -sRr @uri) || :
-          for key in $(echo $ROCKCRAFT_CACHE_ALT_KEYS)
-            do gh api \
-              --method DELETE \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/${{ github.repository }}/actions/caches?key=$(printf %s "$key"|jq -sRr @uri) || :
-          done
-      - name: Save rockcraft container cache
-        if: inputs.cache-action == 'save'
-        uses: actions/cache/save@v4.0.0
-        with:
-          path: ~/.rockcraft-cache/
-          key: ${{ env.ROCKCRAFT_CACHE_KEY }}
-      - name: Delete rock cache
-        if: inputs.cache-action == 'save'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            --method DELETE \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/actions/caches?key=$(printf %s "${{ env.ROCKC_CACHE_KEY }}"|jq -sRr @uri) || :
-          for key in $(echo $ROCK_CACHE_ALT_KEYS)
-            do gh api \
-              --method DELETE \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/${{ github.repository }}/actions/caches?key=$(printf %s "$key"|jq -sRr @uri) || :
-          done
-      - name: Save rock cache
-        if: inputs.cache-action == 'save'
-        uses: actions/cache/save@v4.0.0
-        with:
-          path: ~/.rock-cache
-          key: ${{ env.ROCK_CACHE_KEY }}
       - name: Upload rock to ghcr.io
         if: steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save'
         run: |

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -158,6 +158,7 @@ jobs:
         if: inputs.rockcraft-repository != ''
         env:
           ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
+        working-directory: ${{ matrix.path }}
         run: rockcraft pack --verbosity trace
       - name: Upload rock to ghcr.io
         if: steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save'

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -29,6 +29,14 @@ on:
         type: string
         description: The cache action can either be "save" or "restore".
         default: restore
+      rockcraft-ref:
+        description: Used in conjunction with rockcraft_repo to pull and build rockcraft from source instead of using snapstore version.
+        type: string
+        default: ""
+      rockcraft-repository:
+        description: Pull and build rockcraft from source instead of using snapstore version.
+        type: string
+        default: ""
     outputs:
       images:
         description: List of images built
@@ -88,6 +96,52 @@ jobs:
       matrix:
         path: ${{ fromJSON(needs.get-rocks.outputs.rock-paths) }}
     steps:
+      - uses: actions/checkout@v4
+        if: inputs.rockcraft-repository != ''
+        with:
+          repository: ${{ inputs.rockcraft-repository }}
+          ref: ${{ inputs.rockcraft-ref }}
+          path: rockcraft
+          fetch-depth: 0
+      - name: Get Rockcraft SHA
+        if: inputs.rockcraft-repository != ''
+        id: rockcraft-sha
+        working-directory: ./rockcraft
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - name: Restore Rockcraft Cache
+        if: inputs.rockcraft-repository != ''
+        id: restore-rockcraft
+        uses: actions/cache/restore@v4
+        with:
+          path: ./rockcraft*.snap
+          key: rockcraft-${{ steps.rockcraft-sha.outputs.sha }}
+      - uses: canonical/setup-lxd@v0.1.1
+      - name: Install Snapcraft
+        if: steps.restore-rockcraft.outputs.cache-hit != 'true' && inputs.rockcraft-repository != ''
+        run: sudo snap install snapcraft --classic
+      - name: Build Rockcraft
+        if: steps.restore-rockcraft.outputs.cache-hit != 'true' && inputs.rockcraft-repository != ''
+        working-directory: ./rockcraft
+        run: |
+          snapcraft --use-lxd
+          cp rockcraft*.snap ../
+      - name: Save Rockcraft Cache
+        uses: actions/cache/save@v4
+        if: steps.restore-rockcraft.outputs.cache-hit != 'true' && inputs.rockcraft-repository != ''
+        with:
+          path: ./rockcraft*.snap
+          key: ${{ steps.restore-rockcraft.outputs.cache-primary-key }}
+      - uses: actions/upload-artifact@v4
+        if: inputs.rockcraft-repository != ''
+        with:
+          name: rockcraft-snap
+          path: "rockcraft*.snap"
+      - name: Install Rockcraft
+        if: inputs.rockcraft-repository != ''
+        run: sudo snap install --dangerous --classic rockcraft*.snap
+      - name: Cleanup Rockcraft
+        if: inputs.rockcraft-repository != ''
+        run: rm -rf rockcraft*
       - uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
@@ -138,14 +192,6 @@ jobs:
           path: ~/.rockcraft-cache/
           key: ${{ env.ROCKCRAFT_CACHE_KEY }}
           restore-keys: ${{ env.ROCKCRAFT_CACHE_ALT_KEYS }}
-      - name: Setup lxd
-        if: steps.rockcraft-cache.outputs.cache-hit == 'true'
-        run: |
-          sudo groupadd --force --system lxd
-          sudo usermod --append --groups lxd runner
-          sudo snap refresh lxd --channel latest/stable
-          sudo lxd init --auto
-          sudo iptables -P FORWARD ACCEPT
       - name: Import rockcraft container cache
         if: steps.rockcraft-cache.outputs.cache-hit == 'true'
         working-directory: ${{ inputs.working-directory }}
@@ -154,10 +200,15 @@ jobs:
           sudo lxc --project rockcraft import ~/.rockcraft-cache/${{ env.IMAGE_NAME }}.tar ${{ env.ROCKCRAFT_CONTAINER_NAME }}
           find . -exec touch '{}' ';'
       - name: Build rock
-        if: steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save'
+        if: (steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save') && inputs.rockcraft-repository == ''
         uses: canonical/craft-actions/rockcraft-pack@main
         with:
           path: ${{ matrix.path }}
+      - name: Build rock
+        if: inputs.rockcraft-repository != ''
+        env:
+          ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
+        run: rockcraft pack --verbosity trace
       - name: Generate rockcraft container cache
         if: inputs.cache-action == 'save'
         run: |

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -46,12 +46,6 @@ jobs:
       rock-paths: ${{ steps.gen-rock-paths-and-images.outputs.rock-paths }}
       images: "${{ steps.gen-rock-paths-and-images.outputs.images }}"
     steps:
-      - name: Validate inputs
-        run: |
-          if [ "${{ inputs.cache-action }}" != "save" ] && [ "${{ inputs.cache-action }}" != "restore" ]; then
-            echo "Invalid value for cache-action. It must be 'save' or 'restore'"
-            exit 1
-          fi
       - uses: actions/checkout@v4.1.1
       - name: Generate rock paths and images
         id: gen-rock-paths-and-images

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -66,7 +66,7 @@ jobs:
               }
               rockPaths.push(rockPath)
               core.info(`found rockcraft.yaml in ${rockPath}`)
-              const fileHash = await glob.hashFiles(path.join(rockPath, '**'))
+              const fileHash = await glob.hashFiles(path.join(rockPath, '**') + '\n!.git')
               const rockName = (
                 await exec.getExecOutput('yq', ['.name', rockcraftFile])
               ).stdout.trim()
@@ -138,7 +138,7 @@ jobs:
           IMAGE_NAME=$(yq '.name' "${{ matrix.path }}/rockcraft.yaml")
           IMAGE_BASE=$(yq '.base' "${{ matrix.path }}/rockcraft.yaml")
           IMAGE_BUILD_BASE=$(yq '.["build-base"] // .base' "${{ matrix.path }}/rockcraft.yaml")
-          IMAGE_REF=${{ inputs.registry }}/${{ inputs.owner }}/$IMAGE_NAME:${{ hashFiles(format('{0}/{1}', matrix.path, '**')) }}
+          IMAGE_REF=${{ inputs.registry }}/${{ inputs.owner }}/$IMAGE_NAME:${{ hashFiles(format('{0}/{1}', matrix.path, '**'), '!.git') }}
           INODE_NUM=$(ls -id ${{ matrix.path }} | cut -f 1 -d " ")
           ROCKCRAFT_CONTAINER_NAME=rockcraft-$IMAGE_NAME-on-amd64-for-amd64-$INODE_NUM
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -60,7 +60,10 @@ jobs:
             const rockPaths = []
             const images = []
             for (const rockcraftFile of await rockcraftGlobber.glob()) {
-              const rockPath = path.relative('.', path.dirname(rockcraftFile))
+              let rockPath = path.relative('.', path.dirname(rockcraftFile))
+              if (rockPath === '') {
+                rockPath = '.'
+              }
               rockPaths.push(rockPath)
               core.info(`found rockcraft.yaml in ${rockPath}`)
               const fileHash = await glob.hashFiles(path.join(rockPath, '**'))

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -26,7 +26,7 @@ on:
         description: The working directory for jobs
         default: "./"
       rockcraft-ref:
-        description: Used in conjunction with rockcraft_repo to pull and build rockcraft from source instead of using snapstore version.
+        description: Used in conjunction with rockcraft-repository to pull and build rockcraft from source instead of using snapstore version.
         type: string
         default: ""
       rockcraft-repository:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -265,8 +265,12 @@ jobs:
 
       - uses: actions/checkout@v4.1.1
 
-      - name: Extract charm name
+      - name: Get charm dir
         working-directory: ${{ inputs.working-directory }}
+        run: echo "CHARM_DIR=$([ -d charm ] && realpath charm || realpath .)">> $GITHUB_ENV
+
+      - name: Extract charm name
+        working-directory: ${{ env.CHARM_DIR }}
         run: |
           CHARM_NAME="$([ -f metadata.yaml ] && yq '.name' metadata.yaml || echo UNKNOWN)"
           if [ "$CHARM_NAME" == "UNKNOWN" ]; then
@@ -276,7 +280,7 @@ jobs:
 
       - name: Pack charm
         if: ${{ env.CHARM_NAME != 'UNKNOWN' && !cancelled() }}
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ${{ env.CHARM_DIR }}
         run: |
           charmcraft pack -v
           echo "CHARM_FILE=$(ls $CHARM_NAME_*.charm || echo UNKNOWN)" >> $GITHUB_ENV
@@ -286,13 +290,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CHARM_NAME }}-charm
-          path: ${{ inputs.working-directory }}/${{ env.CHARM_FILE }}
+          path: ${{ env.CHARM_DIR }}/${{ env.CHARM_FILE }}
           if-no-files-found: error
           overwrite: true
 
       - name: Save image names for charm OCI resources
         if: ${{ always() && env.CHARM_NAME != 'UNKNOWN' && !cancelled() }}
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ${{ env.CHARM_DIR }}
         run: |
           echo "$(echo '${{ needs.all-images.outputs.images }}' | jq -cr '.[]')" > ${{ env.CHARM_NAME }}-images
 
@@ -301,7 +305,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CHARM_NAME }}-images
-          path: ${{ inputs.working-directory }}/${{ env.CHARM_NAME }}-images
+          path: ${{ env.CHARM_DIR }}/${{ env.CHARM_NAME }}-images
           if-no-files-found: error
           overwrite: true
 

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -281,6 +281,8 @@ jobs:
       - name: Pack charm
         if: ${{ env.CHARM_NAME != 'UNKNOWN' && !cancelled() }}
         working-directory: ${{ env.CHARM_DIR }}
+        env:
+          CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
         run: |
           charmcraft pack -v
           echo "CHARM_FILE=$(ls $CHARM_NAME_*.charm || echo UNKNOWN)" >> $GITHUB_ENV

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -47,6 +47,14 @@ on:
         description: Actions operator provider as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: microk8s
+      rockcraft-ref:
+        description: Used in conjunction with rockcraft_repo to pull and build rockcraft from source instead of using snapstore version.
+        type: string
+        default: ""
+      rockcraft-repository:
+        description: Pull and build rockcraft from source instead of using snapstore version.
+        type: string
+        default: ""
       microk8s-addons:
         description: Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.
         type: string
@@ -168,6 +176,8 @@ jobs:
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       trivy-image-config: ${{ inputs.trivy-image-config }}
       working-directory: ${{ inputs.working-directory }}
+      rockcraft-repository: ${{ inputs.rockcraft-repository }}
+      rockcraft-ref: ${{ inputs.rockcraft-ref }}
   all-images:
     name: Get rocks or Docker images
     needs: [build-images, build-rocks]

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -6,6 +6,14 @@ name: Integration tests
 on:
   workflow_call:
     inputs:
+      charmcraft-ref:
+        description: Used in conjunction with charmcraft-repository to pull and build charmcraft from source instead of using snapstore version.
+        type: string
+        default: ""
+      charmcraft-repository:
+        description: Pull and build charmcraft from source instead of using snapstore version.
+        type: string
+        default: ""
       channel:
         description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
@@ -48,7 +56,7 @@ on:
         type: string
         default: microk8s
       rockcraft-ref:
-        description: Used in conjunction with rockcraft_repo to pull and build rockcraft from source instead of using snapstore version.
+        description: Used in conjunction with rockcraft-repository to pull and build rockcraft from source instead of using snapstore version.
         type: string
         default: ""
       rockcraft-repository:
@@ -180,7 +188,7 @@ jobs:
       rockcraft-ref: ${{ inputs.rockcraft-ref }}
   all-images:
     name: Get rocks or Docker images
-    needs: [build-images, build-rocks]
+    needs: [ build-images, build-rocks ]
     runs-on: ubuntu-latest
     outputs:
       images: ${{ env.IMAGES }}
@@ -200,8 +208,63 @@ jobs:
     outputs:
       charm-file: ${{ env.CHARM_FILE }}
     steps:
-      - uses: actions/checkout@v4.1.1
       - uses: canonical/setup-lxd@v0.1.1
+
+      - uses: actions/checkout@v4
+        if: inputs.charmcraft-repository != ''
+        with:
+          repository: ${{ inputs.charmcraft-repository }}
+          ref: ${{ inputs.charmcraft-ref }}
+          path: ./charmcraft
+          fetch-depth: 0
+
+      - name: Get Charmcraft SHA
+        if: inputs.charmcraft-repository != ''
+        id: charmcraft-sha
+        working-directory: ./charmcraft
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Restore Charmcraft Cache
+        if: inputs.charmcraft-repository != ''
+        id: restore-charmcraft
+        uses: actions/cache/restore@v4
+        with:
+          path: ./charmcraft*.snap
+          key: charmcraft-${{ steps.charmcraft-sha.outputs.sha }}
+
+      - name: Install Snapcraft
+        if: steps.restore-charmcraft.outputs.cache-hit != 'true' && inputs.charmcraft-repository != ''
+        run: sudo snap install snapcraft --classic
+
+      - name: Build Charmcraft
+        if: steps.restore-charmcraft.outputs.cache-hit != 'true' && inputs.charmcraft-repository != ''
+        working-directory: ./charmcraft
+        run: |
+          snapcraft --use-lxd
+          cp charmcraft*.snap ../
+
+      - name: Save Charmcraft Cache
+        uses: actions/cache/save@v4
+        if: steps.restore-charmcraft.outputs.cache-hit != 'true' && inputs.charmcraft-repository != ''
+        with:
+          path: ./charmcraft*.snap
+          key: ${{ steps.restore-charmcraft.outputs.cache-primary-key }}
+
+      - name: Install charmcraft
+        if: inputs.charmcraft-repository != ''
+        run: sudo snap install --dangerous --classic charmcraft*.snap
+
+      - name: Clean up
+        if: inputs.charmcraft-repository != ''
+        run: rm -rf *
+
+      - name: Install charmcraft
+        if: inputs.charmcraft-repository == ''
+        run: |
+          sudo snap install charmcraft --classic --channel latest/stable
+
+      - uses: actions/checkout@v4.1.1
+
       - name: Extract charm name
         working-directory: ${{ inputs.working-directory }}
         run: |
@@ -210,13 +273,14 @@ jobs:
             CHARM_NAME="$([ -f charmcraft.yaml ] && yq '.name' charmcraft.yaml || echo UNKNOWN)"
           fi
           echo "CHARM_NAME=$CHARM_NAME">> $GITHUB_ENV
+
       - name: Pack charm
         if: ${{ env.CHARM_NAME != 'UNKNOWN' && !cancelled() }}
         working-directory: ${{ inputs.working-directory }}
         run: |
-          sudo snap install charmcraft --classic --channel latest/stable
           charmcraft pack -v
           echo "CHARM_FILE=$(ls $CHARM_NAME_*.charm || echo UNKNOWN)" >> $GITHUB_ENV
+
       - name: Upload charm artifact
         if: ${{ !contains(fromJson('["", "UNKNOWN"]'), env.CHARM_FILE) && !cancelled() }}
         uses: actions/upload-artifact@v4
@@ -225,11 +289,13 @@ jobs:
           path: ${{ inputs.working-directory }}/${{ env.CHARM_FILE }}
           if-no-files-found: error
           overwrite: true
+
       - name: Save image names for charm OCI resources
         if: ${{ always() && env.CHARM_NAME != 'UNKNOWN' && !cancelled() }}
         working-directory: ${{ inputs.working-directory }}
         run: |
           echo "$(echo '${{ needs.all-images.outputs.images }}' | jq -cr '.[]')" > ${{ env.CHARM_NAME }}-images
+
       - name: Upload image artifact
         if: ${{ always() && env.CHARM_NAME != 'UNKNOWN' && !cancelled() }}
         uses: actions/upload-artifact@v4
@@ -242,10 +308,12 @@ jobs:
   integration-test:
     name: Integration tests
     uses: ./.github/workflows/integration_test_run.yaml
-    needs: [all-images, build-charm, get-runner-image]
+    needs: [ all-images, build-charm, get-runner-image ]
     if: ${{ !failure() }}
     secrets: inherit
     with:
+      charmcraft-repository: ${{ inputs.charmcraft-repository }}
+      charmcraft-ref: ${{ inputs.charmcraft-ref }}
       channel: ${{ inputs.channel }}
       charm-file: ${{ needs.build-charm.outputs.charm-file }}
       extra-arguments: ${{ inputs.extra-arguments }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -6,6 +6,14 @@ name: Run integration tests
 on:
   workflow_call:
     inputs:
+      charmcraft-ref:
+        description: Used in conjunction with charmcraft-repository to pull and build charmcraft from source instead of using snapstore version.
+        type: string
+        default: ""
+      charmcraft-repository:
+        description: Pull and build charmcraft from source instead of using snapstore version.
+        type: string
+        default: ""
       channel:
         description: Actions operator provider channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
@@ -158,6 +166,53 @@ jobs:
       }}
     if: ${{ !failure() }}
     steps:
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: ${{ inputs.provider }}
+          microk8s-addons: ${{ inputs.microk8s-addons }}
+          channel: ${{ inputs.channel }}
+          juju-channel: ${{ inputs.juju-channel }}
+      - uses: actions/checkout@v4
+        if: inputs.charmcraft-repository != ''
+        with:
+          repository: ${{ inputs.charmcraft-repository }}
+          ref: ${{ inputs.charmcraft-ref }}
+          path: ./charmcraft
+          fetch-depth: 0
+      - name: Get Charmcraft SHA
+        if: inputs.charmcraft-repository != ''
+        id: charmcraft-sha
+        working-directory: ./charmcraft
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - name: Restore Charmcraft Cache
+        if: inputs.charmcraft-repository != ''
+        id: restore-charmcraft
+        uses: actions/cache/restore@v4
+        with:
+          path: ./charmcraft*.snap
+          key: charmcraft-${{ steps.charmcraft-sha.outputs.sha }}
+      - name: Install Snapcraft
+        if: steps.restore-charmcraft.outputs.cache-hit != 'true' && inputs.charmcraft-repository != ''
+        run: sudo snap install snapcraft --classic
+      - name: Build Charmcraft
+        if: steps.restore-charmcraft.outputs.cache-hit != 'true' && inputs.charmcraft-repository != ''
+        working-directory: ./charmcraft
+        run: |
+          snapcraft --use-lxd
+          cp charmcraft*.snap ../
+      - name: Save Charmcraft Cache
+        uses: actions/cache/save@v4
+        if: steps.restore-charmcraft.outputs.cache-hit != 'true' && inputs.charmcraft-repository != ''
+        with:
+          path: ./charmcraft*.snap
+          key: ${{ steps.restore-charmcraft.outputs.cache-primary-key }}
+      - name: Install charmcraft
+        if: inputs.charmcraft-repository != ''
+        run: sudo snap install --dangerous --classic charmcraft*.snap
+      - name: Clean up
+        if: inputs.charmcraft-repository != ''
+        run: rm -rf *
       - uses: actions/checkout@v4.1.1
       - name: Remove Android SDK
         run: sudo rm -rf /usr/local/lib/android
@@ -168,13 +223,6 @@ jobs:
       - name: Create OpenStack credential file
         working-directory: ${{ inputs.working-directory }}
         run: echo "${{ steps.setup-devstack-swift.outputs.credentials }}" > openrc
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: ${{ inputs.provider }}
-          microk8s-addons: ${{ inputs.microk8s-addons }}
-          channel: ${{ inputs.channel }}
-          juju-channel: ${{ inputs.juju-channel }}
       - name: Configure GHCR in microk8s
         if: ${{ inputs.provider == 'microk8s' }}
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,9 @@ on:
         type: string
         description: The working directory for jobs
         default: "./"
+      shellcheck-working-directory:
+        type: string
+        description: The working directory for the shellcheck-lint job
       self-hosted-runner:
         type: boolean
         description: Whether to use self-hosted runners to run the jobs.
@@ -86,7 +89,7 @@ jobs:
       }}
     defaults:
       run:
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ${{ inputs.shellcheck-working-directory || inputs.working-directory }}
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Gather files to scan

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,9 @@ name: Tests
 on:
   workflow_call:
     inputs:
+      docs-working-directory:
+        type: string
+        description: The working directory for the docs
       working-directory:
         type: string
         description: The working directory for jobs
@@ -334,7 +337,7 @@ jobs:
       }}
     defaults:
       run:
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ${{ inputs.docs-working-directory || inputs.working-directory }}
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Search for docs folder


### PR DESCRIPTION
Add the `rockcraft-repository` and `rockcraft-ref` options to the integration workflow to pull and build rockcraft from that specific source, and use the rockcraft built from source to build rocks in the integration tests. This is to enable the development of some experimental features in rockcraft that are not available in the snap store version of rockcraft.

Also, remove the rockcraft cache system, as the adoption has not been very great, and considering the risk of creating stalled rock images if the cache is enabled. Perhaps we will have an improved cache system in the future.