### PR TITLE
feat: Support using tox with `tox-uv`

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -166,6 +166,11 @@ on:
         type: boolean
         description: (Experimental) Whether to use canonical k8s instead of microk8s
         default: false
+      with-uv:
+        type: boolean
+        description: Whether to use tox with uv
+        required: false
+        default: false
       working-directory:
         type: string
         description: The working directory for jobs
@@ -373,6 +378,7 @@ jobs:
       trivy-fs-config: ${{ inputs.trivy-fs-config }}
       trivy-fs-enabled: ${{ inputs.trivy-fs-enabled }}
       trivy-fs-ref: ${{ inputs.trivy-fs-ref }}
+      with-uv: ${{ inputs.with-uv }}
       working-directory: ${{ inputs.working-directory }}
       zap-auth-header-value: ${{ inputs.zap-auth-header-value }}
       zap-auth-header: ${{ inputs.zap-auth-header }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -92,6 +92,11 @@ on:
         description: Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.
         type: string
         default: "dns ingress rbac storage"
+      python-version:
+        type: string
+        required: false
+        description: Python version to use when installing tox
+        default: ""
       runs-on:
         type: string
         description: Image of the GitHub hosted runner to run the test job. This cannot be combined with self-hosted-runner=true.
@@ -362,6 +367,7 @@ jobs:
       plan: ${{ needs.plan.outputs.plan }}
       pre-run-script: ${{ inputs.pre-run-script }}
       provider: ${{ inputs.provider }}
+      python-version: ${{ inputs.python-version }}
       use-canonical-k8s: ${{ inputs.use-canonical-k8s }}
       registry: ghcr.io
       runs-on: ${{ inputs.runs-on || 'ubuntu-22.04' }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -224,7 +224,7 @@ jobs:
           echo "UNIQUE_ARTIFACT_SUFFIX=$unique_artifact_suffix" >> $GITHUB_ENV
       - name: Setup Astral UV
         if: ${{ inputs.with-uv }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6.1.0
         with:
           python-version: ${{ env.python-version }}
       - name: Install tox with UV

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -124,6 +124,11 @@ on:
         type: boolean
         description: (Experimental) Whether to use canonical k8s instead of microk8s
         default: false
+      with-uv:
+        type: boolean
+        description: Whether to use tox with uv
+        required: false
+        default: false
       working-directory:
         type: string
         description: The working directory for jobs
@@ -177,6 +182,18 @@ jobs:
           inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label, inputs.self-hosted-runner-image
         )) || inputs.runs-on
       }}
+    env:
+      python-version: >-
+        ${{
+          inputs.python-version ||
+          inputs.self-hosted-runner &&
+          (
+            inputs.self-hosted-runner-image == 'noble' && '3.12' ||
+            inputs.self-hosted-runner-image == 'jammy' && '3.10' ||
+            inputs.self-hosted-runner-image == 'focal' && '3.8'
+          ) ||
+          '3.10'
+        }}
     steps:
       - name: Disable snap autorefresh
         run: sudo snap refresh --hold=2h
@@ -200,7 +217,16 @@ jobs:
           fi
           echo "MODULE=$module" >> $GITHUB_ENV
           echo "UNIQUE_ARTIFACT_SUFFIX=$unique_artifact_suffix" >> $GITHUB_ENV
+      - name: Setup Astral UV
+        if: ${{ inputs.with-uv }}
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ env.python-version }}
+      - name: Install tox with UV
+        if: ${{ inputs.with-uv }}
+        run: uv tool install tox --with tox-uv
       - name: Install tox
+        if: ${{ ! inputs.with-uv }}
         run: |
           if which tox &> /dev/null; then
             echo "tox is already installed."

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -57,6 +57,11 @@ on:
         description: Actions operator provider as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: microk8s
+      python-version:
+        type: string
+        required: false
+        description: Python version to use when installing tox
+        default: ""
       microk8s-addons:
         description: Microk8s provider add-ons override. A minimum set of addons (the defaults) must be enabled.
         type: string

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -46,6 +46,14 @@ jobs:
       trivy-image-config: "tests/workflows/integration/test-upload-charm/trivy.yaml"
       self-hosted-runner: true
       self-hosted-runner-label: "edge"
