### PR TITLE
Revert "temporary fix log dump action (#366)"

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -304,7 +304,7 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: ${{ inputs.tmate-timeout }}
       - name: Dump logs
-        uses: Thanhphan1147/charm-logdump-action@e173d0829dbf33b1d8823b97a159d840fb308e82 # temporary fix until https://github.com/canonical/charm-logdump-action/pull/9 is merged 
+        uses: canonical/charm-logdump-action@main
         if: failure()
         with:
           app: ${{ env.CHARM_NAME }}


### PR DESCRIPTION
This reverts commit 3f73e89534558c9930155c1fe356ad78d0178ea4. as the PR for `charm-logdump-action` has been merged.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
