### PR TITLE
Check branch-protection of branch where this workflow is run

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -42,6 +42,11 @@ jobs:
   branch-up-to-date-check-enabled:
     runs-on: ubuntu-22.04
     steps:
+      - env:
+          BRANCH: ${{ github.base_ref || github.ref }}
+        run: |
+          BRANCH=${BRANCH#refs/heads/}  # strip off refs/heads/ if it exists
+          echo "BRANCH=${BRANCH}" >> "$GITHUB_OUTPUT"
       - uses: octokit/request-action@v2.3.0
         id: get-branch-protection
         env:
@@ -50,10 +55,10 @@ jobs:
           route: GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks
           repo: ${{ github.event.repository.name }}
           owner: ${{ github.event.repository.owner.login }}
-          branch: main
+          branch: ${{ env.BRANCH }} 
       - run: |
           if [ ${{ fromJson(steps.get-branch-protection.outputs.data).strict }} != "true" ]; then
-            echo "::error::Strict checks are not enabled for this repository"
+            echo "::error::Strict checks are not enabled for this repository's branch"
             exit 1
           fi
   draft-publish-docs:


### PR DESCRIPTION
Issue: https://github.com/canonical/operator-workflows/issues/290

### Overview

Remove the hard-coded link to the `main` branch on the charm to support branch protection checks on release branches

### Rationale

On push to a main branch, it makes sense to push to `latest/edge`, so one should check the branch protection rules of `main`
On push to a `release-xxx` branch, a charm could publish the xxx/edge and ought to check branch protection rules of that `release-xxx` branch

### Workflow Changes

Look up the active branch based on the workflow event:

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
