### PR TITLE
Feat/ck8s docker mirror

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -285,6 +285,15 @@ jobs:
         id: canonical-k8s
         run: |
           sudo snap install k8s --channel=${{ inputs.channel }} --classic
+
+          MIRROR_CONFIG=/opt/containerd/k8s-containerd/etc/containerd/hosts.d/docker.io
+
+          sudo mkdir -p ${MIRROR_CONFIG}
+          sudo chown $USER ${MIRROR_CONFIG}
+          cat << EOF > ${MIRROR_CONFIG}/hosts.toml
+          [host."$DOCKERHUB_MIRROR"]
+          capabilities = ["pull", "resolve"]
+          EOF
           
           cat << EOF | sudo k8s bootstrap --file -
           containerd-base-dir: /opt/containerd

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -286,6 +286,7 @@ jobs:
         run: |
           sudo snap install k8s --channel=${{ inputs.channel }} --classic
 
+          if [ -n "$DOCKERHUB_MIRROR" ]; then
           MIRROR_CONFIG=/opt/containerd/k8s-containerd/etc/containerd/hosts.d/docker.io
 
           sudo mkdir -p ${MIRROR_CONFIG}
@@ -294,6 +295,7 @@ jobs:
           [host."$DOCKERHUB_MIRROR"]
           capabilities = ["pull", "resolve"]
           EOF
+          fi
           
           cat << EOF | sudo k8s bootstrap --file -
           containerd-base-dir: /opt/containerd

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,19 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
-### 2025-06-19
+## 2025-07-08
+
+### Added
+
+- Support for `DOCKERHUB_MIRROR` in Canonicak Kubernetes configuration.
+
+## 2025-06-19
 
 ### Changed
 
 - Revert "Define required secrets in the promote workflow".
 
-### 2025-06-18
+## 2025-06-18
 
 ### Changed
 
 Revert Make publish libs independent from charm publishing
 
-### 2025-06-12
+## 2025-06-12
 
 ### Changed
 
@@ -28,7 +34,7 @@ Revert Make publish libs independent from charm publishing
 
 - Bug getting the directory when publishing the charm libraries.
 
-### 2025-06-12
+## 2025-06-12
 
 ### Changed
 
@@ -36,13 +42,13 @@ Revert Make publish libs independent from charm publishing
 - Skip integration tests if there are only documentation changes.
 - Make image scanning a required check.
 
-### 2025-06-10
+## 2025-06-10
 
 ### Changed
 
 - The logic to get the plan is extracted to a new action.
 
-### 2025-06-09
+## 2025-06-09
 
 ### Changed
 
@@ -60,7 +66,7 @@ Revert Make publish libs independent from charm publishing
 
 - Support from building charmcraft from source.
 
-### 2025-05-30
+## 2025-05-30
 
 ### Added
 


### PR DESCRIPTION
### Overview

Configure canonical k8s to use DOCKERHUB_MIRROR if the corresponding variable exists.

### Rationale

Without dockerhub mirror, the CI job can easily get rate limited by docker, resulting in flaky tests.

### Workflow Changes

Configure Canonicak K8S snap to use a dockerhub mirror if DOCKERHUB_MIRROR is set.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
