### PR TITLE
fix libs auto-update job to use the correct input

### DIFF
--- a/.github/workflows/auto_update_charm_libs.yaml
+++ b/.github/workflows/auto_update_charm_libs.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Check libs
         working-directory: ${{ inputs.working-directory }}
         run: |
-          sudo snap install charmcraft --classic --channel {{ inputs.charmcraft-channel }}
+          sudo snap install charmcraft --classic --channel ${{ inputs.charmcraft-channel }}
           charmcraft fetch-lib
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}


### PR DESCRIPTION
### Details

Somehow we missed this on merge of https://github.com/canonical/operator-workflows/pull/453