+  integration-with-uv:
+    uses: ./.github/workflows/integration_test.yaml
+    secrets: inherit
+    with:
+      working-directory: "tests/workflows/integration/test-upload-charm/"
+      trivy-image-config: "tests/workflows/integration/test-upload-charm/trivy.yaml"
+      self-hosted-runner: false
+      with-uv: true
   integration-rock:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -54,6 +54,7 @@ jobs:
       trivy-image-config: "tests/workflows/integration/test-upload-charm/trivy.yaml"
       self-hosted-runner: false
       with-uv: true
+      python-version: "3.12"
   integration-rock:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
-## 2025-06-05
+## 2025-06-09
 
 ### Added
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
-### 2025-05-30
+## 2025-06-05
+
+### Added
+
+- Added support for installing `tox` with `uv` in the integration tests workflows.
+
+## 2025-05-30
 
 ### Added
 

--- a/tests/workflows/integration/test-upload-charm/tox.ini
+++ b/tests/workflows/integration/test-upload-charm/tox.ini
@@ -105,7 +105,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==2.9.42.4
+    juju==2.9.49.1
     pytest
     pytest-operator
     pytest-asyncio


### PR DESCRIPTION
### Overview

Add support for using tox with `uv` while running integration tests.

### Rationale

When a charm uses the `uv` plugin, certain environments use the runner environment key, which depends on the tooling available in `uv` and `tox-uv`.

For instance:
```
Run tox -e integration --notest --list-dependencies 2>&1
Traceback (most recent call last):
  File "/home/ubuntu/.local/bin/tox", line 8, in <module>
    sys.exit(run())
  File "/home/ubuntu/.local/pipx/venvs/tox/lib/python3.10/site-packages/tox/run.py", line 20, in run
    result = main(sys.argv[1:] if args is None else args)
  File "/home/ubuntu/.local/pipx/venvs/tox/lib/python3.10/site-packages/tox/run.py", line 46, in main
    return handler(state)
  File "/home/ubuntu/.local/pipx/venvs/tox/lib/python3.10/site-packages/tox/session/cmd/legacy.py", line [11](https://github.com/canonical/rawfile-localpv-operator/actions/runs/15475186584/job/43569031989#step:8:12)5, in legacy
    return run_sequential(state)
  File "/home/ubuntu/.local/pipx/venvs/tox/lib/python3.10/site-packages/tox/session/cmd/run/sequential.py", line 25, in run_sequential
    return execute(state, max_workers=1, has_spinner=False, live=True)
  File "/home/ubuntu/.local/pipx/venvs/tox/lib/python3.10/site-packages/tox/session/cmd/run/common.py", line [16](https://github.com/canonical/rawfile-localpv-operator/actions/runs/15475186584/job/43569031989#step:8:17)7, in execute
    state.envs.ensure_only_run_env_is_active()
  File "/home/ubuntu/.local/pipx/venvs/tox/lib/python3.10/site-packages/tox/session/env_select.py", line 436, in ensure_only_run_env_is_active
    envs, active = self._defined_envs, self._env_name_to_active()
  File "/home/ubuntu/.local/pipx/venvs/tox/lib/python3.10/site-packages/tox/session/env_select.py", line 258, in _defined_envs
    run_env = self._build_run_env(name)
  File "/home/ubuntu/.local/pipx/venvs/tox/lib/python3.10/site-packages/tox/session/env_select.py", line 3[19](https://github.com/canonical/rawfile-localpv-operator/actions/runs/15475186584/job/43569031989#step:8:20), in _build_run_env
    runner = REGISTER.runner(cast("str", env_conf["runner"]))
  File "/home/ubuntu/.local/pipx/venvs/tox/lib/python3.10/site-packages/tox/tox_env/register.py", line 72, in runner
    return self._run_envs[name]
KeyError: 'uv-venv-lock-runner'
Error: Process completed with exit code 1.
````
### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
