### PR TITLE
charmcraft-channel for upload-charm

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -306,6 +306,7 @@ jobs:
         uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           built-charm-path: ${{ env.CHARM_FILE }}
+          charmcraft-channel: ${{ inputs.charmcraft-channel }}
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           channel: ${{ inputs.channel }}

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -30,7 +30,7 @@ on:
         description: |
           Tag prefix, useful when bundling multiple charms in the same repo.
       charmcraft-channel:
-        description: Charmcraft channel to use for the integration test
+        description: Charmcraft channel to use for publishing the charm and resources
         type: string
         default: latest/stable
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The following parameters are available for this workflow:
 |---------------------------|--------|---------------|--------------------------------------------------------------------------------------------------|
 | channel                   | string | latest/edge   | Destination channel to push the charm to                                                         |
 | charm-directory   | string | Null          | The working directory for the charm under working-directory. docs directory, if existing, should be under this directory |
-| charmcraft-channel        | string | latest/stable | Charmcraft channel to use for the integration test                                               |
+| charmcraft-channel        | string | latest/stable | Charmcraft channel to use for publishing the charm and resources                                              |
 | paas-app-charmer-oci-name | string | Null          | Name of the resource oci image for paas-app-charmer generated apps                               |
 | working-directory         | string | "./"          | Directory where jobs should be executed                                                          |
 


### PR DESCRIPTION


### Overview

Pass charmcraft-channel input to upload-charm charm actions

### Rationale

Some charms require `latest/edge` for publishing (e.g. Paas-app charms currently)


### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
