### PR TITLE
Fix if clause in Run k8s integration tests

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -384,7 +384,7 @@ jobs:
           echo "ARGS=$args" >> $GITHUB_ENV
       - name: Run k8s integration tests
         working-directory: ${{ inputs.working-directory }}
-        if: ${{ inputs.provider == 'microk8s' }} || ${ inputs.provider == 'k8s' }
+        if: inputs.provider == 'microk8s' || inputs.provider == 'k8s'
         run: |
           [ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE }}" || :
           [ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_1 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_1 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_1 }}" || :

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
-## 2025-04-29
+## 2025-05-22
 
-### Modified
+### Fixed
 
-- Update `promote_charm` workflow logic to use `charmcraft status` to obtain base information instead of `charmcraft.yaml`.
+- Fix the step "Run k8s integration test" in the integration test workflow to not always run.
 
 ## 2025-05-21
 
@@ -21,6 +21,13 @@ Each revision is versioned by the date of the revision.
 ## Changed
 
 - Allow the "Draft Publish Docs" job to fail, but still consider the "Tests" workflow successful.
+
+## 2025-04-29
+
+### Modified
+
+- Update `promote_charm` workflow logic to use `charmcraft status` to obtain base information instead of `charmcraft.yaml`.
+
 
 ## 2025-03-21
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Fix if clause in Run k8s integration tests

### Rationale

because right now even if "lxd" is the provider this step is used.

E.g. https://github.com/canonical/github-runner-operator/actions/runs/15186513224/job/42709106053

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
