### PR TITLE
Disable VEX notices

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -287,6 +287,7 @@ jobs:
           exit-code: '1'
           severity: ${{ inputs.trivy-severity-config }}
         env:
+          TRIVY_DISABLE_VEX_NOTICE: true
           TRIVY_SKIP_DB_UPDATE: true
       - name: Check trivyignore
         run: |

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -332,6 +332,7 @@ jobs:
           scan-ref: ${{ inputs.trivy-fs-ref }}
           trivy-config: ${{ inputs.trivy-fs-config }}
         env:
+          TRIVY_DISABLE_VEX_NOTICE: true
           TRIVY_SKIP_DB_UPDATE: true
       - name: Set Zap target env for Github Zap Action to Juju Unit IP Address
         if: ${{ inputs.zap-enabled && inputs.zap-target == '' }}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
* Disable the recently enabled by default [VEX notices](https://github.com/aquasecurity/trivy/discussions/6033)

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
