### PR TITLE
Follow up add timeout to integration_test.yaml

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -83,6 +83,10 @@ on:
         description: Use setup-devstack-swift action to prepare a swift server for testing.
         type: boolean
         default: false
+      test-timeout:
+        description: Timeout in minutes for the integration test.
+        type: number
+        default: 360
       test-tox-env:
         description: The tox environment name for the integration test.
         type: string
@@ -339,6 +343,7 @@ jobs:
       self-hosted-runner-label: ${{ inputs.self-hosted-runner-label }}
       series: ${{ inputs.series }}
       setup-devstack-swift: ${{ inputs.setup-devstack-swift }}
+      test-timeout: ${{ inputs.test-timeout }}
       test-tox-env: ${{ inputs.test-tox-env }}
       tmate-debug: ${{ inputs.tmate-debug }}
       tmate-timeout: ${{ inputs.tmate-timeout }}


### PR DESCRIPTION
## Description 
This PR is a follow-up to https://github.com/canonical/operator-workflows/pull/267.

We also need to pass the test-timeout input in `integration_test.yaml` so that it can get set in `integration_test_run.yaml`.

@addyess @jdkandersson @cbartz
