### PR TITLE
Add branch protection requirement to publish charm docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ tmate can be run on failed tests either by setting the `tmate-debug` input to 't
 * publish_charm: Publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel).
 
 This workflow requires a `CHARMHUB_TOKEN` secret containing a charmhub token with package-manage and package-view permissions for the charm and the destination channel. See how to generate it [here](https://juju.is/docs/sdk/remote-env-auth) and a `REPO_ACCESS_TOKEN` secret containg a classic PAT with full repository permissions. See how to generate it [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
+Furthermore, it is required that your main branch is protected and requires the Status Check "Require branches to be up to date before merging" to be enabled.
 
 The following parameters are available for this workflow:
 

--- a/tests/workflows/integration/test-upload-charm/tox.ini
+++ b/tests/workflows/integration/test-upload-charm/tox.ini
@@ -105,7 +105,9 @@ commands =
 description = Run integration tests
 deps =
     juju==2.9.42.4
-    pytest
+    # there are incompatibilities with the version 8.2.0 of pytest and pytest-operator
+    # https://github.com/charmed-kubernetes/pytest-operator/issues/131
+    pytest==8.1.1
     pytest-operator
     pytest-asyncio
     # Type error problem with newer version of macaroonbakery

--- a/tests/workflows/integration/test-upload-charm/tox.ini
+++ b/tests/workflows/integration/test-upload-charm/tox.ini
@@ -120,7 +120,9 @@ commands =
 description = Run integration tests
 deps =
     juju==3.1.2.0
-    pytest
+    # there are incompatibilities with the version 8.2.0 of pytest and pytest-operator
+    # https://github.com/charmed-kubernetes/pytest-operator/issues/131
+    pytest==8.1.1
     pytest-operator
     pytest-asyncio
     # Type error problem with newer version of macaroonbakery

--- a/tests/workflows/integration/test-upload-charm/tox.ini
+++ b/tests/workflows/integration/test-upload-charm/tox.ini
@@ -120,9 +120,7 @@ commands =
 description = Run integration tests
 deps =
     juju==3.1.2.0
-    # there are incompatibilities with the version 8.2.0 of pytest and pytest-operator
-    # https://github.com/charmed-kubernetes/pytest-operator/issues/131
-    pytest==8.1.1
+    pytest
     pytest-operator
     pytest-asyncio
     # Type error problem with newer version of macaroonbakery

--- a/tests/workflows/integration/test-upload-charm/tox.ini
+++ b/tests/workflows/integration/test-upload-charm/tox.ini
@@ -105,9 +105,7 @@ commands =
 description = Run integration tests
 deps =
     juju==2.9.42.4
-    # there are incompatibilities with the version 8.2.0 of pytest and pytest-operator
-    # https://github.com/charmed-kubernetes/pytest-operator/issues/131
-    pytest==8.1.1
+    pytest
     pytest-operator
     pytest-asyncio
     # Type error problem with newer version of macaroonbakery


### PR DESCRIPTION
### Overview

Follow-up to https://github.com/canonical/operator-workflows/pull/288

### Rationale

Make the workflow requirements clear.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
