### PR TITLE
Run approval workflow on PRs opened by bots

### DIFF
--- a/.github/workflows/run_bot_pr_approval.yaml
+++ b/.github/workflows/run_bot_pr_approval.yaml
@@ -1,0 +1,9 @@
+name: Provide approval for bot PRs
+
+on:
+  pull_request:
+
+jobs:
+  bot_pr_approval:
+    uses: canonical/operator-workflows/.github/workflows/bot_pr_approval.yaml@main
+    secrets: inherit

--- a/.github/workflows/run_bot_pr_approval.yaml
+++ b/.github/workflows/run_bot_pr_approval.yaml
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 name: Provide approval for bot PRs
 
 on:


### PR DESCRIPTION
Applicable spec: <link>
N/A

### Overview

<!-- A high level overview of the change -->
Run approval workflow on PRs opened by bots

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
