### PR TITLE
Revert "refactor: make integration_test.yaml not depend on PR event"

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -235,16 +235,9 @@ jobs:
       - name: Find changes
         id: changes
         run: |
-          PREV_COMMIT_SHA="${{ github.event.before }}"
-          CURRENT_COMMIT_SHA="${{ github.sha }}"
-
-          # If there are no commits before the current event, we can assume all files have changed
-          if [ -z $PREV_COMMIT_SHA ]; then
-            CODE_FILE_CHANGES=1
-          else
-            CHANGED_FILES=$(git diff --name-only "$PREV_COMMIT_SHA" "$CURRENT_COMMIT_SHA")
-            CODE_FILE_CHANGES=$(echo "$CHANGED_FILES" | grep -v "\.md$" | wc -l)
-          fi
+          REMOTE=$(git remote show)
+          CHANGED_FILES=$(git diff --name-only "$REMOTE/${{ github.event.pull_request.base.ref }}" "${{ github.event.pull_request.head.sha }}")
+          CODE_FILE_CHANGES=$(echo "$CHANGED_FILES" | grep -v "\.md$" | wc -l)
           echo "has_code_changes=$([[ $CODE_FILE_CHANGES -eq "0" ]] && echo 'False' || echo 'True')" >> $GITHUB_OUTPUT
 
   build:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,12 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
-## 2025-07-29
-
-### Changed
-
-- Refactor integration_test.yaml to make it reusable in any GitHub event, not just Pull Requests.
-
 ## 2025-07-16
 
 ### Changed


### PR DESCRIPTION
Reverts canonical/operator-workflows#734

@DnPlas I've seen some issues with this PR, like in https://github.com/canonical/operator-workflows/actions/runs/16587838147/job/46916575578?pr=732 so I'm reverting it