### PR TITLE
Update if conditions for Allure

### DIFF
--- a/.github/workflows/allure_report.yaml
+++ b/.github/workflows/allure_report.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Publish Allure report
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: always() && !cancelled()
+    if: always() && !cancelled() && github.run_attempt == '1'
     steps:
       - name: Download Allure
         # Following instructions from  https://allurereport.org/docs/install-for-linux/#install-from-a-deb-package

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -228,7 +228,7 @@ jobs:
         run: |
           tox -e ${{ inputs.test-tox-env }} -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} --allure-collection-dir=allure-default ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
       - name: Upload Default Allure results
-        if: env.ENABLE_ALLURE == 'true'
+        if: env.ENABLE_ALLURE == 'true' && github.run_attempt == '1'
         timeout-minutes: 3
         uses: actions/upload-artifact@v4
         with:
@@ -365,7 +365,7 @@ jobs:
           fi
       - name: Upload Allure results
         timeout-minutes: 3
-        if: env.ENABLE_ALLURE == 'true' && always()
+        if: env.ENABLE_ALLURE == 'true' && always() && !cancelled() && github.run_attempt == '1'
         uses: actions/upload-artifact@v4
         with:
           name: allure-results-${{ env.ALLURE_ARTIFACT_SUFFIX }}


### PR DESCRIPTION
### Overview

Allure workflow fails when the workflow is re-run due to the mkdir command. Restricting the allure workflow to run only during the first attempt.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
