### PR TITLE
Add f-string format to integration_test_run

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -214,11 +214,11 @@ jobs:
           module = """${{ matrix.modules }}"""
           unique_artifact_suffix = str(uuid.uuid4())
           if series:
-              unique_artifact_suffix += "-{safe(series)}"
-              series = "--series {matrix.series}"
+              unique_artifact_suffix += f"-{safe(series)}"
+              series = f"--series {series}"
           if module:
-              unique_artifact_suffix += "-{safe(module)}"
-              module = "-k '{module}'"
+              unique_artifact_suffix += f"-{safe(module)}"
+              module = f"-k '{module}'"
           
           GITHUB_ENV_FILE.write(f"SERIES={series}\n")
           GITHUB_ENV_FILE.write(f"MODULE={module}\n")


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Integration tests are failing with `ERROR: Wrong expression passed to '-k': {module}: at column 1: unexpected character "{"`

### Rationale

Fix how to handle module variable

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)
No need to update changelog
<!-- Explanation for any unchecked items above -->
