### PR TITLE
Allow to specify channel for {charm,rock}craft installation

### DIFF
--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -131,6 +131,10 @@ jobs:
       - name: Install Rockcraft
         if: inputs.rockcraft-repository != ''
         run: sudo snap install --dangerous --classic rockcraft*.snap
+      - name: Install rockcraft
+        if: inputs.rockcraft-repository == ''
+        run: |
+          sudo snap install rockcraft --classic --channel ${{ inputs.rockcraft-channel }}
       - name: Cleanup Rockcraft
         if: inputs.rockcraft-repository != ''
         run: rm -rf rockcraft*
@@ -150,10 +154,6 @@ jobs:
           echo "IMAGE_BUILD_BASE=$IMAGE_BUILD_BASE" >> $GITHUB_ENV
           echo "IMAGE_REF=$IMAGE_REF" >> $GITHUB_ENV
           echo "ROCKCRAFT_CONTAINER_NAME=$ROCKCRAFT_CONTAINER_NAME" >> $GITHUB_ENV
-      - name: Install rockcraft
-        if: inputs.rockcraft-repository == ''
-        run: |
-          sudo snap install rockcraft --classic --channel ${{ inputs.charmcraft-channel }}
       - name: Build rock
         env:
           ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -25,6 +25,10 @@ on:
         type: string
         description: The working directory for jobs
         default: "./"
+      rockcraft-channel:
+        type: string
+        description: Rockcraft channel to use for the integration test
+        default: "latest/stable"
       rockcraft-ref:
         description: Used in conjunction with rockcraft-repository to pull and build rockcraft from source instead of using snapstore version.
         type: string
@@ -146,13 +150,11 @@ jobs:
           echo "IMAGE_BUILD_BASE=$IMAGE_BUILD_BASE" >> $GITHUB_ENV
           echo "IMAGE_REF=$IMAGE_REF" >> $GITHUB_ENV
           echo "ROCKCRAFT_CONTAINER_NAME=$ROCKCRAFT_CONTAINER_NAME" >> $GITHUB_ENV
-      - name: Build rock
+      - name: Install rockcraft
         if: inputs.rockcraft-repository == ''
-        uses: canonical/craft-actions/rockcraft-pack@main
-        with:
-          path: ${{ matrix.path }}
+        run: |
+          sudo snap install rockcraft --classic --channel ${{ inputs.charmcraft-channel }}
       - name: Build rock
-        if: inputs.rockcraft-repository != ''
         env:
           ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
         working-directory: ${{ matrix.path }}

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -159,9 +159,6 @@ jobs:
           ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
         working-directory: ${{ matrix.path }}
         run: rockcraft pack --verbosity trace
-      - name: Tmate
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
       - name: Upload rock to ghcr.io
         if: steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save'
         run: |

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -34,7 +34,7 @@ on:
         type: string
         default: ""
       rockcraft-repository:
-        description: Pull and build rockcraft from source instead of using snapstore version.
+        description: Pull and build rockcraft from source instead of using snapstore version (this means that the rockcraft-channel input will be ignored).
         type: string
         default: ""
     outputs:

--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -159,6 +159,9 @@ jobs:
           ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
         working-directory: ${{ matrix.path }}
         run: rockcraft pack --verbosity trace
+      - name: Tmate
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
       - name: Upload rock to ghcr.io
         if: steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save'
         run: |

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -196,9 +196,9 @@ jobs:
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       trivy-image-config: ${{ inputs.trivy-image-config }}
       working-directory: ${{ inputs.working-directory }}
+      rockcraft-channel: ${{ inputs.rockcraft-channel }}
       rockcraft-repository: ${{ inputs.rockcraft-repository }}
       rockcraft-ref: ${{ inputs.rockcraft-ref }}
-      rockcraft-channel: ${{ inputs.rockcraft-channel }}
   all-images:
     name: Get rocks or Docker images
     needs: [ build-images, build-rocks ]

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -15,7 +15,7 @@ on:
         type: string
         default: ""
       charmcraft-repository:
