### PR TITLE
Use github hosted runners for approval bot

### DIFF
--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   approve_pr:
     name: Approve bot PR
-    runs-on: [self-hosted, x64, jammy, edge]
+    runs-on: ubuntu-latest
     steps:
       - name: Show actor
         run: |


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Use github hosted runners for approval bot workflow

### Rationale

We currently have a low capacity for edge runners and this check is currently only waiting for available runners.

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
