### PR TITLE
Set security nesting on lxd container in itest

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -85,6 +85,10 @@ on:
         description: Pull and build rockcraft from source instead of using snapstore version (this means that the rockcraft-channel input will be ignored).
         type: string
         default: ""
+      rockcraft-enable-security-nesting:
+        description: Set security.nesting=true on the rockcraft lxc project to allow for nested containers.
+        type: boolean
+        default: false
       microk8s-addons:
         description: Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.
         type: string
@@ -216,6 +220,10 @@ jobs:
         build: ${{ fromJSON(needs.plan.outputs.plan).build }}
     steps:
       - uses: canonical/setup-lxd@v0.1.1
+      - name: Set LXC security nesting
+        if: ${{ inputs.rockcraft-enable-security-nesting }}
+        run: |
+          lxc profile set default security.nesting true
       - uses: actions/checkout@v4
       - uses: canonical/operator-workflows/internal/build@main
         id: build


### PR DESCRIPTION
This is a follow-up PR after closing #442 .

### Overview

Addresses #441 by adding an input parameter to the integration tests for enabling security nesting when building rocks.

### Rationale

This is needed for rocks with nested containers (e.g. docker containers) as part of the build process.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
