### PR TITLE
Change charm name extraction logic in `promote_charm`

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -84,7 +84,8 @@ jobs:
             exit 1
           fi
 
-          CHARM_NAME=$(yq e '.name' charmcraft.yaml)
+          EXPANDED=$(CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=1 charmcraft expand-extensions)
+          CHARM_NAME=$(echo "$EXPANDED" | yq '.name')
           if [[ -z "$CHARM_NAME" || "$CHARM_NAME" == "null" ]]; then
             echo "Error: Could not extract charm name from charmcraft.yaml."
             exit 1

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-05-27
+
+### Fixed
+
+- Update `promote_charm` workflow to obtain charm name from `charmcraft expand-extensions` instead 
+  of `charmcraft.yaml`.
+
 ## 2025-05-22
 
 ### Fixed
@@ -14,11 +21,11 @@ Each revision is versioned by the date of the revision.
 
 ## 2025-05-21
 
-## Removed
+### Removed
 
 - Ejected draft publish docs step from from promote charm workflow.
 
-## Changed
+### Changed
 
 - Allow the "Draft Publish Docs" job to fail, but still consider the "Tests" workflow successful.
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Update `promote_charm` workflow to obtain charm name from `charmcraft expand-extensions` instead 
  of `charmcraft.yaml`.
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
