### PR TITLE
feat: private endpoint workflow

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -312,12 +312,14 @@ jobs:
         if: ${{ failure() && (inputs.tmate-debug || runner.debug) && !inputs.self-hosted-runner }}
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: ${{ inputs.tmate-timeout }}
-      - name: Dump logs
-        uses: canonical/charm-logdump-action@main
-        if: failure()
-        with:
-          app: ${{ env.CHARM_NAME }}
-          model: testing
+      # Temporarily disable until https://github.com/canonical/charm-logdump-action/pull/9
+      # is resolved
+      # - name: Dump logs
+      #   uses: canonical/charm-logdump-action@main
+      #   if: failure()
+      #   with:
+      #     app: ${{ env.CHARM_NAME }}
+      #     model: testing
       - name: Install k6s
         if: ${{ inputs.load-test-enabled }}
         run: sudo snap install k6

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -312,14 +312,12 @@ jobs:
         if: ${{ failure() && (inputs.tmate-debug || runner.debug) && !inputs.self-hosted-runner }}
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: ${{ inputs.tmate-timeout }}
-      # Temporarily disable until https://github.com/canonical/charm-logdump-action/pull/9
-      # is resolved
-      # - name: Dump logs
-      #   uses: canonical/charm-logdump-action@main
-      #   if: failure()
-      #   with:
-      #     app: ${{ env.CHARM_NAME }}
-      #     model: testing
+      - name: Dump logs
+        uses: canonical/charm-logdump-action@main
+        if: failure()
+        with:
+          app: ${{ env.CHARM_NAME }}
+          model: testing
       - name: Install k6s
         if: ${{ inputs.load-test-enabled }}
         run: sudo snap install k6

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -255,6 +255,15 @@ jobs:
       - name: Pre-run script
         if: ${{ inputs.pre-run-script != '' }}
         run: bash -xe ${{ inputs.pre-run-script }}
+        # pre-run-script can be used to bootstrap private-endpoints.
+        # map the secrets related to private-endpoints as environment variables.
+        env:
+          JUJU_CONTROLLER: ${{ secrets.JUJU_CONTROLLER }}
+          JUJU_MODEL: ${{ secrets.JUJU_MODEL }}
+          PRODSTACK: ${{ secrets.PRODSTACK }}
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+          VAULT_APPROLE_ROLE_ID: ${{ secrets.VAULT_APPROLE_ROLE_ID }}
+          VAULT_APPROLE_SECRET_ID: ${{ secrets.VAULT_APPROLE_SECRET_ID }}
 
       - run: sudo apt install skopeo -y
 


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Pass in secrets related to private endpoints to pre-run script.

### Rationale

To setup private endpoint related services.

### Workflow Changes

Pre-run script now takes in private-endpoint related secrets.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
