### PR TITLE
Add missing charm-directory in promote

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: canonical/charming-actions/release-charm@2.5.0-rc
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          charm-path: ${{ inputs.working-directory }}
+          charm-path: ${{ inputs.working-directory }}/${{ inputs.charm-directory }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           origin-channel: ${{ inputs.origin-channel }}
           destination-channel: ${{ inputs.destination-channel }}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

For paas-app-charmer apps, use `charm-directory` in the `canonical/charming-actions/release-charm` action.

### Rationale

Needed for paas-app-charmer apps to be released.
<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
