### PR TITLE
Dump debug logs on failure

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -408,7 +408,7 @@ jobs:
         if: failure()
         run: |
           juju models
-          for model in $(juju models --format json | jq -r '.models[].name');
+          for model in $(juju models --format json | jq -r '.models[].name')
           do
             echo ==== debug-log in model: $model
             juju debug-log --replay --no-tail -m $model

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -410,8 +410,8 @@ jobs:
           juju models
           for model in $(juju models --format json | jq -r '.models[].name');
           do
-            echo DEBUG-LOG IN MODEL: $model;
-            juju debug-log --replay --no-tail -m $model;
+            echo ==== debug-log in model: $model
+            juju debug-log --replay --no-tail -m $model
       - name: Install k6s
         if: ${{ inputs.load-test-enabled }}
         run: sudo snap install k6

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -412,6 +412,7 @@ jobs:
           do
             echo ==== debug-log in model: $model
             juju debug-log --replay --no-tail -m $model
+          done
       - name: Install k6s
         if: ${{ inputs.load-test-enabled }}
         run: sudo snap install k6

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -404,6 +404,14 @@ jobs:
         with:
           app: ${{ env.CHARM_NAME }}
           model: testing
+      - name: Juju debug-log
+        if: failure()
+        run: |
+          juju models
+          for model in $(juju models --format json | jq -r '.models[].name');
+          do
+            echo DEBUG-LOG IN MODEL: $model;
+            juju debug-log --replay --no-tail -m $model;
       - name: Install k6s
         if: ${{ inputs.load-test-enabled }}
         run: sudo snap install k6


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

When one integration test fails, it is very difficult to debug it. Dumping all the logs in the output (although sometimes a bit heavy) would help debug flaky tests.

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
