### PR TITLE
Correct workflow-runner organization which is missing

### DIFF
--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -38,6 +38,7 @@ jobs:
         parts=(${REPO_FULL_NAME//\// })
         echo "ORG=${parts[0]}" >> $GITHUB_OUTPUT
         echo "REPO=${parts[1]}" >> $GITHUB_OUTPUT
+        echo "REPO_FULL_NAME=${REPO_FULL_NAME}" >> $GITHUB_OUTPUT
         echo "SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
         echo "IS_PR=${{ github.event_name == 'pull_request' }}" >> $GITHUB_OUTPUT
     - name: Workflow run setup

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -45,7 +45,7 @@ jobs:
       if: github.event_name == 'workflow_run'
       run: |
         echo "RUN_ID=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
-        echo "ORG=${{ github.event.workflow_run.organization.login }}" >> $GITHUB_OUTPUT
+        echo "ORG=${{ github.event.workflow_run.repository.owner.login }}" >> $GITHUB_OUTPUT
         echo "REPO=${{ github.event.workflow_run.repository.name }}" >> $GITHUB_OUTPUT
         echo "REPO_FULL_NAME=${{ github.event.workflow_run.repository.full_name }}" >> $GITHUB_OUTPUT
         echo "SHA=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -61,9 +61,10 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4.1.8
         with:
+          pattern: "${{ env.ARTIFACT_NAME }}-*"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ needs.setup-env.outputs.REPO_FULL_NAME }}
           run-id: ${{ needs.setup-env.outputs.RUN_ID }}
-          pattern: "${{ env.ARTIFACT_NAME }}-*"
       - name: Comment on PR
         uses: actions/github-script@v7.0.1
         with:

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       IS_PR: ${{ steps.call.outputs.IS_PR || steps.run.outputs.IS_PR }}
-      ORG: ${{ steps.call.outputs.ORG || steps.run.outputs.ORG }}
+      OWNER: ${{ steps.call.outputs.OWNER || steps.run.outputs.OWNER }}
       REPO: ${{ steps.call.outputs.REPO || steps.run.outputs.REPO }}
       RUN_ID: ${{ steps.call.outputs.RUN_ID || steps.run.outputs.RUN_ID }}
       REPO_FULL_NAME: ${{ steps.call.outputs.REPO_FULL_NAME || steps.run.outputs.REPO_FULL_NAME }}
@@ -36,7 +36,7 @@ jobs:
         echo "RUN_ID=${{ github.run_id }}" >> $GITHUB_OUTPUT
         REPO_FULL_NAME="${{ github.repository }}"
         parts=(${REPO_FULL_NAME//\// })
-        echo "ORG=${parts[0]}" >> $GITHUB_OUTPUT
+        echo "OWNER=${parts[0]}" >> $GITHUB_OUTPUT
         echo "REPO=${parts[1]}" >> $GITHUB_OUTPUT
         echo "REPO_FULL_NAME=${REPO_FULL_NAME}" >> $GITHUB_OUTPUT
         echo "SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
@@ -46,7 +46,7 @@ jobs:
       if: github.event_name == 'workflow_run'
       run: |
         echo "RUN_ID=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
-        echo "ORG=${{ github.event.workflow_run.repository.owner.login }}" >> $GITHUB_OUTPUT
+        echo "OWNER=${{ github.event.workflow_run.repository.owner.login }}" >> $GITHUB_OUTPUT
         echo "REPO=${{ github.event.workflow_run.repository.name }}" >> $GITHUB_OUTPUT
         echo "REPO_FULL_NAME=${{ github.event.workflow_run.repository.full_name }}" >> $GITHUB_OUTPUT
         echo "SHA=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT
@@ -72,7 +72,7 @@ jobs:
           script: |
             const fs = require('fs');
             const artifact = '${{ env.ARTIFACT_NAME }}';
-            const owner = '${{ needs.setup-env.outputs.ORG }}';
+            const owner = '${{ needs.setup-env.outputs.OWNER }}';
             const repo = '${{ needs.setup-env.outputs.REPO }}';
             const sha = '${{ needs.setup-env.outputs.SHA }}';
             const header = `## Test results for commit ${sha}\n\n`;


### PR DESCRIPTION
Applicable spec: #549 

### Overview

workflow runs offer an unset organization
example) https://github.com/canonical/k8s-operator/actions/runs/13507118728/job/37739162857

### Rationale

Appropriately set the organization when detected pull requests

### Workflow Changes

None

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

