### PR TITLE
Remove the usage of REPO_ACCESS_TOKEN in auto_update_charm_libs.yaml

### DIFF
--- a/.github/workflows/auto_update_charm_libs.yaml
+++ b/.github/workflows/auto_update_charm_libs.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Create pull request
         uses: canonical/create-pull-request@main
         with:
-          github-token: ${{ secrets.REPO_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update charm libraries"
           branch-name: "chore/auto-libs"
           title: Update charm libraries


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Remove the usage of REPO_ACCESS_TOKEN in auto_update_charm_libs.yaml

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
