### PR TITLE
Revert "Use the built-in Github token for publish wf (#278)"

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -45,7 +45,7 @@ jobs:
       - uses: octokit/request-action@v2.3.0
         id: get-branch-protection
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
         with:
           route: GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks
           repo: ${{ github.event.repository.name }}
@@ -160,7 +160,7 @@ jobs:
 
           echo "RUN_ID=$RUN_ID" >> $GITHUB_ENV
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
       - name: Get current run id
         if: ${{ github.event_name == 'pull_request' }}
         shell: bash  

--- a/README.md
+++ b/README.md
@@ -103,10 +103,7 @@ tmate can be run on failed tests either by setting the `tmate-debug` input to 't
 
 * publish_charm: Publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel).
 
-This workflow requires a `CHARMHUB_TOKEN` secret containing a charmhub token with package-manage and package-view permissions for the charm and the destination channel. See how to generate it [here](https://juju.is/docs/sdk/remote-env-auth).
-The workflow needs to read the main branch protection settings, commits and workflow runs of the repo.
-If the built-in [GitHub token permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) are too limited, a `REPO_ACCESS_TOKEN` secret containing a classic PAT with full repository permissions is required. See how to generate it [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
-
+This workflow requires a `CHARMHUB_TOKEN` secret containing a charmhub token with package-manage and package-view permissions for the charm and the destination channel. See how to generate it [here](https://juju.is/docs/sdk/remote-env-auth) and a `REPO_ACCESS_TOKEN` secret containg a classic PAT with full repository permissions. See how to generate it [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
 
 The following parameters are available for this workflow:
 


### PR DESCRIPTION
### Overview

This reverts the changes of https://github.com/canonical/operator-workflows/pull/278

### Rationale

Using built-in GH Token for checking branch protection is not possible https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#get-status-checks-protection


### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
