### PR TITLE
Add trivy severity config to integration test

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -139,6 +139,10 @@ on:
       trivy-image-config:
         type: string
         description: Trivy YAML configuration for image testing that is checked in as part of the repo
+      trivy-severity-config:
+        type: string
+        description: Trivy severity configuration for image testing
+        default: "CRITICAL,HIGH"
       upload-image:
         type: string
         description: >-
@@ -270,7 +274,7 @@ jobs:
           input: ${{ matrix.scan.file }}
           trivy-config: ${{ inputs.trivy-image-config }}
           exit-code: '1'
-          severity: 'CRITICAL,HIGH'
+          severity: ${{ inputs.trivy-severity-config }}
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -279,7 +283,7 @@ jobs:
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.46.0
           if [ -f ".trivyignore" ]
           then
-            output=$(trivy image $ROCK_IMAGE --severity HIGH,CRITICAL -q -f json --ignorefile "" | jq -r '.Results[].Vulnerabilities[].VulnerabilityID' 2>/dev/null || echo "No vulnerabilities found")
+            output=$(trivy image $ROCK_IMAGE --severity ${{ inputs.trivy-severity-config }} -q -f json --ignorefile "" | jq -r '.Results[].Vulnerabilities[].VulnerabilityID' 2>/dev/null || echo "No vulnerabilities found")
             line=0
             while read CVE;
             do

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -26,6 +26,7 @@ jobs:
     with:
       working-directory: "tests/workflows/integration/test-upload-charm/"
       trivy-image-config: "tests/workflows/integration/test-upload-charm/trivy.yaml"
+      trivy-severity-config: "CRITICAL,HIGH"
   integration-juju3:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit


### PR DESCRIPTION
### Overview

The trivy scan for ROCK images currently has a hard-coded severity of `CRITICAL,HIGH`, and does not seem to accept even an override in `trivy.yaml`. This PR parameterizes this config value.

### Rationale

It allows greater flexibility when running integration tests to be able to select a specific severity level.

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
