### PR TITLE
Call internal workflows locally rather than with `@main`

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -153,10 +153,10 @@ on:
       upload-image:
         type: string
         description: >-
-          Can be either 'artifact' or 'registry', which determines the method by which images used 
-          in integration tests are uploaded. If set to 'artifact', the images will be uploaded as GitHub 
-          action artifacts. If set to 'registry', the images will be uploaded to ghcr. 
-          If this parameter is not specified, the default behavior is to use 'artifact' for pull requests 
+          Can be either 'artifact' or 'registry', which determines the method by which images used
+          in integration tests are uploaded. If set to 'artifact', the images will be uploaded as GitHub
+          action artifacts. If set to 'registry', the images will be uploaded to ghcr.
+          If this parameter is not specified, the default behavior is to use 'artifact' for pull requests
           originating from forked repositories, and 'registry' for all other cases.
         default: ""
       use-canonical-k8s:
@@ -226,7 +226,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
             fetch-depth: 0
-      - uses: canonical/operator-workflows/internal/plan@main
+      - uses: ./internal/plan
         id: plan
         with:
           identifier: ${{ inputs.identifier }}
@@ -259,7 +259,7 @@ jobs:
         run: |
           pipx install charmcraftcache
       - uses: actions/checkout@v4.2.2
-      - uses: canonical/operator-workflows/internal/build@main
+      - uses: ./internal/build
         id: build
         with:
           build-plan: ${{ toJSON(matrix.build) }}
@@ -277,7 +277,8 @@ jobs:
     outputs:
       scans: ${{ steps.plan-scan.outputs.scans }}
     steps:
-      - uses: canonical/operator-workflows/internal/plan-scan@main
+      - uses: actions/checkout@v4.2.2
+      - uses: ./internal/plan-scan
         id: plan-scan
         with:
           plan: ${{ needs.plan.outputs.plan }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -207,6 +207,8 @@ on:
 env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
+  WORKFLOW_REF: ${{ github.action_ref || github.ref }}
+  WORKFLOW_REPO: ${{ github.action_repository || github.repository }}
 
 jobs:
   plan:
@@ -225,8 +227,13 @@ jobs:
             fi
       - uses: actions/checkout@v4.2.2
         with:
-            fetch-depth: 0
-      - uses: ./internal/plan
+          fetch-depth: 0
+      - uses: actions/checkout@v4.2.2
+        with:
+          repository: ${{ env.WORKFLOW_REPO }}
+          ref: ${{ env.WORKFLOW_REF }}
+          path: _workflow_repo
+      - uses: ./_workflow_repo/internal/plan
         id: plan
         with:
           identifier: ${{ inputs.identifier }}
@@ -259,7 +266,12 @@ jobs:
         run: |
           pipx install charmcraftcache
       - uses: actions/checkout@v4.2.2
-      - uses: ./internal/build
+      - uses: actions/checkout@v4.2.2
+        with:
+          repository: ${{ env.WORKFLOW_REPO }}
+          ref: ${{ env.WORKFLOW_REF }}
+          path: _workflow_repo
+      - uses: ./_workflow_repo/internal/build
         id: build
         with:
           build-plan: ${{ toJSON(matrix.build) }}
@@ -278,7 +290,11 @@ jobs:
       scans: ${{ steps.plan-scan.outputs.scans }}
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: ./internal/plan-scan
+        with:
+          repository: ${{ env.WORKFLOW_REPO }}
+          ref: ${{ env.WORKFLOW_REF }}
+          path: _workflow_repo
+      - uses: ./_workflow_repo/internal/plan-scan
         id: plan-scan
         with:
           plan: ${{ needs.plan.outputs.plan }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -218,6 +218,10 @@ jobs:
       plan: ${{ steps.plan.outputs.plan }}
       has-code-changes: ${{ steps.changes.outputs.has_code_changes }}
     steps:
+      - name: Dump github context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
       - name: Validate input
         run: |
           # exit if runs-on and self-hosted-runner is both set

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -204,12 +204,12 @@ jobs:
           import os
           import re
           import uuid
-          
+
           def safe(s):
               return re.sub('[^0-9a-zA-Z-_]+', '-', s)
-          
+
           GITHUB_ENV_FILE = open(os.environ["GITHUB_ENV"], "a")
-          
+
           series = """${{ matrix.series }}"""
           module = """${{ matrix.modules }}"""
           unique_artifact_suffix = str(uuid.uuid4())
@@ -219,11 +219,11 @@ jobs:
           if module:
               unique_artifact_suffix += f"-{safe(module)}"
               module = f"-k '{module}'"
-          
+
           GITHUB_ENV_FILE.write(f"SERIES={series}\n")
           GITHUB_ENV_FILE.write(f"MODULE={module}\n")
           GITHUB_ENV_FILE.write(f"UNIQUE_ARTIFACT_SUFFIX={unique_artifact_suffix}\n")
-          
+
           GITHUB_ENV_FILE.close()
       - name: Setup Astral UV
         if: ${{ inputs.with-uv }}
@@ -285,7 +285,7 @@ jobs:
         id: canonical-k8s
         run: |
           sudo snap install k8s --channel=${{ inputs.channel }} --classic
-          
+
           cat << EOF | sudo k8s bootstrap --file -
           containerd-base-dir: /opt/containerd
           EOF
@@ -298,7 +298,7 @@ jobs:
           mkdir -p ~/.kube
           sudo k8s config > ~/.kube/config
           echo "kubeconfig=$(sudo k8s config | base64 -w 0)" >> $GITHUB_OUTPUT
-          
+
           IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
           LB_FIRST_ADDR="$(echo "${IPADDR}" | awk -F'.' '{print $1,$2,$3,100}' OFS='.')"
           LB_LAST_ADDR="$(echo "${IPADDR}" | awk -F'.' '{print $1,$2,$3,255}' OFS='.')"
@@ -311,13 +311,13 @@ jobs:
           credentials-yaml: ${{ steps.canonical-k8s.outputs.kubeconfig }}
           microk8s-addons: >-
             ${{
-              ( 
-                github.event.pull_request.head.repo.full_name != github.repository && 
+              (
+                github.event.pull_request.head.repo.full_name != github.repository &&
                 !contains(inputs.microk8s-addons, 'registry')
               ) &&
               (
-                inputs.microk8s-addons == '' && 
-                'registry' || 
+                inputs.microk8s-addons == '' &&
+                'registry' ||
                 format('registry {0}', inputs.microk8s-addons)
               ) ||
               inputs.microk8s-addons
@@ -361,7 +361,7 @@ jobs:
 
       - run: sudo apt install skopeo -y
       - name: Plan Integration
-        uses: canonical/operator-workflows/internal/plan-integration@main
+        uses: ./internal/plan-integration
         id: plan-integration
         with:
           plan: ${{ inputs.plan }}
@@ -387,9 +387,9 @@ jobs:
           [ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_4 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_4 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_4 }}" || :
           [ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_5 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_5 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_5 }}" || :
           if [ "$ENABLE_ALLURE" == "true" ]; then
-            tox -e ${{ inputs.test-tox-env }} -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} --alluredir=allure-results ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }} 
+            tox -e ${{ inputs.test-tox-env }} -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} --alluredir=allure-results ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
           else