-        description: Pull and build charmcraft from source instead of using snapstore version.
+        description: Pull and build charmcraft from source instead of using snapstore version (this means that the `charmcraft-channel` input will be ignored).
         type: string
         default: ""
       channel:
@@ -68,7 +68,7 @@ on:
         type: string
         default: ""
       rockcraft-repository:
-        description: Pull and build rockcraft from source instead of using snapstore version.
+        description: Pull and build rockcraft from source instead of using snapstore version (this means that the rockcraft-channel input will be ignored).
         type: string
         default: ""
       microk8s-addons:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -6,6 +6,10 @@ name: Integration tests
 on:
   workflow_call:
     inputs:
+      charmcraft-channel:
+        description: Charmcraft channel to use for the integration test
+        type: string
+        default: latest/stable
       charmcraft-ref:
         description: Used in conjunction with charmcraft-repository to pull and build charmcraft from source instead of using snapstore version.
         type: string
@@ -55,6 +59,10 @@ on:
         description: Actions operator provider as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: microk8s
+      rockcraft-channel:
+        description: Rockcraft channel to use for the integration test
+        type: string
+        default: latest/stable
       rockcraft-ref:
         description: Used in conjunction with rockcraft-repository to pull and build rockcraft from source instead of using snapstore version.
         type: string
@@ -190,6 +198,7 @@ jobs:
       working-directory: ${{ inputs.working-directory }}
       rockcraft-repository: ${{ inputs.rockcraft-repository }}
       rockcraft-ref: ${{ inputs.rockcraft-ref }}
+      rockcraft-channel: ${{ inputs.rockcraft-channel }}
   all-images:
     name: Get rocks or Docker images
     needs: [ build-images, build-rocks ]
@@ -265,7 +274,7 @@ jobs:
       - name: Install charmcraft
         if: inputs.charmcraft-repository == ''
         run: |
-          sudo snap install charmcraft --classic --channel latest/stable
+          sudo snap install charmcraft --classic --channel ${{ inputs.charmcraft-channel }}
 
       - uses: actions/checkout@v4.1.1
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following workflows are available:
 |--------------------|----------|--------------------|-------------------|
 | charmcraft-channel       | string | latest/stable | Charmcraft channel to use for the integration test |
 | charmcraft-ref           | string | "" | Used in conjunction with charmcraft-repository to pull and build charmcraft from source instead of using snapstore version. |
-| charmcraft-repository    | string | "" | Pull and build charmcraft from source instead of using snapstore version. |
+| charmcraft-repository    | string | "" | Pull and build charmcraft from source instead of using snapstore version (this means that the `charmcraft-channel` input will be ignored). |
 | channel | string | latest/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
 | extra-arguments | string | "" | Additional arguments to pass to the integration test execution |
 | extra-test-matrix | string | '{}' | Additional test matrices to run the integration test combinations |
@@ -41,7 +41,7 @@ The following workflows are available:
 | microk8s-addons | string | "dns ingress rbac storage" | Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled. |
 | rockcraft-channel        | string | latest/stable | Rockcraft channel to use for the integration test |
 | rockcraft-ref            | string | "" | Used in conjunction with rockcraft-repository to pull and build rockcraft from source instead of using snapstore version. |
-| rockcraft-repository     | string | "" | Pull and build rockcraft from source instead of using snapstore version. |
+| rockcraft-repository     | string | "" | Pull and build rockcraft from source instead of using snapstore version (this means that the `rockcraft-channel` input will be ignored). |
 | self-hosted-runner| bool | false | Whether to use self-hosted runner for tests. |
 | self-hosted-runner-label | string | large | Label to filter the self-hosted runner, if the self-hosted runners are used. |
 | series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ The following workflows are available:
 * integration_test: Builds the existing Dockerfiles, if any, and executes the `integration` test target defined in the `tox.ini` file. The tox environment used can be changed with the `test-tox-env` input. The following parameters are available for this workflow:
 
 | Name                     | Type | Default | Description                                                                                                                                       |
-|--------------------------|----------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+|--------------------------|----------|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
 | charmcraft-channel       | string | latest/stable | Charmcraft channel to use for the integration test                                                                                                |
