### PR TITLE
Allow `continue-on-error` in `select-charm`

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -46,6 +46,13 @@ on:
           recent successful integration test that matches the git tree ID.
         type: string
         default: ""
+      select-channel-continue-on-error:
+        description: >-
+          Skip the select-channel step if the channel cannot be selected using the action logic.
+          This is useful when the charm has a fallback logic to select the channel.
+        type: boolean
+        required: false
+        default: false
 env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
@@ -61,6 +68,7 @@ jobs:
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.6.3
         id: select-channel
+        continue-on-error: ${{ inputs.select-channel-continue-on-error }}
   publish-charm:
     name: Publish charm to ${{ inputs.channel || needs.select-channel.outputs.destination-channel }}
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -46,13 +46,6 @@ on:
           recent successful integration test that matches the git tree ID.
         type: string
         default: ""
-      select-channel-continue-on-error:
-        description: >-
-          Skip the select-channel step if the channel cannot be selected using the action logic.
-          This is useful when the charm has a fallback logic to select the channel.
-        type: boolean
-        required: false
-        default: false
 env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
@@ -68,7 +61,7 @@ jobs:
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.6.3
         id: select-channel
-        continue-on-error: ${{ inputs.select-channel-continue-on-error }}
+        continue-on-error: true
   publish-charm:
     name: Publish charm to ${{ inputs.channel || needs.select-channel.outputs.destination-channel }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Overview  
Enable `continue-on-error` in the `select-charm` step.  

## Rationale  
Currently, workflows require the `select-charm` step to succeed in order to proceed with the `publish-charm` step. However, this approach doesn't account for scenarios where the workflow consumer can use the `channel` input value to specify the channel for uploading the charm.  

Example on how we consume the workflow: https://github.com/canonical/k8s-operator/blob/main/.github/workflows/publish-charms.yaml

This is particularly useful for cases such as our `k8s` charms, where branch naming follows upstream patterns (e.g., `release-1.xx`). This pull request allows the runner to bypass the `select-charm` result when needed, aligning with recommendations from the `charming-actions` repository.  

## Related Issues  
Workflow failure in the K8s release process: [GitHub Actions](https://github.com/canonical/k8s-operator/actions/runs/12011007492/job/33479080765)  