### PR TITLE
Promote charms from various working-directories and optional doc-working-directory

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -6,20 +6,27 @@ name: Promote charm
 on:
   workflow_call:
     inputs:
-      origin-channel:
-        type: string
-        description: 'Origin Channel'
-      destination-channel:
-        type: string
-        description: 'Destination Channel'
       base-architecture:
         type: string
         description: 'Charmcraft Base Architecture'
         default: 'amd64'
+      destination-channel:
+        type: string
+        description: 'Destination Channel'
       doc-automation-disabled:
         type: boolean
         description: 'Whether to disable the documentation automation'
         default: true
+      docs-working-directory:
+        type: string
+        description: The working directory for the docs
+      origin-channel:
+        type: string
+        description: 'Origin Channel'
+      working-directory:
+        type: string
+        description: The working directory for jobs
+        default: "./"
 
 jobs:
   get-runner-image:
@@ -49,6 +56,7 @@ jobs:
         uses: canonical/charming-actions/release-charm@2.5.0-rc
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
+          charm-path: ${{ inputs.working-directory }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ inputs.origin-channel }}
           destination-channel: ${{ inputs.destination-channel }}
@@ -58,6 +66,9 @@ jobs:
   draft-publish-docs:
     name: Draft publish docs
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: ${{ inputs.docs-working-directory || inputs.working-directory }}
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Search for docs folder
@@ -76,6 +87,9 @@ jobs:
     if: ${{ github.event.inputs.destination-channel }} == 'latest/stable'
     name: Publish docs
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: ${{ inputs.docs-working-directory || inputs.working-directory }}
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Search for docs folder

--- a/README.md
+++ b/README.md
@@ -115,10 +115,12 @@ The following parameters are available for this workflow:
 
 | Name | Type | Default | Description |
 |--------------------|----------|--------------------|-------------------|
+| base-architecture | string | amd64 | Charm architecture |
 | destination-channel | string | "" | Destination channel |
-| origin-channel | string | "" | Origin channel |
-| architecture | string | amd64 | Charm architecture |
 | doc-automation-disabled | boolean | true | Whether the documentation automation is disabled |
+| doc-working-directory | string | Null | The working directory for the docs |
+| origin-channel | string | "" | Origin channel |
+| working-directory | string | "./" | The working directory for the job |
 
 The runner image will be set to the value of `bases[0].build-on[0]` in the `charmcraft.yaml` file, defaulting to ubuntu-22.04 if the file does not exist.
 


### PR DESCRIPTION
### Overview

Similar to charm testing, charm promotion should support a working-directory for when the repo supports multiple charms and it should support an optional docs-working-directory in the event the charm docs aren't in the same folder path

### Workflow Changes

* New Optional arguments to the `promote_charm` workflow.
* Alphabetize the arguments
* Updated README

### Checklist

- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

