### PR TITLE
Enable experimental extensions in publish workflow

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -49,6 +49,8 @@ on:
 env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
+  CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
+  ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
 
 jobs:
   select-channel:


### PR DESCRIPTION
Define the `ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS` and `CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS` environment variables in the publish workflow to enable experimental extensions in `charming-actions`. This might not work but it's worth a try.