### PR TITLE
Auto approve IS DevOps bot PRs

### DIFF
--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Approve bot PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: contains(fromJSON('["renovate[bot]", "github-actions[bot]"]'), github.actor)
+        if: contains(fromJSON('["renovate[bot]", "github-actions[bot]"]', "is-devops-bot"), github.actor)
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Auto approve IS DevOps bot PRs

### Rationale

<!-- The reason the change is needed -->
Auto approve IS DevOps bot PRs to simplify reviews in this case

### Workflow Changes

<!-- Any high level changes to workflows and why -->
bot_pr_approval

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
