### PR TITLE
Use the python version to separate out the concurrency group

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ on:
         default: false
 
 concurrency:
-  group: operator-workflows-${{ github.workflow }}-${{ inputs.working-directory }}-tests-${{ github.ref }}-self-hosted-${{ inputs.self-hosted-runner }}-uv-${{ inputs.with-uv }}
+  group: operator-workflows-${{ github.workflow }}-${{ inputs.working-directory }}-tests-${{ github.ref }}-self-hosted-${{ inputs.self-hosted-runner }}-py${{ inputs.python-version }}-uv-${{ inputs.with-uv }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -10,15 +10,31 @@ jobs:
   simple:
     uses: ./.github/workflows/test.yaml
     secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: 
+        - '3.8'
+        - '3.10'
+        - '3.12'
     with:
       working-directory: "tests/workflows/integration/test-upload-charm/"
       self-hosted-runner: false
+      python-version: ${{ matrix.python-version }}
   simple-uv:
     uses: ./.github/workflows/test.yaml
     secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: 
+        - '3.8'
+        - '3.10'
+        - '3.12'
     with:
       working-directory: "tests/workflows/integration/test-upload-charm/"
       self-hosted-runner: false
+      python-version: ${{ matrix.python-version }}
       with-uv: true
   simple-self-hosted:
     uses: ./.github/workflows/test.yaml

--- a/tests/workflows/integration/test-upload-charm/tox.ini
+++ b/tests/workflows/integration/test-upload-charm/tox.ini
@@ -38,7 +38,7 @@ deps =
     boto3
     bs4
     codespell
-    flake8<6.0.0
+    flake8
     flake8-docstrings
     flake8-docstrings-complete
     flake8-builtins
@@ -50,7 +50,7 @@ deps =
     psycopg2-binary
     pydocstyle>=2.10
     pylint
-    pyproject-flake8<6.0.0
+    pyproject-flake8
     pytest_asyncio
     pytest_operator
     pep8-naming


### PR DESCRIPTION
Unit test concurrency-group was preventing multiple versions of python to be run in a matrix style job.