### PR TITLE
temporary fix log dump action

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -304,7 +304,7 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: ${{ inputs.tmate-timeout }}
       - name: Dump logs
-        uses: canonical/charm-logdump-action@main
+        uses: Thanhphan1147/charm-logdump-action@e173d0829dbf33b1d8823b97a159d840fb308e82 # temporary fix until https://github.com/canonical/charm-logdump-action/pull/9 is merged 
         if: failure()
         with:
           app: ${{ env.CHARM_NAME }}


### PR DESCRIPTION
Temporary change `canonical/charm-logdump-action` to `Thanhphan1147/charm-logdump-action` as a temporary workaround before https://github.com/canonical/charm-logdump-action/pull/9 is merged

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