+| charmcraft-ref           | string | "" | Used in conjunction with charmcraft-repository to pull and build charmcraft from source instead of using snapstore version.                       |
+| charmcraft-repository    | string | "" | Pull and build charmcraft from source instead of using snapstore version.                                                                         |
 | channel                  | string | latest/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage)                                         |
 | extra-arguments          | string | "" | Additional arguments to pass to the integration test execution                                                                                    |
 | extra-test-matrix        | string | '{}' | Additional test matrices to run the integration test combinations                                                                                 |
@@ -38,6 +40,8 @@ The following workflows are available:
 | provider                 | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage)                                         |
 | microk8s-addons          | string | "dns ingress rbac storage" | Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.                                                       |
 | rockcraft-channel        | string | latest/stable | Rockcraft channel to use for the integration test                                                                                                 |
+| rockcraft-ref            | string | "" | Used in conjunction with rockcraft-repository to pull and build rockcraft from source instead of using snapstore version.                         |
+| rockcraft-repository     | string | "" | Pull and build rockcraft from source instead of using snapstore version.                                                                          |
 | self-hosted-runner       | bool | false | Whether to use self-hosted runner for tests.                                                                                                      |
 | self-hosted-runner-label | string | large | Label to filter the self-hosted runner, if the self-hosted runners are used.                                                                      |
 | series                   | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |

--- a/README.md
+++ b/README.md
@@ -23,41 +23,43 @@ The following workflows are available:
 
 * integration_test: Builds the existing Dockerfiles, if any, and executes the `integration` test target defined in the `tox.ini` file. The tox environment used can be changed with the `test-tox-env` input. The following parameters are available for this workflow:
 
