### PR TITLE
Use the latest version of charming-actions in publish workflows

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.7
       - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@2.5.0-rc
+        uses: canonical/charming-actions/release-charm@2.6.1
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           charm-path: ${{ inputs.working-directory }}/${{ inputs.charm-directory }}

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -57,7 +57,7 @@ jobs:
       destination-channel: ${{ steps.select-channel.outputs.name }}
     steps:
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@main
+        uses: canonical/charming-actions/channel@2.5.0-rc
         id: select-channel
   publish-charm:
     name: Publish charm to ${{ inputs.channel || needs.select-channel.outputs.destination-channel }}
@@ -90,7 +90,7 @@ jobs:
           rm -rf $TEMP_DIR
           ls -lah
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@main
+        uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           built-charm-path: ${{ steps.publish.outputs.charms }}
           charmcraft-channel: ${{ inputs.charmcraft-channel }}
@@ -134,7 +134,7 @@ jobs:
           rm -rf .* * || :
           cp -rp $TEMP_DIR/. .
           rm -rf $TEMP_DIR
-      - uses: canonical/charming-actions/release-libraries@main
+      - uses: canonical/charming-actions/release-libraries@2.5.0-rc
         name: Release libs
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -57,7 +57,7 @@ jobs:
       destination-channel: ${{ steps.select-channel.outputs.name }}
     steps:
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.5.0-rc
+        uses: canonical/charming-actions/channel@2.6.1
         id: select-channel
   publish-charm:
     name: Publish charm to ${{ inputs.channel || needs.select-channel.outputs.destination-channel }}
@@ -90,7 +90,7 @@ jobs:
           rm -rf $TEMP_DIR
           ls -lah
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.5.0-rc
+        uses: canonical/charming-actions/upload-charm@2.6.1
         with:
           built-charm-path: ${{ steps.publish.outputs.charms }}
           charmcraft-channel: ${{ inputs.charmcraft-channel }}
@@ -134,7 +134,7 @@ jobs:
           rm -rf .* * || :
           cp -rp $TEMP_DIR/. .
           rm -rf $TEMP_DIR
-      - uses: canonical/charming-actions/release-libraries@2.5.0-rc
+      - uses: canonical/charming-actions/release-libraries@2.6.1
         name: Release libs
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -57,7 +57,7 @@ jobs:
       destination-channel: ${{ steps.select-channel.outputs.name }}
     steps:
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.5.0-rc
+        uses: canonical/charming-actions/channel@main
         id: select-channel
   publish-charm:
     name: Publish charm to ${{ inputs.channel || needs.select-channel.outputs.destination-channel }}
@@ -90,7 +90,7 @@ jobs:
           rm -rf $TEMP_DIR
           ls -lah
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.5.0-rc
+        uses: canonical/charming-actions/upload-charm@main
         with:
           built-charm-path: ${{ steps.publish.outputs.charms }}
           charmcraft-channel: ${{ inputs.charmcraft-channel }}
@@ -134,7 +134,7 @@ jobs:
           rm -rf .* * || :
           cp -rp $TEMP_DIR/. .
           rm -rf $TEMP_DIR
-      - uses: canonical/charming-actions/release-libraries@2.5.0-rc
+      - uses: canonical/charming-actions/release-libraries@main
         name: Release libs
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -402,7 +402,7 @@ jobs:
       - uses: actions/checkout@v4.1.7
       - name: Check libs
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: canonical/charming-actions/check-libraries@2.5.0-rc
+        uses: canonical/charming-actions/check-libraries@2.6.1
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The latest version of `charming-actions` on the `main` branch includes several fixes for the publishing actions, specifically for charms that use extensions. For the time being, switch to `charming-actions@main` to enable charm publishing.