### PR TITLE
Revert parallelizing publish

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -180,13 +180,13 @@ jobs:
     name: Release charm libs
     runs-on: ubuntu-24.04
     if: ${{ inputs.publish-libs && needs.plan.outputs.has-code-changes == 'True' }}
-    needs: [ plan ]
+    needs: [ plan, publish-charm ]
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Change directory
         run: |
           TEMP_DIR=$(mktemp -d)
-          cp -rp ${{ inputs.working-directory }}/${{ fromJSON(needs.plan.outputs.plan).build[0].source_directory }}/. $TEMP_DIR
+          cp -rp ./${{ needs.publish-charm.outputs.charm-directory }}/. $TEMP_DIR
           rm -rf .* * || :
           cp -rp $TEMP_DIR/. .
           rm -rf $TEMP_DIR

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+### 2025-06-18
+
+### Changed
+
+Revert Make publish libs independent from charm publishing
+
 ### 2025-06-12
 
 ### Changed


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
This reverts #679 . There's an issue peeventing lib publishing for multi-repo setups

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
