### PR TITLE
refactor: make integration_test.yaml not depend on PR event

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -232,13 +232,22 @@ jobs:
           identifier: ${{ inputs.identifier }}
           upload-image: ${{ inputs.upload-image }}
           working-directory: ${{ inputs.working-directory }}
+
       - name: Find changes
+        id: find-changes
+        uses: tj-actions/changed-files@v44
+        with:
+          files_ignore: |
+            **/*.md
+
+      - name: Check for changes
         id: changes
         run: |
-          REMOTE=$(git remote show)
-          CHANGED_FILES=$(git diff --name-only "$REMOTE/${{ github.event.pull_request.base.ref }}" "${{ github.event.pull_request.head.sha }}")
-          CODE_FILE_CHANGES=$(echo "$CHANGED_FILES" | grep -v "\.md$" | wc -l)
-          echo "has_code_changes=$([[ $CODE_FILE_CHANGES -eq "0" ]] && echo 'False' || echo 'True')" >> $GITHUB_OUTPUT
+          if [[ "${{ steps.find-changes.outputs.all_changed_files_count }}" -gt 0 ]]; then
+            echo "has_code_changes=True" >> $GITHUB_OUTPUT
+          else
+            echo "has_code_changes=False" >> $GITHUB_OUTPUT
+          fi
 
   build:
     name: Build ${{ matrix.build.type }} (${{ matrix.build.name }})

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -234,20 +234,16 @@ jobs:
           working-directory: ${{ inputs.working-directory }}
 
       - name: Find changes
-        id: find-changes
-        uses: tj-actions/changed-files@v44
-        with:
-          files_ignore: |
-            **/*.md
-
-      - name: Check for changes
         id: changes
         run: |
-          if [[ "${{ steps.find-changes.outputs.all_changed_files_count }}" -gt 0 ]]; then
-            echo "has_code_changes=True" >> $GITHUB_OUTPUT
-          else
-            echo "has_code_changes=False" >> $GITHUB_OUTPUT
+          has_code_changes=True
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            REMOTE=$(git remote show)
+            CHANGED_FILES=$(git diff --name-only "$REMOTE/${{ github.event.pull_request.base.ref }}" "${{ github.event.pull_request.head.sha }}")
+            CODE_FILE_CHANGES=$(echo "$CHANGED_FILES" | grep -v "\.md$" | wc -l)
+            has_code_changes=$([[ $CODE_FILE_CHANGES -eq "0" ]] && echo 'False' || echo 'True')
           fi
+          echo "has_code_changes=$has_code_changes" >> $GITHUB_OUTPUT
 
   build:
     name: Build ${{ matrix.build.type }} (${{ matrix.build.name }})

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-07-29
+
+### Changed
+
+- Use tj-actions/changed-files action in integration_test.yaml to make it reusable in any GitHub event, not just Pull Requests.
+
 ## 2025-07-16
 
 ### Changed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ### Changed
 
-- Use tj-actions/changed-files action in integration_test.yaml to make it reusable in any GitHub event, not just Pull Requests.
+- Refactor integration_test.yaml to make it reusable in any GitHub event, not just Pull Requests.
 
 ## 2025-07-16
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

This commit refactors the custom logic for checking changes and adds the following assumptions:
* If the event triggering the workflow is not PR, it is assumed there are changes. This is helpful when running the workflow on push or on workflow dispatch as we always want to run integration tests in those cases.
* If the event triggering the workflow is a PR, we'll check for changes not made to `md` files.
This change will allow this workflow to be reusable outside of the context of a PR, as well as avoid issues with depending on the event that triggers it.

Fixes #733

### Rationale

<!-- The reason the change is needed -->

Some teams (specially charming teams) prefer to run integration tests again on `merge`. The workflow's current dependency on the PR event makes this impossible.

### Workflow Changes

<!-- Any high level changes to workflows and why -->

Refactor of the logic for calculating if there were code changes.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->

* I cannot tag the PR

### Additional notes

* [CI working](https://github.com/DnPlas/temporal-k8s-operator/actions/runs/16599886182/job/46956272379) on merge
* [CI working](https://github.com/DnPlas/temporal-k8s-operator/pull/2/checks) on PR