### PR TITLE
docs: document the feature to export secrets as environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ The following secrets are available for this workflow:
 |--------------------|-------------------|
 | INTEGRATION_TEST_ARGS | Additional arguments to pass to the integration test execution that contain secrets |
 
+Furthermore, in order to export sensitive data as environment variables into the integration test run,
+a mapping of variables to secrets can be defined by setting the [GitHub Action Variable](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables)
+`INTEGRATION_TEST_SECRET_ENV_NAME` with the name of the environment variable you want to export and `INTEGRATION_TEST_SECRET_ENV_VALUE` with the value you want the environment variable to have.
+ There are six slots available, in addition to the one mentioned above, you can use
+`INTEGRATION_TEST_SECRET_ENV_NAME_{1,...5}` and `INTEGRATION_TEST_SECRET_ENV_VALUE_{1,...5}`.
+
 When running the integration tests, the following posargs will be automatically passed to the `integration` target:
 
 * --charm-file [charm_file_name]: The name of the charm artifact generated prior to the integration tests run, this argument can be supplied multiple times for charm with multiple bases.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The following secrets are available for this workflow:
 Furthermore, in order to export sensitive data as environment variables into the integration test run,
 a mapping of variables to secrets can be defined by setting the [GitHub Action Variable](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables)
 `INTEGRATION_TEST_SECRET_ENV_NAME` with the name of the environment variable you want to export and `INTEGRATION_TEST_SECRET_ENV_VALUE` with the value you want the environment variable to have.
- There are six slots available, in addition to the one mentioned above, you can use
+ There are six slots available. In addition to the one mentioned above, you can use
 `INTEGRATION_TEST_SECRET_ENV_NAME_{1,...5}` and `INTEGRATION_TEST_SECRET_ENV_VALUE_{1,...5}`.
 
 When running the integration tests, the following posargs will be automatically passed to the `integration` target:


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Create documentation for the feature added in https://github.com/canonical/operator-workflows/pull/427 .

### Rationale

To make users aware of the feature and how to use it.

### Workflow Changes

n/a
### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
