### PR TITLE
remove draft-publish-docs from required status check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -496,6 +496,7 @@ jobs:
   required_status_checks:
     name: Required Test Status Checks
     needs:
+      - draft-publish-docs
       - docker-lint
       - inclusive-naming-check
       - lib-check
@@ -514,7 +515,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - run: |
-          [ '${{ needs.draft-publish-docs.result }}' = 'success' ] || (echo draft-publish-docs failed && false)
+          [ '${{ needs.draft-publish-docs.result }}' = 'success' ] || (echo 'Warning: The "Draft Publish Docs" job failed. The workflow will still be considered successful.' )
           [ '${{ needs.docker-lint.result }}' = 'success' ] || (echo docker-lint failed && false)
           [ '${{ needs.inclusive-naming-check.result }}' = 'success' ] || (echo inclusive-naming-check failed && false)
           [ '${{ needs.lib-check.result }}' = 'success' ] || (echo lib-check failed && false)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -496,7 +496,6 @@ jobs:
   required_status_checks:
     name: Required Test Status Checks
     needs:
-      - draft-publish-docs
       - docker-lint
       - inclusive-naming-check
       - lib-check

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-05-21
+
+- Allow the "Draft Publish Docs" job to fail, but still consider the "Tests" workflow successful.
+
 ## 2025-03-21
 
 ### Added


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Allow the "Draft Publish Docs" job to fail, but still consider the "Tests" workflow successful.

### Rationale

It has been discussed in PFE team internally that this job is currently hard to troubleshoot and slows down people from merging their PR's. 

Publishing or overwriting documents from Git is still prevented in the event of a failure, as this is currently done in the promotion workflow.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
