### PR TITLE
Enable new GH token for lib updates

### DIFF
--- a/.github/workflows/auto_update_charm_libs.yaml
+++ b/.github/workflows/auto_update_charm_libs.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Create pull request
         uses: canonical/create-pull-request@main
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.REPO_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
           commit-message: "chore: update charm libraries"
           branch-name: "chore/auto-libs"
           title: Update charm libraries


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Enable new GH token for lib updates `REPO_ACCESS_TOKEN` so that workflows can run when the PR is open. If unspecified, default to `GITHUB_TOKEN`

### Rationale

<!-- The reason the change is needed -->
N/A

### Workflow Changes

<!-- Any high level changes to workflows and why -->
N/A

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
