### PR TITLE
Fix lib publishing job

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -173,7 +173,7 @@ jobs:
       - name: Change directory
         run: |
           TEMP_DIR=$(mktemp -d)
-          cp -rp ./${{ inputs.working-directory }}/${{ fromJSON(needs.plan.outputs.plan).build[0].source_directory }}/. $TEMP_DIR
+          cp -rp ${{ inputs.working-directory }}/${{ fromJSON(needs.plan.outputs.plan).build[0].source_directory }}/. $TEMP_DIR
           rm -rf .* * || :
           cp -rp $TEMP_DIR/. .
           rm -rf $TEMP_DIR

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,12 @@ Each revision is versioned by the date of the revision.
 
 ### 2025-06-12
 
+### Fixed
+
+- Bug getting the directory when publishing the charm libraries
+
+### 2025-06-12
+
 ### Changed
 
 - Skip building and scanning artifacts if there are only documentation changes


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Fixes a bug getting the path for the libs introduced in #679 

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
