### PR TITLE
refactor: make integration_test.yaml not depend on PR event

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -235,9 +235,16 @@ jobs:
       - name: Find changes
         id: changes
         run: |
-          REMOTE=$(git remote show)
-          CHANGED_FILES=$(git diff --name-only "$REMOTE/${{ github.event.pull_request.base.ref }}" "${{ github.event.pull_request.head.sha }}")
-          CODE_FILE_CHANGES=$(echo "$CHANGED_FILES" | grep -v "\.md$" | wc -l)
+          PREV_COMMIT_SHA="${{ github.event.before }}"
+          CURRENT_COMMIT_SHA="${{ github.sha }}"
+
+          # If there are no commits before the current event, we can assume all files have changed
+          if [ -z $PREV_COMMIT_SHA ]; then
+            CODE_FILE_CHANGES=1
+          else
+            CHANGED_FILES=$(git diff --name-only "$PREV_COMMIT_SHA" "$CURRENT_COMMIT_SHA")
+            CODE_FILE_CHANGES=$(echo "$CHANGED_FILES" | grep -v "\.md$" | wc -l)
+          fi
           echo "has_code_changes=$([[ $CODE_FILE_CHANGES -eq "0" ]] && echo 'False' || echo 'True')" >> $GITHUB_OUTPUT
 
   build:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-07-29
+
+### Changed
+
+- Refactor integration_test.yaml to make it reusable in any GitHub event, not just Pull Requests.
+
 ## 2025-07-16
 
 ### Changed


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

This commit changes the logic for checking whether there were code changes; instead of using the PR event exclusively for getting commit SHAs to compare changes between the PR and the target branch, we can now make the same check with any event that triggers the workflow.
This change will allow this workflow to be reusable outside of the context of a PR.

Fixes #733

### Rationale

<!-- The reason the change is needed -->

Some teams (specially charming teams) prefer to run integration tests again on `merge`. The workflow's current dependency on the PR event makes this impossible.

### Workflow Changes

<!-- Any high level changes to workflows and why -->

Refactor of the logic for calculating if there were code changes.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->

* I cannot tag the PR

### Additional notes:

* [PR](https://github.com/DnPlas/temporal-k8s-operator/pull/1) that shows the workflow running on a PR event.
* [On merge](https://github.com/DnPlas/temporal-k8s-operator/actions/runs/16581846121) action running showing the workflow can also run on a different event.
* I refactored the workflow to use a similar logic to what we had in the past, but it is totally possible to use `tj-actions/changed-files` actions instead. Please let me know if that's more desirable. 