-            tox -e ${{ inputs.test-tox-env }} -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }} 
+            tox -e ${{ inputs.test-tox-env }} -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
           fi
       - name: Run lxd integration tests
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -162,6 +162,10 @@ on:
         description: Rules file to ignore any alerts from the ZAP scan
         type: string
 
+env:
+  WORKFLOW_REF: ${{ github.action_ref || github.ref }}
+  WORKFLOW_REPO: ${{ github.action_repository || github.repository }}
+
 jobs:
   integration-test:
     name: Integration tests
@@ -360,8 +364,13 @@ jobs:
           VAULT_APPROLE_SECRET_ID: ${{ secrets.VAULT_APPROLE_SECRET_ID }}
 
       - run: sudo apt install skopeo -y
+      - uses: actions/checkout@v4.2.2
+        with:
+          repository: ${{ env.WORKFLOW_REPO }}
+          ref: ${{ env.WORKFLOW_REF }}
+          path: _workflow_repo
       - name: Plan Integration
-        uses: ./internal/plan-integration
+        uses: ./_workflow_repo/internal/plan-integration
         id: plan-integration
         with:
           plan: ${{ inputs.plan }}

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -55,6 +55,8 @@ env:
   OWNER: ${{ github.repository_owner }}
   CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
   ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
+  WORKFLOW_REF: ${{ github.action_ref || github.ref }}
+  WORKFLOW_REPO: ${{ github.action_repository || github.repository }}
 
 jobs:
   select-channel:
@@ -75,8 +77,12 @@ jobs:
       has-code-changes: ${{ steps.changes.outputs.has_code_changes }}
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          repository: ${{ env.WORKFLOW_REPO }}
+          ref: ${{ env.WORKFLOW_REF }}
+          path: _workflow_repo
       - name: Get plan
-        uses: ./internal/get-plan
+        uses: ./_workflow_repo/internal/get-plan
         id: get-plan
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -111,7 +117,12 @@ jobs:
         # required to use skopeo embedded within rockcraft - otherwise a docker error
         # "io: read/write on closed pipe" will happen
       - run: sudo snap install rockcraft --classic
-      - uses: ./internal/publish
+      - uses: actions/checkout@v4.2.2
+        with:
+          repository: ${{ env.WORKFLOW_REPO }}
+          ref: ${{ env.WORKFLOW_REF }}
+          path: _workflow_repo
+      - uses: ./_workflow_repo/internal/publish
         id: publish
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -74,8 +74,9 @@ jobs:
       run-id: ${{ steps.get-plan.outputs.run-id }}
       has-code-changes: ${{ steps.changes.outputs.has_code_changes }}
     steps:
+      - uses: actions/checkout@v4.2.2
       - name: Get plan
