### PR TITLE
add_charmcraft_channel_input

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,10 @@ on:
         type: string
         description: The working directory for the docs
         default: "."
+      charmcraft-channel:
+        description: Charmcraft channel to use
+        type: string
+        default: latest/stable
       working-directory:
         type: string
         description: The working directory for jobs
@@ -406,6 +410,7 @@ jobs:
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          charmcraft-channel: ${{ inputs.charmcraft-channel }}
   required_status_checks:
     name: Required Test Status Checks
     needs:


### PR DESCRIPTION
The charmcraft channel used in https://github.com/canonical/charming-actions can take the charmcraft channel as input, we need to support this as the yaml schema for `charmcraft.yaml` have significant differences between charmcraft v2 and v3 and a v3 schema will not pass validation with charmcraft v2

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
