### PR TITLE
Pass through tag-prefix to the canonical/charming-actions/release-cha…

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -32,6 +32,11 @@ on:
       origin-channel:
         type: string
         description: 'Origin Channel'
+      tag-prefix:
+        type: string
+        required: false
+        description: |
+          Tag prefix, useful when promoting multiple charms from the same repo.
       working-directory:
         type: string
         description: The working directory for jobs
@@ -176,6 +181,7 @@ jobs:
           base-name: ${{ needs.validate-inputs.outputs.name }}
           base-channel: ${{ needs.validate-inputs.outputs.channel }}
           base-architecture: ${{ needs.validate-inputs.outputs.arch }}
+          tag-prefix: ${{ inputs.tag-prefix }}
   draft-publish-docs:
     name: Draft publish docs
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### Overview

When a charm repo contains multiple charms, the promote-charm action fails because the charms have been tagged with a `<charm>-<rev>` tag-prefix` needed during the promote job


### Details
* the action [has an input](https://github.com/canonical/charming-actions/blob/934193396735701141a1decc3613818e412da606/release-charm/action.yaml#L30-L33) for tag-prefix that's unsupplied by operator-workflows
* this [tag-prefix is used](https://github.com/canonical/charming-actions/blob/934193396735701141a1decc3613818e412da606/src/actions/release-charm/release-charm.ts#L71-L74) after the charmcraft release is run to promote the charm