-        uses: canonical/operator-workflows/internal/get-plan@main
+        uses: ./internal/get-plan
         id: get-plan
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -110,7 +111,7 @@ jobs:
         # required to use skopeo embedded within rockcraft - otherwise a docker error
         # "io: read/write on closed pipe" will happen
       - run: sudo snap install rockcraft --classic
-      - uses: canonical/operator-workflows/internal/publish@main
+      - uses: ./internal/publish
         id: publish
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run_bot_pr_approval.yaml
+++ b/.github/workflows/run_bot_pr_approval.yaml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   bot_pr_approval:
-    uses: canonical/operator-workflows/.github/workflows/bot_pr_approval.yaml@main
+    uses: ./.github/workflows/bot_pr_approval.yaml
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,6 +62,9 @@ concurrency:
 env:
   CONCURRENCY_GROUP: operator-workflows-${{ inputs.working-directory }}-tests-${{ github.ref }}-self-hosted-${{ inputs.self-hosted-runner }}-py${{ inputs.python-version }}-uv-${{ inputs.with-uv }}
   REPORT_NAME: "report"
+  WORKFLOW_REF: ${{ github.action_ref || github.ref }}
+  WORKFLOW_REPO: ${{ github.action_repository || github.repository }}
+
 
 jobs:
   inclusive-naming-check:
@@ -254,7 +257,7 @@ jobs:
             options+=" --break-system-packages"
           fi
           python3 -m pip install check-jsonschema $options
-          curl -fLsSo $PWD/metadata.schema https://raw.githubusercontent.com/canonical/operator-workflows/${REF}/.github/files/metadata.schema
+          curl -fLsSo $PWD/metadata.schema https://raw.githubusercontent.com/${WORKFLOW_REPO}/${WORKFLOW_REF}/.github/files/metadata.schema
           check-jsonschema metadata.yaml --schemafile metadata.schema
   lint-and-unit-test:
     name: Lint and unit tests
@@ -474,8 +477,7 @@ jobs:
       - name: Get default license configuration
         if: steps.licenserc-yaml.outputs.exists == 'false'
         run: |
-          REF="${{ github.action_ref || 'main' }}"
-          curl -fLsSo .licenserc.yaml https://raw.githubusercontent.com/canonical/operator-workflows/${REF}/.github/files/.licenserc.yaml
+          curl -fLsSo .licenserc.yaml https://raw.githubusercontent.com/${WORKFLOW_REPO}/${WORKFLOW_REF}/.github/files/.licenserc.yaml
       - name: Check license headers
         uses: apache/skywalking-eyes/header@main
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,6 @@ on:
         required: false
         default: false
 
-        
 concurrency:
   group: operator-workflows-${{ github.workflow }}-${{ inputs.working-directory }}-tests-${{ github.ref }}-self-hosted-${{ inputs.self-hosted-runner }}-py${{ inputs.python-version }}-uv-${{ inputs.with-uv }}
   cancel-in-progress: true
@@ -249,12 +248,13 @@ jobs:
         if: steps.metadata-yaml.outputs.exists == 'true'
         id: run-lint
         run: |
+          REF="${{ github.action_ref || 'main' }}"
           options=""
           if [[ "${{ inputs.self-hosted-runner-image }}" == "noble" ]]; then
             options+=" --break-system-packages"
           fi
           python3 -m pip install check-jsonschema $options
-          curl -fLsSo $PWD/metadata.schema https://raw.githubusercontent.com/canonical/operator-workflows/main/.github/files/metadata.schema
+          curl -fLsSo $PWD/metadata.schema https://raw.githubusercontent.com/canonical/operator-workflows/${REF}/.github/files/metadata.schema
           check-jsonschema metadata.yaml --schemafile metadata.schema
   lint-and-unit-test:
     name: Lint and unit tests
@@ -296,7 +296,7 @@ jobs:
       - name: Install tox
         if: ${{ ! inputs.with-uv }}
         run: pip install tox
-          
+
       # Test with tox-uv and python setup by UV
       - name: Setup Astral UV
         if: ${{ inputs.with-uv }}
@@ -443,7 +443,7 @@ jobs:
       - name: Publish documentation
         if: ${{ steps.docs-exist.outputs.docs_exist == 'True' && !github.event.pull_request.head.repo.fork && env.discourse_api_username != '' && env.discourse_api_key != '' }}
         uses: canonical/discourse-gatekeeper@stable
-        env: 
+        env:
           discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
           discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
         with:
@@ -474,7 +474,8 @@ jobs:
       - name: Get default license configuration
         if: steps.licenserc-yaml.outputs.exists == 'false'
         run: |
-          curl -fLsSo .licenserc.yaml https://raw.githubusercontent.com/canonical/operator-workflows/main/.github/files/.licenserc.yaml
+          REF="${{ github.action_ref || 'main' }}"
+          curl -fLsSo .licenserc.yaml https://raw.githubusercontent.com/canonical/operator-workflows/${REF}/.github/files/.licenserc.yaml
       - name: Check license headers
         uses: apache/skywalking-eyes/header@main
         with:


### PR DESCRIPTION
Fixes #683 

Avoids calling `canonical/operator-workflows/internal/<action>@main` because it prevents the operatork-workflows from being pinned.