-| Name | Type | Default | Description |
-|--------------------|----------|--------------------|-------------------|
-| channel | string | latest/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
-| extra-arguments | string | "" | Additional arguments to pass to the integration test execution |
-| extra-test-matrix | string | '{}' | Additional test matrices to run the integration test combinations |
-| image-build-args | string | "" | List of build args to pass to the build image job |
-| juju-channel | string | 2.9/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
-| load-test-enabled | bool | false | Whether load testing is enabled. If enabled, k6 will expect a load_tests/load-test.js file with the tests to run. |
-| load-test-run-args | string | "" | Command line arguments for the load test execution. |
-| modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |
-| pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
-| provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
-| microk8s-addons | string | "dns ingress rbac storage" | Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled. |
-| self-hosted-runner| bool | false | Whether to use self-hosted runner for tests. |
-| self-hosted-runner-label | string | large | Label to filter the self-hosted runner, if the self-hosted runners are used. |
-| series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
-| setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for testing. |
-| test-timeout | number | 360 | The timeout in minutes for the integration test |
-| test-tox-env | string | "integration" | The tox environment name for the integration test. |
-| tmate-debug | bool | false | Enable tmate debugging after integration test failure. |
-| tmate-timeout | number | 30 | Timeout in minutes to keep tmate debugging session. |
-| trivy-fs-config | string | "" | Trivy YAML configuration for fs type |
-| trivy-fs-enabled | boolean | false | Whether Trivy testing of type fs is enabled |
-| trivy-fs-ref | string | "." | Target directory to do the Trivy testing |
-| trivy-image-config | string | "" | Trivy YAML configuration for image type |
-| working-directory | string | "./" | Custom working directory for jobs to run on |
-| zap-auth-header | string | "" | If this is defined then its value will be added as a header to all of the ZAP requests |
-| zap-auth-header-value | string | "" | If this is defined then its value will be used as the header name to all of the ZAP requests |
-| zap-before-command | string | "" | Command to run before ZAP testing |
-| zap-cmd-options | string | "-T 60" | Options to be used by ZAP. Default sets maximum scanning time to 60 minutes |
-| zap-enabled | boolean | false | Whether ZAP testing is enabled |
-| zap-target | string | "" | If this is not set, the unit IP address will be used as ZAP target |
-| zap-target-protocol | string | "http" | ZAP target protocol |
-| zap-target-port | string | 80 | ZAP target port |
-| zap-rules-file-name | string | "" | Rules file to ignore any alerts from the ZAP scan |
+| Name                     | Type | Default | Description                                                                                                                                       |
+|--------------------------|----------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| charmcraft-channel       | string | latest/stable | Charmcraft channel to use for the integration test                                                                                                |
+| channel                  | string | latest/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage)                                         |
+| extra-arguments          | string | "" | Additional arguments to pass to the integration test execution                                                                                    |
+| extra-test-matrix        | string | '{}' | Additional test matrices to run the integration test combinations                                                                                 |
+| image-build-args         | string | "" | List of build args to pass to the build image job                                                                                                 |
+| juju-channel             | string | 2.9/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage)                                         |
+| load-test-enabled        | bool | false | Whether load testing is enabled. If enabled, k6 will expect a load_tests/load-test.js file with the tests to run.                                 |
+| load-test-run-args       | string | "" | Command line arguments for the load test execution.                                                                                               |
+| modules                  | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument        |
+| pre-run-script           | string | "" | Path to the bash script to be run before the integration tests                                                                                    |
+| provider                 | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage)                                         |
+| microk8s-addons          | string | "dns ingress rbac storage" | Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.                                                       |
+| rockcraft-channel        | string | latest/stable | Rockcraft channel to use for the integration test                                                                                                 |
+| self-hosted-runner       | bool | false | Whether to use self-hosted runner for tests.                                                                                                      |
+| self-hosted-runner-label | string | large | Label to filter the self-hosted runner, if the self-hosted runners are used.                                                                      |
+| series                   | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
+| setup-devstack-swift     | bool | false | Use setup-devstack-swift action to prepare a swift server for testing.                                                                            |
+| test-timeout             | number | 360 | The timeout in minutes for the integration test                                                                                                   |
+| test-tox-env             | string | "integration" | The tox environment name for the integration test.                                                                                                |
+| tmate-debug              | bool | false | Enable tmate debugging after integration test failure.                                                                                            |
+| tmate-timeout            | number | 30 | Timeout in minutes to keep tmate debugging session.                                                                                               |
+| trivy-fs-config          | string | "" | Trivy YAML configuration for fs type                                                                                                              |
+| trivy-fs-enabled         | boolean | false | Whether Trivy testing of type fs is enabled                                                                                                       |
+| trivy-fs-ref             | string | "." | Target directory to do the Trivy testing                                                                                                          |
+| trivy-image-config       | string | "" | Trivy YAML configuration for image type                                                                                                           |
+| working-directory        | string | "./" | Custom working directory for jobs to run on                                                                                                       |
+| zap-auth-header          | string | "" | If this is defined then its value will be added as a header to all of the ZAP requests                                                            |
+| zap-auth-header-value    | string | "" | If this is defined then its value will be used as the header name to all of the ZAP requests                                                      |
+| zap-before-command       | string | "" | Command to run before ZAP testing                                                                                                                 |
+| zap-cmd-options          | string | "-T 60" | Options to be used by ZAP. Default sets maximum scanning time to 60 minutes                                                                       |
+| zap-enabled              | boolean | false | Whether ZAP testing is enabled                                                                                                                    |
+| zap-target               | string | "" | If this is not set, the unit IP address will be used as ZAP target                                                                                |
+| zap-target-protocol      | string | "http" | ZAP target protocol                                                                                                                               |
+| zap-target-port          | string | 80 | ZAP target port                                                                                                                                   |
+| zap-rules-file-name      | string | "" | Rules file to ignore any alerts from the ZAP scan                                                                                                 |
 
 More information about OWASP ZAP testing can be found [here](OWASPZAP.md).
 

--- a/README.md
+++ b/README.md
@@ -23,47 +23,47 @@ The following workflows are available:
 
 * integration_test: Builds the existing Dockerfiles, if any, and executes the `integration` test target defined in the `tox.ini` file. The tox environment used can be changed with the `test-tox-env` input. The following parameters are available for this workflow:
 
