### PR TITLE
fix: Export secrets only if defined

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -349,12 +349,12 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'microk8s' }}
         run: |
-          export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE }}" || :
-          export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_1 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_1 }}" || :
-          export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_2 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_2 }}" || :
-          export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_3 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_3 }}" || :
-          export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_4 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_4 }}" || :
-          export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_5 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_5 }}" || :
+          ([ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE }}") || :
+          ([ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_1 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_1 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_1 }}") || :
+          ([ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_2 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_2 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_2 }}") || :
+          ([ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_3 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_3 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_3 }}") || :
+          ([ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_4 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_4 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_4 }}") || :
+          ([ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_5 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_5 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_5 }}") || :
           if [ "$ENABLE_ALLURE" == "true" ]; then
             tox -e ${{ inputs.test-tox-env }} -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} --alluredir=allure-results ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }} 
           else

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -349,12 +349,12 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.provider == 'microk8s' }}
         run: |
-          ([ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE }}") || :
-          ([ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_1 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_1 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_1 }}") || :
-          ([ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_2 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_2 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_2 }}") || :
-          ([ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_3 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_3 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_3 }}") || :
-          ([ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_4 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_4 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_4 }}") || :
-          ([ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_5 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_5 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_5 }}") || :
+          [ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE }}" || :
+          [ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_1 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_1 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_1 }}" || :
+          [ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_2 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_2 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_2 }}" || :
+          [ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_3 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_3 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_3 }}" || :
+          [ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_4 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_4 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_4 }}" || :
+          [ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_5 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_5 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_5 }}" || :
           if [ "$ENABLE_ALLURE" == "true" ]; then
             tox -e ${{ inputs.test-tox-env }} -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} --alluredir=allure-results ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }} 
           else


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Follow-up of https://github.com/canonical/operator-workflows/pull/427 . Only export if the corresponding variables are defined.

### Rationale

Otherwise there are lines like 

```
/home/runner/work/_temp/5cc9d4c0-ea61-41fe-b2f1-fb21a308ad8d.sh: line 1: export: `=': not a valid identifier
/home/runner/work/_temp/5cc9d4c0-ea61-41fe-b2f1-fb21a308ad8d.sh: line 2: export: `=': not a valid identifier
/home/runner/work/_temp/5cc9d4c0-ea61-41fe-b2f1-fb21a308ad8d.sh: line 3: export: `=': not a valid identifier
/home/runner/work/_temp/5cc9d4c0-ea61-41fe-b2f1-fb21a308ad8d.sh: line 4: export: `=': not a valid identifier
/home/runner/work/_temp/5cc9d4c0-ea61-41fe-b2f1-fb21a308ad8d.sh: line 5: export: `=': not a valid identifier
/home/runner/work/_temp/5cc9d4c0-ea61-41fe-b2f1-fb21a308ad8d.sh: line 6: export: `=': not a valid identifier
```

which have no impact on the workflow run, but still might confuse. https://github.com/canonical/content-cache-k8s-operator/actions/runs/12387020163/job/34576999577#step:26:235

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
