### PR TITLE
feat: Support for custom ubuntu series when selecting self-hosted runners in integration tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -206,6 +206,14 @@ jobs:
     outputs:
       plan: ${{ steps.plan.outputs.plan }}
     steps:
+      - name: Validate input
+        run: |
+          # exit if runs-on and self-hosted-runner is both set
+          if [ "${{ inputs.runs-on }}" != "ubuntu-22.04" ] && [ ${{ inputs.self-hosted-runner }} == true ]
+          then
+              echo "::error Both runs-on and self-hosted-runner cannot be set at the same time."
+              exit 1
+          fi
       - uses: actions/checkout@v4.2.2
       - uses: canonical/operator-workflows/internal/plan@main
         id: plan

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -90,7 +90,7 @@ on:
         default: "dns ingress rbac storage"
       runs-on:
         type: string
-        description: Image runner for building the images
+        description: Image of the runner to run the test job. This gets ignored if self-hosted-runner is set to true.
         default: ubuntu-22.04
       self-hosted-runner:
         type: boolean

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -88,6 +88,10 @@ on:
         description: Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.
         type: string
         default: "dns ingress rbac storage"
+      runs-on:
+        type: string
+        description: Image runner for building the images
+        default: ubuntu-22.04
       self-hosted-runner:
         type: boolean
         description: Whether to use self-hosted runners to run the jobs.
@@ -96,6 +100,10 @@ on:
         type: string
         description: Architecture to use on self-hosted runners to run the jobs.
         default: "x64"
+      self-hosted-runner-image:
+        type: string
+        description: Image of the requested runner. Supports only 'jammy' or 'noble'.
+        default: "jammy"
       self-hosted-runner-label:
         type: string
         description: Label for selecting the self-hosted runners.
@@ -331,7 +339,9 @@ jobs:
       pre-run-script: ${{ inputs.pre-run-script }}
       provider: ${{ inputs.provider }}
       registry: ghcr.io
+      runs-on: ${{ inputs.runs-on }}
       self-hosted-runner-arch: ${{ inputs.self-hosted-runner-arch }}
+      self-hosted-runner-image: ${{ inputs.self-hosted-runner-image }}
       self-hosted-runner-label: ${{ inputs.self-hosted-runner-label }}
       self-hosted-runner: ${{ inputs.self-hosted-runner }}
       series: ${{ inputs.series }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -345,7 +345,7 @@ jobs:
       pre-run-script: ${{ inputs.pre-run-script }}
       provider: ${{ inputs.provider }}
       registry: ghcr.io
-      runs-on: ${{ inputs.runs-on }}
+      runs-on: ${{ inputs.runs-on || 'ubuntu-22.04' }}
       self-hosted-runner-arch: ${{ inputs.self-hosted-runner-arch }}
       self-hosted-runner-image: ${{ inputs.self-hosted-runner-image }}
       self-hosted-runner-label: ${{ inputs.self-hosted-runner-label }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -90,8 +90,7 @@ on:
         default: "dns ingress rbac storage"
       runs-on:
         type: string
-        description: Image of the runner to run the test job. This gets ignored if self-hosted-runner is set to true.
-        default: ubuntu-22.04
+        description: Image of the GitHub hosted runner to run the test job. This cannot be combined with self-hosted-runner=true.
       self-hosted-runner:
         type: boolean
         description: Whether to use self-hosted runners to run the jobs.
@@ -209,11 +208,10 @@ jobs:
       - name: Validate input
         run: |
           # exit if runs-on and self-hosted-runner is both set
-          if [ "${{ inputs.runs-on }}" != "ubuntu-22.04" ] && [ ${{ inputs.self-hosted-runner }} == true ]
-          then
-              echo "::error Both runs-on and self-hosted-runner cannot be set at the same time."
-              exit 1
-          fi
+            if [ -n "${{ inputs.runs-on }}" ] && [ "${{ inputs.self-hosted-runner }}" = "true" ]; then
+                echo "::error Both runs-on and self-hosted-runner cannot be set at the same time."
+                exit 1
+            fi
       - uses: actions/checkout@v4.2.2
       - uses: canonical/operator-workflows/internal/plan@main
         id: plan
@@ -347,7 +345,7 @@ jobs:
       pre-run-script: ${{ inputs.pre-run-script }}
       provider: ${{ inputs.provider }}
       registry: ghcr.io
-      runs-on: ${{ inputs.runs-on }}
+      runs-on: ${{ inputs.runs-on }} || "ubuntu-22.04"
       self-hosted-runner-arch: ${{ inputs.self-hosted-runner-arch }}
       self-hosted-runner-image: ${{ inputs.self-hosted-runner-image }}
       self-hosted-runner-label: ${{ inputs.self-hosted-runner-label }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -345,7 +345,7 @@ jobs:
       pre-run-script: ${{ inputs.pre-run-script }}
       provider: ${{ inputs.provider }}
       registry: ghcr.io
-      runs-on: ${{ inputs.runs-on }} || "ubuntu-22.04"
+      runs-on: ${{ inputs.runs-on }}
       self-hosted-runner-arch: ${{ inputs.self-hosted-runner-arch }}
       self-hosted-runner-image: ${{ inputs.self-hosted-runner-image }}
       self-hosted-runner-label: ${{ inputs.self-hosted-runner-label }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -77,6 +77,10 @@ on:
         type: string
         description: Architecture to use on self-hosted runners to run the jobs.
         default: "x64"
+      self-hosted-runner-image:
+        type: string
+        description: Image of the requested runner. Supports only 'jammy' or 'noble'.
+        default: "jammy"
       self-hosted-runner-label:
         type: string
         description: Label for selecting the self-hosted runners.
@@ -166,8 +170,8 @@ jobs:
       ${{
         inputs.runs-on == 'ubuntu-22.04' &&
         inputs.self-hosted-runner &&
-        fromJson(format('[''self-hosted'', ''{0}'', ''jammy'', ''{1}'']',
-          inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label
+        fromJson(format('[''self-hosted'', ''{0}'', ''{1}'', ''{2}'']',
+          inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label, inputs.self-hosted-runner-image
         )) || inputs.runs-on
       }}
     steps:

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -67,7 +67,7 @@ on:
         default: ""
       runs-on:
         type: string
-        description: Image runner for building the images
+        description: Image of the runner to run the test job. This gets ignored if self-hosted-runner is set to true.
         default: ubuntu-22.04
       self-hosted-runner:
         type: boolean

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -168,7 +168,6 @@ jobs:
       fail-fast: false
     runs-on: >-
       ${{
-        inputs.runs-on == 'ubuntu-22.04' &&
         inputs.self-hosted-runner &&
         fromJson(format('[''self-hosted'', ''{0}'', ''{1}'', ''{2}'']',
           inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label, inputs.self-hosted-runner-image


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Provide support for custom series (noble, jammy) for self-hosted runners in integration tests. Similar change as done in  https://github.com/canonical/operator-workflows/pull/345

Also remove the hard-coding of `ubuntu-22.04` when using gh hosted runners by passing over runs-on .

### Rationale

Some runs are easier to perform using noble runners (they ship python 3.12 per default).

### Workflow Changes

`integration_test` workflow is adapted to have an option for specifying the image and runs-on is passed over to `integration_test_run`.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
