### PR TITLE
Remove draft publish from the list of required checks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -526,7 +526,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - run: |
-          [ '${{ needs.draft-publish-docs.result }}' = 'success' ] || (echo 'Warning: The "Draft Publish Docs" job failed. The workflow will still be considered successful.' )
           [ '${{ needs.docker-lint.result }}' = 'success' ] || (echo docker-lint failed && false)
           [ '${{ needs.inclusive-naming-check.result }}' = 'success' ] || (echo inclusive-naming-check failed && false)
           [ '${{ needs.lib-check.result }}' = 'success' ] || (echo lib-check failed && false)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-07-16
+
+### Changed
+
+- Remove draft publish from the list of required checks #722
+
 ## 2025-07-14
 
 ### Added


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Remove draft publish from the list of required checks. It will be run, but the test workflow won't be considered failed if this job unsuccessful

### Rationale

<!-- The reason the change is needed -->
Draft publish is error prone

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
