### PR TITLE
Pick the first artifact and use it to comment on the PR

### DIFF
--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -7,7 +7,7 @@ on:
   workflow_call:
 
 env:
-  ARTIFACT_NAME: report
+  ARTIFACT_NAME: "report-"
 
 jobs:
   comment-on-pr:
@@ -30,7 +30,7 @@ jobs:
                 run_id: run_id,
             });
             const matchArtifact = artifacts.data.artifacts.filter(artifact =>
-              artifact.name == '${{ env.ARTIFACT_NAME }}'
+              artifact.name.startsWith('${{ env.ARTIFACT_NAME }}')
             )[0];
             const download = await github.rest.actions.downloadArtifact({
                 owner: owner,


### PR DESCRIPTION
Applicable spec: Resolved #549 

### Overview

the report artifact is no longer named `report` but rather `report-${concurrency-group}`

### Rationale

PR commenter is failing

### Workflow Changes

Adjust the artifact search to look for artifacts whose name starts with `report-`

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
