### PR TITLE
fix ref to removed better-build branch

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -196,7 +196,7 @@ jobs:
       plan: ${{ steps.plan.outputs.plan }}
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: canonical/operator-workflows/internal/plan@better-build
+      - uses: canonical/operator-workflows/internal/plan@main
         id: plan
         with:
           identifier: ${{ inputs.identifier }}


### PR DESCRIPTION
Applicable spec: N/A

### Overview

remove existing reference to better build

### Rationale

breaks workflows: https://github.com/canonical/github-runner-image-builder-operator/actions/runs/9497500412/job/26174202575#step:1:25

### Workflow Changes

None

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