-| Name                     | Type | Default | Description                                                                                                                                       |
-|--------------------------|----------|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| charmcraft-channel       | string | latest/stable | Charmcraft channel to use for the integration test                                                                                                |
-| charmcraft-ref           | string | "" | Used in conjunction with charmcraft-repository to pull and build charmcraft from source instead of using snapstore version.                       |
-| charmcraft-repository    | string | "" | Pull and build charmcraft from source instead of using snapstore version.                                                                         |
-| channel                  | string | latest/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage)                                         |
-| extra-arguments          | string | "" | Additional arguments to pass to the integration test execution                                                                                    |
-| extra-test-matrix        | string | '{}' | Additional test matrices to run the integration test combinations                                                                                 |
-| image-build-args         | string | "" | List of build args to pass to the build image job                                                                                                 |
-| juju-channel             | string | 2.9/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage)                                         |
-| load-test-enabled        | bool | false | Whether load testing is enabled. If enabled, k6 will expect a load_tests/load-test.js file with the tests to run.                                 |
-| load-test-run-args       | string | "" | Command line arguments for the load test execution.                                                                                               |
-| modules                  | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument        |
-| pre-run-script           | string | "" | Path to the bash script to be run before the integration tests                                                                                    |
-| provider                 | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage)                                         |
-| microk8s-addons          | string | "dns ingress rbac storage" | Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.                                                       |
-| rockcraft-channel        | string | latest/stable | Rockcraft channel to use for the integration test                                                                                                 |
-| rockcraft-ref            | string | "" | Used in conjunction with rockcraft-repository to pull and build rockcraft from source instead of using snapstore version.                         |
-| rockcraft-repository     | string | "" | Pull and build rockcraft from source instead of using snapstore version.                                                                          |
-| self-hosted-runner       | bool | false | Whether to use self-hosted runner for tests.                                                                                                      |
-| self-hosted-runner-label | string | large | Label to filter the self-hosted runner, if the self-hosted runners are used.                                                                      |
-| series                   | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
-| setup-devstack-swift     | bool | false | Use setup-devstack-swift action to prepare a swift server for testing.                                                                            |
-| test-timeout             | number | 360 | The timeout in minutes for the integration test                                                                                                   |
-| test-tox-env             | string | "integration" | The tox environment name for the integration test.                                                                                                |
-| tmate-debug              | bool | false | Enable tmate debugging after integration test failure.                                                                                            |
-| tmate-timeout            | number | 30 | Timeout in minutes to keep tmate debugging session.                                                                                               |
-| trivy-fs-config          | string | "" | Trivy YAML configuration for fs type                                                                                                              |
-| trivy-fs-enabled         | boolean | false | Whether Trivy testing of type fs is enabled                                                                                                       |
-| trivy-fs-ref             | string | "." | Target directory to do the Trivy testing                                                                                                          |
-| trivy-image-config       | string | "" | Trivy YAML configuration for image type                                                                                                           |
-| working-directory        | string | "./" | Custom working directory for jobs to run on                                                                                                       |
-| zap-auth-header          | string | "" | If this is defined then its value will be added as a header to all of the ZAP requests                                                            |
-| zap-auth-header-value    | string | "" | If this is defined then its value will be used as the header name to all of the ZAP requests                                                      |
-| zap-before-command       | string | "" | Command to run before ZAP testing                                                                                                                 |
-| zap-cmd-options          | string | "-T 60" | Options to be used by ZAP. Default sets maximum scanning time to 60 minutes                                                                       |
-| zap-enabled              | boolean | false | Whether ZAP testing is enabled                                                                                                                    |
-| zap-target               | string | "" | If this is not set, the unit IP address will be used as ZAP target                                                                                |
-| zap-target-protocol      | string | "http" | ZAP target protocol                                                                                                                               |
-| zap-target-port          | string | 80 | ZAP target port                                                                                                                                   |
-| zap-rules-file-name      | string | "" | Rules file to ignore any alerts from the ZAP scan                                                                                                 |
+| Name | Type | Default | Description |
+|--------------------|----------|--------------------|-------------------|
+| charmcraft-channel       | string | latest/stable | Charmcraft channel to use for the integration test |
+| charmcraft-ref           | string | "" | Used in conjunction with charmcraft-repository to pull and build charmcraft from source instead of using snapstore version. |
+| charmcraft-repository    | string | "" | Pull and build charmcraft from source instead of using snapstore version. |
+| channel | string | latest/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| extra-arguments | string | "" | Additional arguments to pass to the integration test execution |
+| extra-test-matrix | string | '{}' | Additional test matrices to run the integration test combinations |
+| image-build-args | string | "" | List of build args to pass to the build image job |
+| juju-channel | string | 2.9/stable | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| load-test-enabled | bool | false | Whether load testing is enabled. If enabled, k6 will expect a load_tests/load-test.js file with the tests to run. |
+| load-test-run-args | string | "" | Command line arguments for the load test execution. |
+| modules | string | '[""]' | List of modules to run in parallel in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument |
+| pre-run-script | string | "" | Path to the bash script to be run before the integration tests |
+| provider | string | microk8s | Actions operator provider as defined [here](https://github.com/charmed-kubernetes/actions-operator#usage) |
+| microk8s-addons | string | "dns ingress rbac storage" | Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled. |
+| rockcraft-channel        | string | latest/stable | Rockcraft channel to use for the integration test |
+| rockcraft-ref            | string | "" | Used in conjunction with rockcraft-repository to pull and build rockcraft from source instead of using snapstore version. |
+| rockcraft-repository     | string | "" | Pull and build rockcraft from source instead of using snapstore version. |
+| self-hosted-runner| bool | false | Whether to use self-hosted runner for tests. |
+| self-hosted-runner-label | string | large | Label to filter the self-hosted runner, if the self-hosted runners are used. |
+| series | string | '[""]' | List of series to run the tests in JSON format, i.e. '["jammy", "focal"]'. Each element will be passed to pytest through tox as --series argument |
+| setup-devstack-swift | bool | false | Use setup-devstack-swift action to prepare a swift server for testing. |
+| test-timeout | number | 360 | The timeout in minutes for the integration test |
+| test-tox-env | string | "integration" | The tox environment name for the integration test. |
+| tmate-debug | bool | false | Enable tmate debugging after integration test failure. |
+| tmate-timeout | number | 30 | Timeout in minutes to keep tmate debugging session. |
+| trivy-fs-config | string | "" | Trivy YAML configuration for fs type |
+| trivy-fs-enabled | boolean | false | Whether Trivy testing of type fs is enabled |
+| trivy-fs-ref | string | "." | Target directory to do the Trivy testing |
+| trivy-image-config | string | "" | Trivy YAML configuration for image type |
+| working-directory | string | "./" | Custom working directory for jobs to run on |
+| zap-auth-header | string | "" | If this is defined then its value will be added as a header to all of the ZAP requests |
+| zap-auth-header-value | string | "" | If this is defined then its value will be used as the header name to all of the ZAP requests |
+| zap-before-command | string | "" | Command to run before ZAP testing |
+| zap-cmd-options | string | "-T 60" | Options to be used by ZAP. Default sets maximum scanning time to 60 minutes |
+| zap-enabled | boolean | false | Whether ZAP testing is enabled |
+| zap-target | string | "" | If this is not set, the unit IP address will be used as ZAP target |
+| zap-target-protocol | string | "http" | ZAP target protocol |
+| zap-target-port | string | 80 | ZAP target port |
+| zap-rules-file-name | string | "" | Rules file to ignore any alerts from the ZAP scan |
 
 More information about OWASP ZAP testing can be found [here](OWASPZAP.md).
 


### PR DESCRIPTION
### Overview

Add inputs to specify channel for charmcraft/rockcraft installation.

Beyond that add missing input description for {charm,rock}craft-{ref,repo} inputs.

### Rationale

Some workflows (like the one for 12-factor charms) require the use of these *crafts from the edge channel instead of stable.

### Workflow Changes

`build_rocks` and `integration_test_run` is adapted to use the input

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->