### PR TITLE
default architecture of self-hosted runner to x64, allowing for others

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -93,6 +93,10 @@ on:
         type: boolean
         description: Whether to use self-hosted runners to run the jobs.
         default: false
+      self-hosted-runner-arch:
+        type: string
+        description: Architecture to use on self-hosted runners to run the jobs.
+        default: "x64"
       self-hosted-runner-label:
         type: string
         description: Label for selecting the self-hosted runners.
@@ -313,6 +317,7 @@ jobs:
       pre-run-script: ${{ inputs.pre-run-script }}
       provider: ${{ inputs.provider }}
       registry: ghcr.io
+      self-hosted-runner-arch: ${{ inputs.self-hosted-runner-arch }}
       self-hosted-runner-label: ${{ inputs.self-hosted-runner-label }}
       self-hosted-runner: ${{ inputs.self-hosted-runner }}
       series: ${{ inputs.series }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -73,6 +73,10 @@ on:
         type: boolean
         description: Whether to use self-hosted runners to run the jobs.
         default: true
+      self-hosted-runner-arch:
+        type: string
+        description: Architecture to use on self-hosted runners to run the jobs.
+        default: "x64"
       self-hosted-runner-label:
         type: string
         description: Label for selecting the self-hosted runners.
@@ -162,8 +166,9 @@ jobs:
       ${{
         inputs.runs-on == 'ubuntu-22.04' &&
         inputs.self-hosted-runner &&
-        fromJson(format('[''self-hosted'', ''x64'', ''jammy'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
-        inputs.runs-on
+        fromJson(format('[''self-hosted'', ''{0}'', ''jammy'', ''{1}'']',
+          inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label
+        )) || inputs.runs-on
       }}
     if: ${{ !failure() }}
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,10 @@ on:
         type: boolean
         description: Whether to use self-hosted runners to run the jobs.
         default: true
+      self-hosted-runner-arch:
+        type: string
+        description: Architecture to use on self-hosted runners to run the jobs.
+        default: "x64"
       self-hosted-runner-label:
         type: string
         description: Label for selecting the self-hosted runners.
@@ -39,8 +43,9 @@ jobs:
     runs-on: >-
       ${{
         inputs.self-hosted-runner &&
-        fromJson(format('[''self-hosted'', ''x64'', ''jammy'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
-        'ubuntu-22.04'
+        fromJson(format('[''self-hosted'', ''{0}'', ''jammy'', ''{1}'']',
+          inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label
+        )) || 'ubuntu-22.04'
       }}
     defaults:
       run:
@@ -88,8 +93,9 @@ jobs:
     runs-on: >-
       ${{
         inputs.self-hosted-runner &&
-        fromJson(format('[''self-hosted'', ''x64'', ''jammy'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
-        'ubuntu-22.04'
+        fromJson(format('[''self-hosted'', ''{0}'', ''jammy'', ''{1}'']',
+          inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label
+        )) || 'ubuntu-22.04'
       }}
     defaults:
       run:
@@ -157,8 +163,9 @@ jobs:
     runs-on: >-
       ${{
         inputs.self-hosted-runner &&
-        fromJson(format('[''self-hosted'', ''x64'', ''jammy'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
-        'ubuntu-22.04'
+        fromJson(format('[''self-hosted'', ''{0}'', ''jammy'', ''{1}'']',
+          inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label
+        )) || 'ubuntu-22.04'
       }}
     defaults:
       run:
@@ -179,8 +186,9 @@ jobs:
     runs-on: >-
       ${{
         inputs.self-hosted-runner &&
-        fromJson(format('[''self-hosted'', ''x64'', ''jammy'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
-        'ubuntu-22.04'
+        fromJson(format('[''self-hosted'', ''{0}'', ''jammy'', ''{1}'']',
+          inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label
+        )) || 'ubuntu-22.04'
       }}
     defaults:
       run:
@@ -203,8 +211,9 @@ jobs:
     runs-on: >-
       ${{
         inputs.self-hosted-runner &&
-        fromJson(format('[''self-hosted'', ''x64'', ''jammy'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
-        'ubuntu-22.04'
+        fromJson(format('[''self-hosted'', ''{0}'', ''jammy'', ''{1}'']',
+          inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label
+        )) || 'ubuntu-22.04'
       }}
     defaults:
       run:
@@ -333,8 +342,9 @@ jobs:
     runs-on: >-
       ${{
         inputs.self-hosted-runner &&
-        fromJson(format('[''self-hosted'', ''x64'', ''jammy'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
-        'ubuntu-22.04'
+        fromJson(format('[''self-hosted'', ''{0}'', ''jammy'', ''{1}'']',
+          inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label
+        )) || 'ubuntu-22.04'
       }}
     defaults:
       run:
@@ -359,8 +369,9 @@ jobs:
     runs-on: >-
       ${{
         inputs.self-hosted-runner &&
-        fromJson(format('[''self-hosted'', ''x64'', ''jammy'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
-        'ubuntu-22.04'
+        fromJson(format('[''self-hosted'', ''{0}'', ''jammy'', ''{1}'']',
+          inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label
+        )) || 'ubuntu-22.04'
       }}
     defaults:
       run:
@@ -383,8 +394,9 @@ jobs:
     runs-on: >-
       ${{
         inputs.self-hosted-runner &&
-        fromJson(format('[''self-hosted'', ''x64'', ''jammy'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
-        'ubuntu-22.04'
+        fromJson(format('[''self-hosted'', ''{0}'', ''jammy'', ''{1}'']',
+          inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label
+        )) || 'ubuntu-22.04'
       }}
     steps:
       - uses: actions/checkout@v4.1.5
@@ -408,8 +420,9 @@ jobs:
     runs-on: >-
       ${{
         inputs.self-hosted-runner &&
-        fromJson(format('[''self-hosted'', ''x64'', ''jammy'', ''{0}'']',  inputs.self-hosted-runner-label)) ||
-        'ubuntu-22.04'
+        fromJson(format('[''self-hosted'', ''{0}'', ''jammy'', ''{1}'']',
+          inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label
+        )) || 'ubuntu-22.04'
       }}
     if: always() && !cancelled()
     timeout-minutes: 5


### PR DESCRIPTION
Resolves #317 by defaulting self-hosted runners to x64 but allowing for changes to ARM runners.

Since there are other architectures available to self-hosted runners, we should allow the workflows to target architecture labels other than just x64.  With a new input passed to the workflows, `self-hosted-runner-arch` defaulted to `x64`, downstream charm workflows can run on other architectures such as ARM.