### PR TITLE
Fix integration tests from forks

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -175,7 +175,7 @@ jobs:
             ${{
               ( 
                 github.event.pull_request.head.repo.full_name == github.repository && 
-                !contains('registry', inputs.microk8s-addons)
+                !contains(inputs.microk8s-addons, 'registry')
               ) &&
               (
                 inputs.microk8s-addons == '' && 

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -174,7 +174,7 @@ jobs:
           microk8s-addons: >-
             ${{
               ( 
-                github.event.pull_request.head.repo.full_name == github.repository || 
+                github.event.pull_request.head.repo.full_name == github.repository && 
                 !contains('registry', inputs.microk8s-addons)
               ) &&
               (

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -60,7 +60,7 @@ on:
       microk8s-addons:
         description: Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.
         type: string
-        default: "dns ingress rbac registry storage"
+        default: "dns ingress rbac storage"
       registry:
         type: string
         description: Registry to push the built images
@@ -171,7 +171,19 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: ${{ inputs.provider }}
-          microk8s-addons: ${{ inputs.microk8s-addons }}
+          microk8s-addons: >-
+            ${{
+              ( 
+                github.event.pull_request.head.repo.full_name == github.repository || 
+                !contains('registry', inputs.microk8s-addons)
+              ) &&
+              (
+                inputs.microk8s-addons == '' && 
+                'registry' || 
+                format('registry {0}', inputs.microk8s-addons)
+              ) ||
+              inputs.microk8s-addons
+            }}
           channel: ${{ inputs.channel }}
           juju-channel: ${{ inputs.juju-channel }}
       - uses: actions/checkout@v4

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -60,7 +60,7 @@ on:
       microk8s-addons:
         description: Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.
         type: string
-        default: "dns ingress rbac storage"
+        default: "dns ingress rbac registry storage"
       registry:
         type: string
         description: Registry to push the built images

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -175,7 +175,7 @@ jobs:
             ${{
               ( 
                 github.event.pull_request.head.repo.full_name != github.repository && 
-                >!contains(inputs.microk8s-addons, 'registry')
+                !contains(inputs.microk8s-addons, 'registry')
               ) &&
               (
                 inputs.microk8s-addons == '' && 

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -174,8 +174,8 @@ jobs:
           microk8s-addons: >-
             ${{
               ( 
-                github.event.pull_request.head.repo.full_name == github.repository && 
-                !contains(inputs.microk8s-addons, 'registry')
+                github.event.pull_request.head.repo.full_name != github.repository && 
+                >!contains(inputs.microk8s-addons, 'registry')
               ) &&
               (
                 inputs.microk8s-addons == '' && 


### PR DESCRIPTION
Applicable spec: <link>
N/A

### Overview

<!-- A high level overview of the change -->
Fix integration tests from forks by enabling the microk8s registry if disabled when running from a fork

### Rationale

<!-- The reason the change is needed -->
N/a

### Workflow Changes

<!-- Any high level changes to workflows and why -->
N/A

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
