### PR TITLE
Add option to remove requirement on check-lib

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,6 +54,11 @@ on:
         type: boolean
         required: false
         default: false
+      require-check-lib:
+        description: Whether to make it required for the check-lib check to be successful.
+        type: boolean
+        required: false
+        default: true
 
         
 concurrency:
@@ -498,6 +503,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           charm-path: ${{ inputs.working-directory }}/${{ inputs.charm-directory }}
           charmcraft-channel: ${{ inputs.charmcraft-channel }}
+          fail_on_error: ${{ inputs.require-check-lib }}
   required_status_checks:
     name: Required Test Status Checks
     needs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -503,7 +503,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           charm-path: ${{ inputs.working-directory }}/${{ inputs.charm-directory }}
           charmcraft-channel: ${{ inputs.charmcraft-channel }}
-          fail_on_error: ${{ inputs.require-check-lib }}
   required_status_checks:
     name: Required Test Status Checks
     needs:
@@ -530,7 +529,7 @@ jobs:
           [ '${{ needs.draft-publish-docs.result }}' = 'success' ] || (echo 'Warning: The "Draft Publish Docs" job failed. The workflow will still be considered successful.' )
           [ '${{ needs.docker-lint.result }}' = 'success' ] || (echo docker-lint failed && false)
           [ '${{ needs.inclusive-naming-check.result }}' = 'success' ] || (echo inclusive-naming-check failed && false)
-          [ '${{ needs.lib-check.result }}' = 'success' ] || (echo lib-check failed && false)
+          if [ '${{ needs.lib-check.result }}' = 'success' ] || [ '${{ inputs.require-check-lib }}' == 'true' ]; then (echo lib-check failed && false); fi
           [ '${{ needs.lint-and-unit-test.result }}' = 'success' ] || (echo lint-and-unit-test failed && false)
           [ '${{ needs.metadata-lint.result }}' = 'success' ] || (echo metadata-lint failed && false)
           [ '${{ needs.shellcheck-lint.result }}' = 'success' ] || (echo shellcheck-lint failed && false)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -496,7 +496,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Check libs
-        if: ${{ !github.event.pull_request.head.repo.fork }} && ${{ inputs.requirer-check-lib }}
+        if: ${{ !github.event.pull_request.head.repo.fork && inputs.requirer-check-lib }}
         uses: canonical/charming-actions/check-libraries@2.7.0
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
@@ -529,7 +529,7 @@ jobs:
           [ '${{ needs.draft-publish-docs.result }}' = 'success' ] || (echo 'Warning: The "Draft Publish Docs" job failed. The workflow will still be considered successful.' )
           [ '${{ needs.docker-lint.result }}' = 'success' ] || (echo docker-lint failed && false)
           [ '${{ needs.inclusive-naming-check.result }}' = 'success' ] || (echo inclusive-naming-check failed && false)
-          if [ '${{ inputs.require-check-lib }}' == 'true' ] || [ '${{ needs.lib-check.result }}' = 'success' ]; then (echo lib-check failed && false); fi
+          if [ '${{ inputs.require-check-lib }}' = 'true' ] || [ '${{ needs.lib-check.result }}' = 'success' ]; then (echo lib-check failed && false); fi
           [ '${{ needs.lint-and-unit-test.result }}' = 'success' ] || (echo lint-and-unit-test failed && false)
           [ '${{ needs.metadata-lint.result }}' = 'success' ] || (echo metadata-lint failed && false)
           [ '${{ needs.shellcheck-lint.result }}' = 'success' ] || (echo shellcheck-lint failed && false)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -529,7 +529,7 @@ jobs:
           [ '${{ needs.draft-publish-docs.result }}' = 'success' ] || (echo 'Warning: The "Draft Publish Docs" job failed. The workflow will still be considered successful.' )
           [ '${{ needs.docker-lint.result }}' = 'success' ] || (echo docker-lint failed && false)
           [ '${{ needs.inclusive-naming-check.result }}' = 'success' ] || (echo inclusive-naming-check failed && false)
-          if [ '${{ inputs.require-check-lib }}' = 'true' ] || [ '${{ needs.lib-check.result }}' = 'success' ]; then (echo lib-check failed && false); fi
+          [ '${{ needs.lib-check.result }}' = 'success' ] || (echo lib-check failed && false)
           [ '${{ needs.lint-and-unit-test.result }}' = 'success' ] || (echo lint-and-unit-test failed && false)
           [ '${{ needs.metadata-lint.result }}' = 'success' ] || (echo metadata-lint failed && false)
           [ '${{ needs.shellcheck-lint.result }}' = 'success' ] || (echo shellcheck-lint failed && false)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -496,7 +496,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Check libs
-        if: ${{ !github.event.pull_request.head.repo.fork }}
+        if: ${{ !github.event.pull_request.head.repo.fork }} && ${{ inputs.requirer-check-lib }}
         uses: canonical/charming-actions/check-libraries@2.7.0
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
@@ -529,7 +529,7 @@ jobs:
           [ '${{ needs.draft-publish-docs.result }}' = 'success' ] || (echo 'Warning: The "Draft Publish Docs" job failed. The workflow will still be considered successful.' )
           [ '${{ needs.docker-lint.result }}' = 'success' ] || (echo docker-lint failed && false)
           [ '${{ needs.inclusive-naming-check.result }}' = 'success' ] || (echo inclusive-naming-check failed && false)
-          if [ '${{ needs.lib-check.result }}' = 'success' ] || [ '${{ inputs.require-check-lib }}' == 'true' ]; then (echo lib-check failed && false); fi
+          if [ '${{ inputs.require-check-lib }}' == 'true' ] || [ '${{ needs.lib-check.result }}' = 'success' ]; then (echo lib-check failed && false); fi
           [ '${{ needs.lint-and-unit-test.result }}' = 'success' ] || (echo lint-and-unit-test failed && false)
           [ '${{ needs.metadata-lint.result }}' = 'success' ] || (echo metadata-lint failed && false)
           [ '${{ needs.shellcheck-lint.result }}' = 'success' ] || (echo shellcheck-lint failed && false)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ on:
         required: false
         default: false
       require-check-lib:
-        description: Whether to make it required for the check-lib check to be successful.
+        description: Whether to run the check-libraries action.
         type: boolean
         required: false
         default: true

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-07-14
+
+### Added
+
+- Add option to disable check-lib test.
+
 ## 2025-07-08
 
 ### Added


### PR DESCRIPTION
### Overview

In some PRs, we want to use newly created charm libraries before they get published. When this is the case, the check-lib action fails. It is then interesting to be able to opt out.

Example run: https://github.com/canonical/dns-operators/pull/178

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
