### PR TITLE
Fix the inclusive naming workflow running in the subdirectory

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,10 +84,10 @@ jobs:
           # Combine all entries and replace matching elements by
           # .name in .rules for the ones in .woke.yaml
           woke_file=""
-          if [ -f ./${{ inputs.working-directory }}/.woke.yaml ]; then
-            woke_file="./${{ inputs.working-directory }}/.woke.yaml"
-          elif [ -f ./${{ inputs.working-directory }}/.woke.yml ]; then
-            woke_file="./${{ inputs.working-directory }}/.woke.yml"
+          if [ -f .woke.yaml ]; then
+            woke_file=".woke.yaml"
+          elif [ -f .woke.yml ]; then
+            woke_file=".woke.yml"
           fi
           if [ ! -z "$woke_file" ]; then
             yq eval-all '

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,9 +70,6 @@ jobs:
           inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label, inputs.self-hosted-runner-image
         )) || 'ubuntu-22.04'
       }}
-    defaults:
-      run:
-        working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Change directory

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -101,10 +101,9 @@ jobs:
         uses: canonical/inclusive-naming@main
         with:
           fail-on-error: "true"
-          workdir: ${{ inputs.working-directory }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
-          woke-args: ". -c /tmp/config.yml"
+          woke-args: "${{ inputs.working-directory }} -c /tmp/config.yml"
           filter-mode: nofilter
           woke-version: latest
   vale:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,11 +79,13 @@ jobs:
           rm -rf .* * || :
           cp -rp $TEMP_DIR/. .
           rm -rf $TEMP_DIR
-          ls -lah
       - uses: actions/checkout@v4.2.2
         with:
           repository: canonical/Inclusive-naming
-          path: /tmp
+          path: tmp-inclusive-naming
+      - run: |
+          mv tmp-inclusive-naming/config.yml /tmp/config.yml
+          rm -rf tmp-inclusive-naming
       - name: Merge configuration files
         run: |
           # Combine all entries and replace matching elements by

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,29 +72,22 @@ jobs:
       }}
     steps:
       - uses: actions/checkout@v4.2.2
-      - name: Change directory
-        run: |
-          TEMP_DIR=$(mktemp -d)
-          cp -rp ./${{ inputs.working-directory }}/. $TEMP_DIR
-          rm -rf .* * || :
-          cp -rp $TEMP_DIR/. .
-          rm -rf $TEMP_DIR
-      - uses: actions/checkout@v4.2.2
         with:
           repository: canonical/Inclusive-naming
           path: tmp-inclusive-naming
       - run: |
           mv tmp-inclusive-naming/config.yml /tmp/config.yml
           rm -rf tmp-inclusive-naming
+      - uses: actions/checkout@v4.2.2
       - name: Merge configuration files
         run: |
           # Combine all entries and replace matching elements by
           # .name in .rules for the ones in .woke.yaml
           woke_file=""
-          if [ -f .woke.yaml ]; then
-            woke_file=".woke.yaml"
-          elif [ -f .woke.yml ]; then
-            woke_file=".woke.yml"
+          if [ -f ./${{ inputs.working-directory }}/.woke.yaml ]; then
+            woke_file="./${{ inputs.working-directory }}/.woke.yaml"
+          elif [ -f ./${{ inputs.working-directory }}/.woke.yml ]; then
+            woke_file="./${{ inputs.working-directory }}/.woke.yml"
           fi
           if [ ! -z "$woke_file" ]; then
             yq eval-all '
@@ -108,6 +101,7 @@ jobs:
         uses: canonical/inclusive-naming@main
         with:
           fail-on-error: "true"
+          workdir: ${{ inputs.working-directory }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           woke-args: ". -c /tmp/config.yml"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,11 +75,18 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v4.2.2
+      - name: Change directory
+        run: |
+          TEMP_DIR=$(mktemp -d)
+          cp -rp ./${{ inputs.working-directory }}/. $TEMP_DIR
+          rm -rf .* * || :
+          cp -rp $TEMP_DIR/. .
+          rm -rf $TEMP_DIR
+          ls -lah
+      - uses: actions/checkout@v4.2.2
         with:
           repository: canonical/Inclusive-naming
-          path: ${{ inputs.working-directory }}
-      - run: mv * /tmp
-      - uses: actions/checkout@v4.2.2
+          path: /tmp
       - name: Merge configuration files
         run: |
           # Combine all entries and replace matching elements by
@@ -106,7 +113,6 @@ jobs:
           reporter: github-pr-review
           woke-args: ". -c /tmp/config.yml"
           filter-mode: nofilter
-          workdir: ${{ inputs.working-directory }}
           woke-version: latest
   vale:
     name: Style checker

--- a/tests/workflows/integration/test-upload-charm/tox.ini
+++ b/tests/workflows/integration/test-upload-charm/tox.ini
@@ -49,6 +49,7 @@ deps =
     ops-lib-pgsql
     psycopg2-binary
     pydocstyle>=2.10
+    snowballstemmer<3.0.0
     pylint
     pyproject-flake8
     pytest_asyncio


### PR DESCRIPTION
Applicable spec: <link>

### Overview

The excluding file option in the `woke` configuration has some issues matching files inside subdirectories. This appears to be a problem with `woke`'s pattern matching mechanism. Based on some testing, the only way to run `woke` inside a subdirectory is to execute it from the root directory as the working directory and provide the subdirectory as an argument to `woke`. Update the inclusive naming workflow accordingly.

This change has a side effect: the `woke` configuration file must now be placed in the root directory. However, this seems to be a reasonable compromise until the issue within `woke` is fixed.

Here's an example of the `.woke.yaml` file and a successful test workflow run using the new inclusive naming workflow.

https://github.com/canonical/http-proxy-operators/blob/bcf599577d5f4bfaae36b0a01d7da94553e54081/.woke.yaml
https://github.com/canonical/http-proxy-operators/actions/runs/14177765146/job/39716637075?pr=2

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
