### PR TITLE
Simplifies the download of report to use job syntax

### DIFF
--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -9,6 +9,10 @@ on:
     workflows: ["Workflow Unit tests"]
     types: [completed]
 
+permissions:
+  # Needed to add and delete comments on a PRs
+  pull-requests: write
+
 env:
   ARTIFACT_NAME: "report"
 
@@ -17,37 +21,41 @@ jobs:
     name: Setup environment
     runs-on: ubuntu-24.04
     outputs:
+      IS_PR: ${{ steps.call.outputs.IS_PR || steps.run.outputs.IS_PR }}
       ORG: ${{ steps.call.outputs.ORG || steps.run.outputs.ORG }}
       REPO: ${{ steps.call.outputs.REPO || steps.run.outputs.REPO }}
       RUN_ID: ${{ steps.call.outputs.RUN_ID || steps.run.outputs.RUN_ID }}
       REPO_FULL_NAME: ${{ steps.call.outputs.REPO_FULL_NAME || steps.run.outputs.REPO_FULL_NAME }}
       SHA: ${{ steps.call.outputs.SHA || steps.run.outputs.SHA }}
     steps:
-    - name: Workflow call setup
+    - name: Workflow call setup from a Pull Request
       id: call
-      if: github.event_name == 'workflow_call'
+      if: github.event_name == 'pull_request'
       run: |
-        echo "RUN_ID=${{ github.event.workflow_call.run_id }}" >> $GITHUB_OUTPUT
-        echo "ORG=${{ github.event.workflow_call.organization.login }}" >> $GITHUB_OUTPUT
-        echo "REPO=${{ github.event.workflow_call.repository.name }}" >> $GITHUB_OUTPUT
-        echo "REPO_FULL_NAME=${{ github.event.workflow_call.repository.full_name }}" >> $GITHUB_OUTPUT
-        echo "SHA=${{ github.event.workflow_call.head_sha }}" >> $GITHUB_OUTPUT
+        echo "Setting up from a workflow call"
+        echo "RUN_ID=${{ github.run_id }}" >> $GITHUB_OUTPUT
+        REPO_FULL_NAME="${{ github.repository }}"
+        parts=(${REPO_FULL_NAME//\// })
+        echo "ORG=${parts[0]}" >> $GITHUB_OUTPUT
+        echo "REPO=${parts[1]}" >> $GITHUB_OUTPUT
+        echo "SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+        echo "IS_PR=${{ github.event_name == 'pull_request' }}" >> $GITHUB_OUTPUT
     - name: Workflow run setup
       id: run
       if: github.event_name == 'workflow_run'
       run: |
         echo "RUN_ID=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
-        echo "ORG=${{ github.event.workflow_call.organization.login }}" >> $GITHUB_OUTPUT
-        echo "REPO=${{ github.event.workflow_call.repository.name }}" >> $GITHUB_OUTPUT
+        echo "ORG=${{ github.event.workflow_run.organization.login }}" >> $GITHUB_OUTPUT
+        echo "REPO=${{ github.event.workflow_run.repository.name }}" >> $GITHUB_OUTPUT
         echo "REPO_FULL_NAME=${{ github.event.workflow_run.repository.full_name }}" >> $GITHUB_OUTPUT
         echo "SHA=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT
-
+        echo "IS_PR=${{ github.event.workflow_run.event == 'pull_request' }}" >> $GITHUB_OUTPUT
 
   comment-on-prs:
     name: Comment on PRs
     runs-on: ubuntu-24.04
     needs: setup-env
-    if: github.event.workflow_run.event == 'pull_request'
+    if: ${{ needs.setup-env.outputs.IS_PR }}
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4.1.8
@@ -83,7 +91,7 @@ jobs:
                     owner: owner,
                     repo: repo,
                     issue_number: issue_number,
-                    header + body,
+                    body: (header + body),
                 });
             }
 

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -13,16 +13,47 @@ env:
   ARTIFACT_NAME: "report"
 
 jobs:
+  setup-env:
+    name: Setup environment
+    runs-on: ubuntu-24.04
+    outputs:
+      ORG: ${{ steps.call.outputs.ORG || steps.run.outputs.ORG }}
+      REPO: ${{ steps.call.outputs.REPO || steps.run.outputs.REPO }}
+      RUN_ID: ${{ steps.call.outputs.RUN_ID || steps.run.outputs.RUN_ID }}
+      REPO_FULL_NAME: ${{ steps.call.outputs.REPO_FULL_NAME || steps.run.outputs.REPO_FULL_NAME }}
+      SHA: ${{ steps.call.outputs.SHA || steps.run.outputs.SHA }}
+    steps:
+    - name: Workflow call setup
+      id: call
+      if: github.event_name == 'workflow_call'
+      run: |
+        echo "RUN_ID=${{ github.event.workflow_call.run_id }}" >> $GITHUB_OUTPUT
+        echo "ORG=${{ github.event.workflow_call.organization.login }}" >> $GITHUB_OUTPUT
+        echo "REPO=${{ github.event.workflow_call.repository.name }}" >> $GITHUB_OUTPUT
+        echo "REPO_FULL_NAME=${{ github.event.workflow_call.repository.full_name }}" >> $GITHUB_OUTPUT
+        echo "SHA=${{ github.event.workflow_call.head_sha }}" >> $GITHUB_OUTPUT
+    - name: Workflow run setup
+      id: run
+      if: github.event_name == 'workflow_run'
+      run: |
+        echo "RUN_ID=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+        echo "ORG=${{ github.event.workflow_call.organization.login }}" >> $GITHUB_OUTPUT
+        echo "REPO=${{ github.event.workflow_call.repository.name }}" >> $GITHUB_OUTPUT
+        echo "REPO_FULL_NAME=${{ github.event.workflow_run.repository.full_name }}" >> $GITHUB_OUTPUT
+        echo "SHA=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT
+
+
   comment-on-prs:
     name: Comment on PRs
     runs-on: ubuntu-24.04
