### PR TITLE
Fix inputs to octokit/request-action workflow call

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -48,9 +48,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
         with:
           route: GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks
-          repo: ${{ github.event.repository.name }}
-          owner: ${{ github.event.repository.owner.login }}
-          branch: main
       - run: |
           if [ ${{ fromJson(steps.get-branch-protection.outputs.data).strict }} != "true" ]; then
             echo "::error::Strict checks are not enabled for this repository"


### PR DESCRIPTION
The octokit/request-action@v2.3.0 doesn't include these arguments `repo`, `owner` and `branch`.  

https://github.com/octokit/request-action/blob/v2.3.0/action.yml

I'm unsure how this ever worked, but I think the inputs were largely being ignored. Please remove them now because they are breaking action runs

https://github.com/canonical/k8s-operator/actions/workflows/publish-charms.yaml