### PR TITLE
fix: split artifact filtering and commenting

### DIFF
--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -32,8 +32,8 @@ jobs:
                 repo: context.payload.workflow_run.repository.name,
                 run_id: ${{ github.event.workflow_run.id }},
             });
-            const zips = artifacts.data.artifacts.filter(artifact =>
-              artifact.name.startsWith('${{ env.ARTIFACT_NAME }}-')
+            const zips = artifacts.data.artifacts.flatMap(artifact =>
+              artifact.name.startsWith('${{ env.ARTIFACT_NAME }}-')? [artifact.name] : []
             );
             return JSON.stringify(zips);
   comment-on-prs:

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -13,57 +13,44 @@ env:
   ARTIFACT_NAME: "report"
 
 jobs:
-  download-artifacts:
-    name: Download Artifacts
+  filter-artifacts:
+    name: Filter Artifacts
     runs-on: ubuntu-24.04
     if: github.event.workflow_run.event == 'pull_request'
     outputs:
-      artifacts: ${{ fromJson(steps.download-artifact.outputs.result) }}
+      artifacts: ${{ fromJson(steps.filter-artifacts.outputs.result) }}
     steps:
       - uses: actions/checkout@v4.2.2
-      - id:   download-artifact
-        name: Download test report artifact
+      - id:   filter-artifacts
+        name: Filter test report artifacts
         uses: actions/github-script@v7.0.1
         with:
           script: |
             const fs = require('fs');
-            const owner = context.payload.workflow_run.repository.owner.login;
-            const repo = context.payload.workflow_run.repository.name;
-            const run_id = ${{ github.event.workflow_run.id }};
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-                owner: owner,
-                repo: repo,
-                run_id: run_id,
+                owner: context.payload.workflow_run.repository.owner.login,
+                repo: context.payload.workflow_run.repository.name,
+                run_id: ${{ github.event.workflow_run.id }},
             });
-            const report_artifacts = artifacts.data.artifacts.filter(artifact =>
+            const zips = artifacts.data.artifacts.filter(artifact =>
               artifact.name.startsWith('${{ env.ARTIFACT_NAME }}-')
-            )
-            const zips = await Promise.all(
-              report_artifacts.map(async artifact => {
-                const download = await github.rest.actions.downloadArtifact({
-                    owner: owner,
-                    repo: repo,
-                    artifact_id: artifact.id,
-                    archive_format: 'zip',
-                });
-                const zipPath = `${artifact}.zip`;
-                fs.writeFileSync(zipPath, Buffer.from(download.data));
-                return zipPath;
-              })
             );
             return JSON.stringify(zips);
   comment-on-prs:
     name: Comment on PRs
     runs-on: ubuntu-24.04
-    needs: download-artifacts
+    needs: filter-artifacts
     if: github.event.workflow_run.event == 'pull_request'
     strategy:
       matrix:
-        artifact: ${{fromJson(needs.download-artifacts.outputs.artifacts)}}
+        artifact: ${{fromJson(needs.filter-artifacts.outputs.artifacts)}}
     steps:
-      - name: Unzip
-        shell: bash
-        run: unzip ${{ matrix.artifact }}
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          repository: ${{ github.event.workflow_run.repository.name }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: ${{ matrix.artifact }}
       - name: Comment on PR
         uses: actions/github-script@v7.0.1
         with:
@@ -73,11 +60,13 @@ jobs:
             const comments = JSON.parse(fs.readFileSync('${{ env.ARTIFACT_NAME }}.json'));
             const owner = context.payload.workflow_run.repository.owner.login;
             const repo = context.payload.workflow_run.repository.name;
+            const sha = context.payload.workflow_run.head_sha
+            const header = `## Test results for commit ${sha}\n\n`;
 
             const pull = (await github.rest.pulls.list({
                 owner: owner,
                 repo: repo,
-            })).data.filter(pr => pr.head.sha == context.payload.workflow_run.head_sha)[0];
+            })).data.filter(pr => pr.head.sha == sha)[0];
             const issue_number = pull.number;
 
             const createComment = async (body) => {
@@ -85,7 +74,7 @@ jobs:
                     owner: owner,
                     repo: repo,
                     issue_number: issue_number,
-                    body,
+                    header + body,
                 });
             }
 
@@ -96,7 +85,9 @@ jobs:
                     issue_number: issue_number,
                 });
                 const githubActionsComments = existingComments.data.filter(
-                    comment => comment.user.login == 'github-actions[bot]'
+                    comment =>
+                      comment.user.login == 'github-actions[bot]' &&
+                      !comment.body.startsWith(header),
                 );
                 for (const comment of githubActionsComments) {
                     await github.rest.issues.deleteComment({

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -40,7 +40,7 @@ jobs:
     name: Comment on PRs
     runs-on: ubuntu-24.04
     needs: filter-artifacts
-    if: github.event.workflow_run.event == 'pull_request'
+    if: github.event.workflow_run.event == 'pull_request' && needs.filter-artifacts.outputs.artifacts != '[]'
     strategy:
       matrix:
         artifact: ${{fromJson(needs.filter-artifacts.outputs.artifacts)}}

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -46,7 +46,7 @@ jobs:
         artifact: ${{fromJson(needs.filter-artifacts.outputs.artifacts)}}
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.8
         with:
           repository: ${{ github.event.workflow_run.repository.name }}
           run-id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
Applicable spec: Issue: #549 

### Overview

As part of fixing the PR commenter, split apart the filtering from the downloading of artifacts

### Rationale

At the moment, we download artifacts that aren't available to the comment job.
We should instead let each "comment" step download and comment together. 

### Workflow Changes

Each report will now generate a separate set of comments on a PR. The sha will appear in the header to help remove old comments if new commits are made for a PR. 

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