+    needs: setup-env
     if: github.event.workflow_run.event == 'pull_request'
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          repository: ${{ github.event.workflow_run.repository.full_name }}
-          run-id: ${{ github.event.workflow_run.id }}
+          repository: ${{ needs.setup-env.outputs.REPO_FULL_NAME }}
+          run-id: ${{ needs.setup-env.outputs.RUN_ID }}
           pattern: "${{ env.ARTIFACT_NAME }}-*"
       - name: Comment on PR
         uses: actions/github-script@v7.0.1
@@ -31,9 +62,9 @@ jobs:
           script: |
             const fs = require('fs');
             const artifact = '${{ env.ARTIFACT_NAME }}';
-            const owner = context.payload.workflow_run.repository.owner.login;
-            const repo = context.payload.workflow_run.repository.name;
-            const sha = context.payload.workflow_run.head_sha
+            const owner = '${{ needs.setup-env.outputs.ORG }}';
+            const repo = '${{ needs.setup-env.outputs.REPO }}';
+            const sha = '${{ needs.setup-env.outputs.SHA }}';
             const header = `## Test results for commit ${sha}\n\n`;
             const comments = fs.readdirSync('.')
                 .filter(d => fs.statSync(d).isDirectory() && d.startsWith(`${artifact}-`))

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -13,55 +13,33 @@ env:
   ARTIFACT_NAME: "report"
 
 jobs:
-  filter-artifacts:
-    name: Filter Artifacts
-    runs-on: ubuntu-24.04
-    if: github.event.workflow_run.event == 'pull_request'
-    outputs:
-      artifacts: ${{ fromJson(steps.filter-artifacts.outputs.result) }}
-    steps:
-      - uses: actions/checkout@v4.2.2
-      - id:   filter-artifacts
-        name: Filter test report artifacts
-        uses: actions/github-script@v7.0.1
-        with:
-          script: |
-            const fs = require('fs');
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-                owner: context.payload.workflow_run.repository.owner.login,
-                repo: context.payload.workflow_run.repository.name,
-                run_id: ${{ github.event.workflow_run.id }},
-            });
-            const zips = artifacts.data.artifacts.flatMap(artifact =>
-              artifact.name.startsWith('${{ env.ARTIFACT_NAME }}-')? [artifact.name] : []
-            );
-            return JSON.stringify(zips);
   comment-on-prs:
     name: Comment on PRs
     runs-on: ubuntu-24.04
-    needs: filter-artifacts
-    if: github.event.workflow_run.event == 'pull_request' && needs.filter-artifacts.outputs.artifacts != '[]'
-    strategy:
-      matrix:
-        artifact: ${{fromJson(needs.filter-artifacts.outputs.artifacts)}}
+    if: github.event.workflow_run.event == 'pull_request'
     steps:
-      - name: Download artifact
+      - name: Download artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          repository: ${{ github.event.workflow_run.repository.name }}
+          repository: ${{ github.event.workflow_run.repository.full_name }}
           run-id: ${{ github.event.workflow_run.id }}
-          name: ${{ matrix.artifact }}
+          pattern: "${{ env.ARTIFACT_NAME }}-*"
       - name: Comment on PR
         uses: actions/github-script@v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const comments = JSON.parse(fs.readFileSync('${{ env.ARTIFACT_NAME }}.json'));
+            const artifact = '${{ env.ARTIFACT_NAME }}';
             const owner = context.payload.workflow_run.repository.owner.login;
             const repo = context.payload.workflow_run.repository.name;
             const sha = context.payload.workflow_run.head_sha
             const header = `## Test results for commit ${sha}\n\n`;
+            const comments = fs.readdirSync('.')
+                .filter(d => fs.statSync(d).isDirectory() && d.startsWith(`${artifact}-`))
+                .map(dir => `${dir}/${artifact}.json`)
+                .filter(fs.existsSync)
+                .flatMap(filePath => JSON.parse(fs.readFileSync(filePath, 'utf8')));
 
             const pull = (await github.rest.pulls.list({
                 owner: owner,

--- a/.github/workflows/workflow_simple_test.yaml
+++ b/.github/workflows/workflow_simple_test.yaml
@@ -56,3 +56,11 @@ jobs:
           [ '${{ needs.simple.result }}' = 'success' ] || (echo simple failed && false)
           [ '${{ needs.simple-uv.result }}' = 'success' ] || (echo simple-uv failed && false)
           [ '${{ needs.simple-self-hosted.result }}' = 'success' ] || (echo simple-self-hosted failed && false)
+  test-comment:
+    name: Comment on the pull request
+    uses: ./.github/workflows/comment.yaml
+    if: always() && !cancelled()
+    needs:
+      - simple
+      - simple-uv
+      - simple-self-hosted


### PR DESCRIPTION
Applicable spec: #549

### Overview

* `download-artifact` action already supports globbed downloads, use this instead of pre-filtering.
* rather than use a matrix of downloading each artifact, download all the `report-` artifacts in one go, read the report out of each downloaded artifact folder `report-<....>/report.json` and use it to fill up a list of `comments` to post

### Rationale

Simplifies the comment on PR job

### Workflow Changes

None

### Checklist

- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

