### PR TITLE
Download report artifacts in an async loop

### DIFF
--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -6,7 +6,7 @@ name: Comment on the pull request
 on:
   workflow_call:
   workflow_run:
-    workflows: ["Workflow test"]
+    workflows: ["Workflow Unit tests"]
     types: [completed]
 
 env:

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -35,19 +35,22 @@ jobs:
                 repo: repo,
                 run_id: run_id,
             });
-            const zips = artifacts.data.artifacts.filter(artifact =>
+            const report_artifacts = artifacts.data.artifacts.filter(artifact =>
               artifact.name.startsWith('${{ env.ARTIFACT_NAME }}-')
-            ).forEach(artifact => {
-              const download = await github.rest.actions.downloadArtifact({
-                  owner: owner,
-                  repo: repo,
-                  artifact_id: artifact.id,
-                  archive_format: 'zip',
-              });
-              const zipPath = '${artifact}.zip';
-              fs.writeFileSync(zipPath, Buffer.from(download.data));
-              return zipPath;
-            });
+            )
+            const zips = await Promise.all(
+              report_artifacts.map(async artifact => {
+                const download = await github.rest.actions.downloadArtifact({
+                    owner: owner,
+                    repo: repo,
+                    artifact_id: artifact.id,
+                    archive_format: 'zip',
+                });
+                const zipPath = `${artifact}.zip`;
+                fs.writeFileSync(zipPath, Buffer.from(download.data));
+                return zipPath;
+              })
+            );
             return JSON.stringify(zips);
   comment-on-prs:
     name: Comment on PRs

--- a/.github/workflows/workflow_simple_test.yaml
+++ b/.github/workflows/workflow_simple_test.yaml
@@ -1,0 +1,58 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: Workflow Unit Tests
+
+on:
+  pull_request:
+
+jobs:
+  simple:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: 
+        - '3.8'
+        - '3.10'
+        - '3.12'
+    with:
+      working-directory: "tests/workflows/integration/test-upload-charm/"
+      self-hosted-runner: false
+      python-version: ${{ matrix.python-version }}
+  simple-uv:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: 
+        - '3.8'
+        - '3.10'
+        - '3.12'
+    with:
+      working-directory: "tests/workflows/integration/test-upload-charm/"
+      self-hosted-runner: false
+      python-version: ${{ matrix.python-version }}
+      with-uv: true
+  simple-self-hosted:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+    with:
+      working-directory: "tests/workflows/integration/test-upload-charm/"
+      self-hosted-runner: true
+      self-hosted-runner-label: "edge"
+  check:
+    runs-on: ubuntu-latest
+    if: always() && !cancelled()
+    timeout-minutes: 5
+    needs:
+      - simple
+      - simple-uv
+      - simple-self-hosted
+    steps:
+      - run: |
+          [ '${{ needs.simple.result }}' = 'success' ] || (echo simple failed && false)
+          [ '${{ needs.simple-uv.result }}' = 'success' ] || (echo simple-uv failed && false)
+          [ '${{ needs.simple-self-hosted.result }}' = 'success' ] || (echo simple-self-hosted failed && false)

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -1,48 +1,12 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-name: Workflow test
+name: Workflow Integration tests
 
 on:
   pull_request:
 
 jobs:
-  simple:
-    uses: ./.github/workflows/test.yaml
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: 
-        - '3.8'
-        - '3.10'
-        - '3.12'
-    with:
-      working-directory: "tests/workflows/integration/test-upload-charm/"
-      self-hosted-runner: false
-      python-version: ${{ matrix.python-version }}
-  simple-uv:
-    uses: ./.github/workflows/test.yaml
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: 
-        - '3.8'
-        - '3.10'
-        - '3.12'
-    with:
-      working-directory: "tests/workflows/integration/test-upload-charm/"
-      self-hosted-runner: false
-      python-version: ${{ matrix.python-version }}
-      with-uv: true
-  simple-self-hosted:
-    uses: ./.github/workflows/test.yaml
-    secrets: inherit
-    with:
-      working-directory: "tests/workflows/integration/test-upload-charm/"
-      self-hosted-runner: true
-      self-hosted-runner-label: "edge"
   integration:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit
@@ -139,9 +103,6 @@ jobs:
     if: always() && !cancelled()
     timeout-minutes: 5
     needs:
-      - simple
-      - simple-uv
-      - simple-self-hosted
       - integration
       - integration-juju3
       - integration-artifact
@@ -154,9 +115,6 @@ jobs:
       - allure-report
     steps:
       - run: |
-          [ '${{ needs.simple.result }}' = 'success' ] || (echo simple failed && false)
-          [ '${{ needs.simple-uv.result }}' = 'success' ] || (echo simple-uv failed && false)
-          [ '${{ needs.simple-self-hosted.result }}' = 'success' ] || (echo simple-self-hosted failed && false)
           [ '${{ needs.integration.result }}' = 'success' ] || (echo integration failed && false)
           [ '${{ needs.integration-juju3.result }}' = 'success' ] || (echo integration-juju3 failed && false)
           [ '${{ needs.integration-artifact.result }}' = 'success' ] || (echo integration-artifact failed && false)


### PR DESCRIPTION
fix:  ensure report artifacts are downloaded in an async loop

Example of continuing failures:
* https://github.com/canonical/infrastructure-services/actions/runs/13242857666