### PR TITLE
Unzip each report artifact and comment on the PR from each one

### DIFF
--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -7,16 +7,19 @@ on:
   workflow_call:
 
 env:
-  ARTIFACT_NAME: "report-"
+  ARTIFACT_NAME: "report"
 
 jobs:
-  comment-on-pr:
-    name: Comment on PR
+  download-artifacts:
+    name: Download Artifacts
     runs-on: ubuntu-24.04
     if: github.event.workflow_run.event == 'pull_request'
+    outputs:
+      artifacts: ${{ fromJson(steps.download-artifact.outputs.result) }}
     steps:
       - uses: actions/checkout@v4.2.2
-      - name: Download test report artifact
+      - id:   download-artifact
+        name: Download test report artifact
         uses: actions/github-script@v7.0.1
         with:
           script: |
@@ -29,19 +32,32 @@ jobs:
                 repo: repo,
                 run_id: run_id,
             });
-            const matchArtifact = artifacts.data.artifacts.filter(artifact =>
-              artifact.name.startsWith('${{ env.ARTIFACT_NAME }}')
-            )[0];
-            const download = await github.rest.actions.downloadArtifact({
-                owner: owner,
-                repo: repo,
-                artifact_id: matchArtifact.id,
-                archive_format: 'zip',
+            const zips = artifacts.data.artifacts.filter(artifact =>
+              artifact.name.startsWith('${{ env.ARTIFACT_NAME }}-')
+            ).forEach(artifact => {
+              const download = await github.rest.actions.downloadArtifact({
+                  owner: owner,
+                  repo: repo,
+                  artifact_id: artifact.id,
+                  archive_format: 'zip',
+              });
+              const zipPath = '${artifact}.zip';
+              fs.writeFileSync(zipPath, Buffer.from(download.data));
+              return zipPath;
             });
-            fs.writeFileSync('${{ env.ARTIFACT_NAME }}.zip', Buffer.from(download.data));
+            return JSON.stringify(zips);
+  comment-on-prs:
+    name: Comment on PRs
+    runs-on: ubuntu-24.04
+    needs: download-artifacts
+    if: github.event.workflow_run.event == 'pull_request'
+    strategy:
+      matrix:
+        artifact: ${{fromJson(needs.download-artifacts.outputs.artifacts)}}
+    steps:
       - name: Unzip
         shell: bash
-        run: unzip ${{ env.ARTIFACT_NAME }}.zip
+        run: unzip ${{ matrix.artifact }}
       - name: Comment on PR
         uses: actions/github-script@v7.0.1
         with:

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -5,6 +5,9 @@ name: Comment on the pull request
 
 on:
   workflow_call:
+  workflow_run:
+    workflows: ["Workflow test"]
+    types: [completed]
 
 env:
   ARTIFACT_NAME: "report"

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -140,6 +140,7 @@ jobs:
     timeout-minutes: 5
     needs:
       - simple
+      - simple-uv
       - simple-self-hosted
       - integration
       - integration-juju3
@@ -154,6 +155,7 @@ jobs:
     steps:
       - run: |
           [ '${{ needs.simple.result }}' = 'success' ] || (echo simple failed && false)
+          [ '${{ needs.simple-uv.result }}' = 'success' ] || (echo simple-uv failed && false)
           [ '${{ needs.simple-self-hosted.result }}' = 'success' ] || (echo simple-self-hosted failed && false)
           [ '${{ needs.integration.result }}' = 'success' ] || (echo integration failed && false)
           [ '${{ needs.integration-juju3.result }}' = 'success' ] || (echo integration-juju3 failed && false)


### PR DESCRIPTION
Applicable spec: #549

### Overview

So, inside each artifact is a file called "report.json".  It's necessary to unpack each artifact and comment from each one of them.

### Rationale

Without, the wrong report file is read

### Workflow Changes

This workflow can now report multiple coverage reports if multiple are run.

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
