### PR TITLE
Fine-grained PATs in publish-charm workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ tmate can be run on failed tests either by setting the `tmate-debug` input to 't
 
 * publish_charm: Publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel).
 
-This workflow requires a `CHARMHUB_TOKEN` secret containing a charmhub token with package-manage and package-view permissions for the charm and the destination channel. See how to generate it [here](https://juju.is/docs/sdk/remote-env-auth) and a `REPO_ACCESS_TOKEN` secret, which contains a 
-fine-grained PAT with `administration:read` access, or a classic PAT with full repository permissions. See how to generate it [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
+This workflow requires a `CHARMHUB_TOKEN` secret containing a charmhub token with package-manage and package-view permissions for the charm and the destination channel. See how to generate it [here](https://juju.is/docs/sdk/remote-env-auth), and a `REPO_ACCESS_TOKEN` secret, which contains a 
+fine-grained PAT with `administration:read` access for the respective repository, or a classic PAT with full repository permissions. See how to generate it [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
 Furthermore, it is required that your main branch is protected and requires the Status Check "Require branches to be up to date before merging" to be enabled.
 
 The following parameters are available for this workflow:

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ tmate can be run on failed tests either by setting the `tmate-debug` input to 't
 
 * publish_charm: Publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel).
 
-This workflow requires a `CHARMHUB_TOKEN` secret containing a charmhub token with package-manage and package-view permissions for the charm and the destination channel. See how to generate it [here](https://juju.is/docs/sdk/remote-env-auth) and a `REPO_ACCESS_TOKEN` secret containg a classic PAT with full repository permissions. See how to generate it [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
+This workflow requires a `CHARMHUB_TOKEN` secret containing a charmhub token with package-manage and package-view permissions for the charm and the destination channel. See how to generate it [here](https://juju.is/docs/sdk/remote-env-auth) and a `REPO_ACCESS_TOKEN` secret, which contains a 
+fine-grained PAT with `administration:read` access, or a classic PAT with full repository permissions. See how to generate it [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
 Furthermore, it is required that your main branch is protected and requires the Status Check "Require branches to be up to date before merging" to be enabled.
 
 The following parameters are available for this workflow:


### PR DESCRIPTION
### Overview

Explain that fine-grained PATs can be used for `REPO_ACCESS_TOKEN` secret in the publish-charm workflow.

### Rationale

Fine-grained PATs are more secure and can be limited to a single repo.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
