### PR TITLE
fix: ignore go trivy vuln in pebble

### DIFF
--- a/tests/workflows/integration/test-rock/.trivyignore
+++ b/tests/workflows/integration/test-rock/.trivyignore
@@ -1,2 +1,3 @@
 # Pebble CVE, false positive: https://github.com/canonical/pebble/issues/498#issuecomment-2339325722
 CVE-2024-34156
+CVE-2024-45338

--- a/tests/workflows/integration/test-rock/.trivyignore
+++ b/tests/workflows/integration/test-rock/.trivyignore
@@ -1,3 +1,4 @@
 # Pebble CVE, false positive: https://github.com/canonical/pebble/issues/498#issuecomment-2339325722
 CVE-2024-34156
+# Can be removed after https://github.com/canonical/pebble/pull/540 is released
 CVE-2024-45338


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Adds pebble CVE ignore to test rock (pebble).
This will unblock other PRs.
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
