### PR TITLE
Use default branch as base branch for doc

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -197,6 +197,7 @@ jobs:
           dry_run: ${{ inputs.doc-automation-disabled }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           charm_dir:  ${{ inputs.working-directory }}/${{ inputs.charm-directory }}
+          base_branch: ${{ github.event.repository.default_branch }}
       - name: Show index page
         if: ${{ steps.docs-exist.outputs.docs_exist == 'True' && env.discourse_api_username != '' && env.discourse_api_key != '' }}
         run: echo '${{ steps.publishDocumentation.outputs.index_url }}'

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -127,6 +127,7 @@ jobs:
           dry_run: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
           charm_dir: ${{ needs.publish-charm.outputs.charm-directory }}
+          base_branch: ${{ github.event.repository.default_branch }}
   release-charm-libs:
     name: Release charm libs
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -453,6 +453,7 @@ jobs:
           dry_run: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
           charm_dir: ${{ inputs.working-directory }}/${{ inputs.charm-directory }}
+          base_branch: ${{ github.event.repository.default_branch }}
   license-headers-check:
     name: Check license headers
     runs-on: >-

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+### 2025-06-04
+
+### Changed
+
+- gatekeeper is now called with a "base_branch" argument set to the default branch of the repository. This is to support documentation actions on repositories not using "main" as their main branch.
+
 ### 2025-05-30
 
 ### Added


### PR DESCRIPTION
Some of our repositories are following the $major/main convention for their main branch, and by default gatekeeper looks for "main".

With this PR we instruct gatekeeper to use the default branch of the project as the source of truth for documentation.

The proposal come from comments in a previous PR on the same topic: https://github.com/canonical/operator-workflows/pull/617