### PR TITLE
Cache trivy DB

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -279,6 +279,17 @@ jobs:
         run: |
           docker image pull ${{ matrix.scan.image }}
           docker image save -o ${{ matrix.scan.file }} ${{ matrix.scan.image }}
+      ## To avoid the trivy-db becoming outdated, we save the cache for one day
+      - name: Get data
+        id: date
+        run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+      - name: Restore trivy cache
+        uses: actions/cache@v4.1.2
+        with:
+          path: cache/db
+          key: trivy-cache-${{ steps.date.outputs.date }}
+          restore-keys:
+            trivy-cache-
       - name: Run Github Trivy Image Action
         uses: aquasecurity/trivy-action@0.28.0
         with:
@@ -289,6 +300,11 @@ jobs:
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      ## Trivy-db uses `0600` permissions.
+      ## But `action/cache` use `runner` user by default
+      ## So we need to change the permissions before caching the database.
+      - name: change permissions for trivy.db
+        run: sudo chmod 0644 ./cache/db/trivy.db
       - name: Check trivyignore
         run: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.46.0

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -300,6 +300,7 @@ jobs:
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          TRIVY_SKIP_DB_UPDATE: false
       ## Trivy-db uses `0600` permissions.
       ## But `action/cache` use `runner` user by default
       ## So we need to change the permissions before caching the database.

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -289,7 +289,7 @@ jobs:
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          TRIVY_SKIP_DB_UPDATE: false
+          TRIVY_SKIP_DB_UPDATE: true
       - name: Check trivyignore
         run: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.46.0

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -287,8 +287,6 @@ jobs:
           exit-code: '1'
           severity: ${{ inputs.trivy-severity-config }}
         env:
-          TRIVY_USERNAME: ${{ github.actor }}
-          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TRIVY_SKIP_DB_UPDATE: true
       - name: Check trivyignore
         run: |

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -279,17 +279,6 @@ jobs:
         run: |
           docker image pull ${{ matrix.scan.image }}
           docker image save -o ${{ matrix.scan.file }} ${{ matrix.scan.image }}
-      ## To avoid the trivy-db becoming outdated, we save the cache for one day
-      - name: Get data
-        id: date
-        run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
-      - name: Restore trivy cache
-        uses: actions/cache@v4.1.2
-        with:
-          path: cache/db
-          key: trivy-cache-${{ steps.date.outputs.date }}
-          restore-keys:
-            trivy-cache-
       - name: Run Github Trivy Image Action
         uses: aquasecurity/trivy-action@0.28.0
         with:
@@ -301,11 +290,6 @@ jobs:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TRIVY_SKIP_DB_UPDATE: false
-      ## Trivy-db uses `0600` permissions.
-      ## But `action/cache` use `runner` user by default
-      ## So we need to change the permissions before caching the database.
-      - name: change permissions for trivy.db
-        run: sudo chmod 0644 ./cache/db/trivy.db
       - name: Check trivyignore
         run: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.46.0

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -332,7 +332,7 @@ jobs:
           scan-ref: ${{ inputs.trivy-fs-ref }}
           trivy-config: ${{ inputs.trivy-fs-config }}
         env:
-          TRIVY_SKIP_DB_UPDATE: false
+          TRIVY_SKIP_DB_UPDATE: true
       - name: Set Zap target env for Github Zap Action to Juju Unit IP Address
         if: ${{ inputs.zap-enabled && inputs.zap-target == '' }}
         run: echo "ZAP_TARGET=$(juju show-unit ${{ env.CHARM_NAME }}/0 --format=json | jq -r '.["${{ env.CHARM_NAME }}/0"]["address"]')" >> $GITHUB_ENV

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -205,7 +205,7 @@ jobs:
       - name: Restore Charmcraft Cache
         if: inputs.charmcraft-repository != ''
         id: restore-charmcraft
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v4.1.2
         with:
           path: ./charmcraft*.snap
           key: charmcraft-${{ steps.charmcraft-sha.outputs.sha }}
@@ -219,7 +219,7 @@ jobs:
           snapcraft --use-lxd
           cp charmcraft*.snap ../
       - name: Save Charmcraft Cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v4.1.2
         if: steps.restore-charmcraft.outputs.cache-hit != 'true' && inputs.charmcraft-repository != ''
         with:
           path: ./charmcraft*.snap
