### PR TITLE
fix: rock from fork

### DIFF
--- a/.github/workflows/build_rocks.yaml
+++ b/.github/workflows/build_rocks.yaml
@@ -160,14 +160,39 @@ jobs:
         working-directory: ${{ matrix.path }}
         run: rockcraft pack --verbosity trace
       - name: Upload rock to ghcr.io
-        if: steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save'
+        if: ${{ !github.event.pull_request.head.repo.fork && (steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save') }}
         run: |
           skopeo --insecure-policy copy oci-archive:$(ls "${{ matrix.path }}"/*.rock) docker://$IMAGE_REF --dest-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}"
+      - name: Save rock as tar (fork)
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          image_name=$(yq .name "${{ matrix.path }}"/rockcraft.yaml)
+          skopeo --insecure-policy copy oci-archive:$(ls "${{ matrix.path }}"/*.rock) docker-daemon:${image_name}:test
+          docker save ${image_name}:test > ${image_name}.tar
+          echo "TAR_NAME=${IMAGE_NAME}.tar" >> $GITHUB_ENV
+      - name: Save rock tar to cache (fork)
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        id: save-rock-tar-cache
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.TAR_NAME }}
+          key: ${{ github.run_id }}
       - name: Run Github Trivy Image Action
+        if: ${{ !github.event.pull_request.head.repo.fork && (steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save') }}
         uses: aquasecurity/trivy-action@0.19.0
-        if: steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save'
         with:
           image-ref: ${{ env.IMAGE_REF }}
+          trivy-config: ${{ inputs.trivy-image-config }}
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Github Trivy Image Action (fork)
+        if: ${{ github.event.pull_request.head.repo.fork && (steps.rock-cache.outputs.cache-hit != 'true' || inputs.cache-action == 'save') }}
+        uses: aquasecurity/trivy-action@0.19.0
+        with:
+          input: ${{ env.TAR_NAME  }}
           trivy-config: ${{ inputs.trivy-image-config }}
           exit-code: '1'
           severity: 'CRITICAL,HIGH'
@@ -179,7 +204,11 @@ jobs:
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.46.0
           if [ -f ".trivyignore" ]
           then
-            output=$(trivy image $ROCK_IMAGE --severity HIGH,CRITICAL -q -f json --ignorefile "" | jq -r '.Results[].Vulnerabilities[].VulnerabilityID' 2>/dev/null || echo "No vulnerabilities found")
+            if [ ${{ !github.event.pull_request.head.repo.fork }} ]; then
+              output=$(trivy image $ROCK_IMAGE --severity HIGH,CRITICAL -q -f json --ignorefile "" | jq -r '.Results[].Vulnerabilities[].VulnerabilityID' 2>/dev/null || echo "No vulnerabilities found")
+            else
+              output=$(trivy image --input ${{ env.TAR_NAME  }} --severity HIGH,CRITICAL -q -f json --ignorefile "" | jq -r '.Results[].Vulnerabilities[].VulnerabilityID' 2>/dev/null || echo "No vulnerabilities found")
+            fi
             line=0
             while read CVE;
             do

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -254,7 +254,21 @@ jobs:
           path: ${{ inputs.working-directory }}
           pattern: '*-charm'
           merge-multiple: true
-
+      - name: Get fork cache path
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          for image in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
+            image_tar_name=$(echo $image | awk -F '/' '{print $(NF)}' | awk -F ":" '{print $1}')
+          done
+          echo "IMAGE_TAR=$image_tar_name" >> $GITHUB_ENV
+      - name: Restore rock from cache
+        id: cache-primes-restore
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.IMAGE_TAR }}.tar
+          key: ${{ github.run_id }}
+          fail-on-cache-miss: true
       - name: Integration tests variable setting
         working-directory: ${{ inputs.working-directory }}/${{ inputs.charm-directory }}
         run: |
@@ -265,9 +279,21 @@ jobs:
           echo "CHARM_NAME=$CHARM_NAME" >> $GITHUB_ENV
 
           args=""
-          for image in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
-            args="${args} --$(echo $image | awk -F '/' '{print $NF}' | cut -d ':' -f 1)-image ${image}"
-          done
+          if ${{ !github.event.pull_request.head.repo.fork }}; then
+            for image in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
+              args="${args} --$(echo $image | awk -F '/' '{print $NF}' | cut -d ':' -f 1)-image ${image}"
+            done
+          else
+            sudo microk8s enable registry
+            sudo microk8s status --wait-ready
+            for image in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
+              image_tar_name=$(echo $image | awk -F '/' '{print $(NF)}' | awk -F ":" '{print $1}')
+              sudo docker load --input ${image_tar_name}.tar
+              sudo docker image tag ${image_tar_name}:test localhost:32000/${image_tar_name}:test
+              sudo docker push localhost:32000/${image_tar_name}:test
+              args="${args} --$(echo $image | awk -F '/' '{print $NF}' | cut -d ':' -f 1)-image localhost:32000/${image_tar_name}:test"
+            done
+          fi
           charm_artifacts=(`find . -maxdepth 1 -name "*.charm"`)
           if [ ! -e ${{ inputs.charm-file }} ]; then
             args="${args} --charm-file=${{ inputs.charm-file }}"


### PR DESCRIPTION
Applicable spec: N/A

### Overview

GHCR does not allow rocks to be upload to ghcr.io from forks due to org permission settings (write).
This PR mitigates the use of upload-artefacts action on PRs from forks by using actions/cache, which do not require org write permissions.

**The release charm library depends on upload-artefacts. This PR explicitly creates a workaround to not use upload-artifacts action, hence the publish_charm workflow will fail.**

We should consider whether this should be refactored or the workaround should be accepted. 

[Passing workflow run from fork using this workflow example](https://github.com/canonical/jenkins-k8s-operator/actions/runs/8662300399/job/23754213813?pr=142).

TODO: Check whether the existing workflow works.

### Rationale

To allow PRs from forks to run.

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