@@ -324,6 +324,17 @@ jobs:
       - name: Run k6 load tests
         if: ${{ inputs.load-test-enabled }}
         run: k6 run load_tests/load-test.js ${{ inputs.load-test-run-args }}
+       ## To avoid the trivy-db becoming outdated, we save the cache for one day
+      - name: Get data
+        id: date
+        run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+      - name: Restore trivy cache
+        uses: actions/cache@v4.1.2
+        with:
+          path: cache/db
+          key: trivy-cache-${{ steps.date.outputs.date }}
+          restore-keys:
+            trivy-cache-
       - name: Run Github Trivy FS Action
         if: ${{ inputs.trivy-fs-enabled }}
         uses: aquasecurity/trivy-action@0.28.0
@@ -331,6 +342,11 @@ jobs:
           scan-type: "fs"
           scan-ref: ${{ inputs.trivy-fs-ref }}
           trivy-config: ${{ inputs.trivy-fs-config }}
+      ## Trivy-db uses `0600` permissions.
+      ## But `action/cache` use `runner` user by default
+      ## So we need to change the permissions before caching the database.
+      - name: change permissions for trivy.db
+        run: sudo chmod 0644 ./cache/db/trivy.db
       - name: Set Zap target env for Github Zap Action to Juju Unit IP Address
         if: ${{ inputs.zap-enabled && inputs.zap-target == '' }}
         run: echo "ZAP_TARGET=$(juju show-unit ${{ env.CHARM_NAME }}/0 --format=json | jq -r '.["${{ env.CHARM_NAME }}/0"]["address"]')" >> $GITHUB_ENV

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -329,6 +329,7 @@ jobs:
         id: date
         run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
       - name: Restore trivy cache
+        if: ${{ inputs.trivy-fs-enabled }}
         uses: actions/cache@v4.1.2
         with:
           path: cache/db
@@ -342,10 +343,13 @@ jobs:
           scan-type: "fs"
           scan-ref: ${{ inputs.trivy-fs-ref }}
           trivy-config: ${{ inputs.trivy-fs-config }}
+        env:
+          TRIVY_SKIP_DB_UPDATE: false
       ## Trivy-db uses `0600` permissions.
       ## But `action/cache` use `runner` user by default
       ## So we need to change the permissions before caching the database.
       - name: change permissions for trivy.db
+        if: ${{ inputs.trivy-fs-enabled }}
         run: sudo chmod 0644 ./cache/db/trivy.db
       - name: Set Zap target env for Github Zap Action to Juju Unit IP Address
         if: ${{ inputs.zap-enabled && inputs.zap-target == '' }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -324,18 +324,6 @@ jobs:
       - name: Run k6 load tests
         if: ${{ inputs.load-test-enabled }}
         run: k6 run load_tests/load-test.js ${{ inputs.load-test-run-args }}
-       ## To avoid the trivy-db becoming outdated, we save the cache for one day
-      - name: Get data
-        id: date
-        run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
-      - name: Restore trivy cache
-        if: ${{ inputs.trivy-fs-enabled }}
-        uses: actions/cache@v4.1.2
-        with:
-          path: cache/db
-          key: trivy-cache-${{ steps.date.outputs.date }}
-          restore-keys:
-            trivy-cache-
       - name: Run Github Trivy FS Action
         if: ${{ inputs.trivy-fs-enabled }}
         uses: aquasecurity/trivy-action@0.28.0
@@ -345,12 +333,6 @@ jobs:
           trivy-config: ${{ inputs.trivy-fs-config }}
         env:
           TRIVY_SKIP_DB_UPDATE: false
-      ## Trivy-db uses `0600` permissions.
-      ## But `action/cache` use `runner` user by default
-      ## So we need to change the permissions before caching the database.
-      - name: change permissions for trivy.db
-        if: ${{ inputs.trivy-fs-enabled }}
-        run: sudo chmod 0644 ./cache/db/trivy.db
       - name: Set Zap target env for Github Zap Action to Juju Unit IP Address
         if: ${{ inputs.zap-enabled && inputs.zap-target == '' }}
         run: echo "ZAP_TARGET=$(juju show-unit ${{ env.CHARM_NAME }}/0 --format=json | jq -r '.["${{ env.CHARM_NAME }}/0"]["address"]')" >> $GITHUB_ENV


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
* Cache the trivy DB as per https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#cache

### Rationale

<!-- The reason the change is needed -->
Avoid pulling the cache every time, which might result in hitting rate limits. This should mitigate the issue a bit.

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
