### PR TITLE
Move setup devstack-swift before setup operator environment

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -315,6 +315,10 @@ jobs:
           LB_LAST_ADDR="$(echo "${IPADDR}" | awk -F'.' '{print $1,$2,$3,255}' OFS='.')"
           LB_ADDR_RANGE="${LB_FIRST_ADDR}-${LB_LAST_ADDR}"
           sudo k8s set load-balancer.cidrs=$LB_ADDR_RANGE load-balancer.enabled=true load-balancer.l2-mode=true
+      - name: Setup Devstack Swift
+        if: ${{ inputs.setup-devstack-swift }}
+        id: setup-devstack-swift
+        uses: canonical/setup-devstack-swift@v1
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -338,10 +342,6 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - name: Remove Android SDK
         run: sudo rm -rf /usr/local/lib/android
-      - name: Setup Devstack Swift
-        if: ${{ inputs.setup-devstack-swift }}
-        id: setup-devstack-swift
-        uses: canonical/setup-devstack-swift@v1
       - name: Create OpenStack credential file
         working-directory: ${{ inputs.working-directory }}
         run: echo "${{ steps.setup-devstack-swift.outputs.credentials }}" > openrc

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,12 @@ Each revision is versioned by the date of the revision.
 
 ## 2025-07-29
 
+### Fixed
+
+- Move setup devstack-swift before setup operator environment to avoid a Kubernetes network issue.
+
+## 2025-07-29
+
 ### Changed
 
 - Refactor integration_test.yaml to make it reusable in any GitHub event, not just Pull Requests.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

The system load caused by installing and setting up DevStack may cause pods inside microk8s to restart. These restarts can trigger a bug in the Kubernetes portmap plugin that duplicates hostport DNAT rules in iptables, causing services like nginx Ingress to fail. This has been a long-standing issue: https://github.com/projectcalico/calico/issues/3412

Here are some records demonstrating the issue:

Before `setup-devstack-swift`
```
NAMESPACE                             NAME                                           READY   STATUS    RESTARTS   AGE     IP            NODE              NOMINATED NODE   READINESS GATES
controller-github-pr-38df1-microk8s   pod/controller-0                               3/3     Running   0          100s    10.1.133.70   pkrvm76nib4usnx   <none>           <none>
controller-github-pr-38df1-microk8s   pod/modeloperator-748d759596-lkvd7             1/1     Running   0          69s     10.1.133.71   pkrvm76nib4usnx   <none>           <none>
ingress                               pod/nginx-ingress-microk8s-controller-9fxhj    1/1     Running   0          3m4s    10.1.133.67   pkrvm76nib4usnx   <none>           <none>
kube-system                           pod/calico-kube-controllers-759cd8b574-k4rpr   1/1     Running   0          3m13s   10.1.133.65   pkrvm76nib4usnx   <none>           <none>
kube-system                           pod/calico-node-48kcl                          1/1     Running   0          3m13s   10.1.0.254    pkrvm76nib4usnx   <none>           <none>
kube-system                           pod/coredns-7896dbf49-qwpwn                    1/1     Running   0          3m13s   10.1.133.66   pkrvm76nib4usnx   <none>           <none>
kube-system                           pod/hostpath-provisioner-5fbc49d86c-q4bc7      1/1     Running   0          117s    10.1.133.68   pkrvm76nib4usnx   <none>           <none>
testing                               pod/modeloperator-6d555f674c-9mvnd             1/1     Running   0          67s     10.1.133.72   pkrvm76nib4usnx   <none>           <none>
```

```
Chain CNI-DN-3df1ea18c45e214f7a5d4 (1 references)
num   pkts bytes target     prot opt in     out     source               destination         
1        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       10.1.133.67          0.0.0.0/0            tcp dpt:80
2        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       127.0.0.1            0.0.0.0/0            tcp dpt:80
3        0     0 DNAT       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:80 to:10.1.133.67:80
4        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       10.1.133.67          0.0.0.0/0            tcp dpt:443
5        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       127.0.0.1            0.0.0.0/0            tcp dpt:443
6        0     0 DNAT       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:443 to:10.1.133.67:443
7        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       10.1.133.67          0.0.0.0/0            tcp dpt:10254
8        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       127.0.0.1            0.0.0.0/0            tcp dpt:10254
9        0     0 DNAT       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:10254 to:10.1.133.67:10254

Chain CNI-HOSTPORT-DNAT (2 references)
num   pkts bytes target     prot opt in     out     source               destination         
1        0     0 CNI-DN-3df1ea18c45e214f7a5d4  tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            /* dnat name: "k8s-pod-network" id: "90681b52025360fbd9c1a5e1d1eb329ba2907cc73100b25ecbf279c07313c599" */ multiport dports 80,443,10254
```

After `setup-devstack-swift`
```
NAMESPACE                             NAME                                           READY   STATUS    RESTARTS   AGE     IP            NODE              NOMINATED NODE   READINESS GATES
controller-github-pr-38df1-microk8s   pod/controller-0                               3/3     Running   3          9m4s    10.1.133.74   pkrvm76nib4usnx   <none>           <none>
controller-github-pr-38df1-microk8s   pod/modeloperator-748d759596-lkvd7             1/1     Running   1          8m33s   10.1.133.78   pkrvm76nib4usnx   <none>           <none>
ingress                               pod/nginx-ingress-microk8s-controller-9fxhj    1/1     Running   1          10m     10.1.133.75   pkrvm76nib4usnx   <none>           <none>
kube-system                           pod/calico-kube-controllers-759cd8b574-k4rpr   1/1     Running   1          10m     10.1.133.76   pkrvm76nib4usnx   <none>           <none>
kube-system                           pod/calico-node-48kcl                          1/1     Running   1          10m     10.1.0.254    pkrvm76nib4usnx   <none>           <none>
kube-system                           pod/coredns-7896dbf49-qwpwn                    1/1     Running   1          10m     10.1.133.77   pkrvm76nib4usnx   <none>           <none>
kube-system                           pod/hostpath-provisioner-5fbc49d86c-q4bc7      1/1     Running   1          9m21s   10.1.133.73   pkrvm76nib4usnx   <none>           <none>
testing                               pod/modeloperator-6d555f674c-9mvnd             1/1     Running   1          8m31s   10.1.133.79   pkrvm76nib4usnx   <none>           <none>
```

```
Chain CNI-DN-3df1ea18c45e214f7a5d4 (1 references)
num   pkts bytes target     prot opt in     out     source               destination         
1        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       10.1.133.67          0.0.0.0/0            tcp dpt:80
2        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       127.0.0.1            0.0.0.0/0            tcp dpt:80
3        0     0 DNAT       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:80 to:10.1.133.67:80
4        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       10.1.133.67          0.0.0.0/0            tcp dpt:443
5        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       127.0.0.1            0.0.0.0/0            tcp dpt:443
6        0     0 DNAT       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:443 to:10.1.133.67:443
7        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       10.1.133.67          0.0.0.0/0            tcp dpt:10254
8        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       127.0.0.1            0.0.0.0/0            tcp dpt:10254
9        0     0 DNAT       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:10254 to:10.1.133.67:10254

Chain CNI-DN-f60ef0085dbdf07a8e3c4 (1 references)
num   pkts bytes target     prot opt in     out     source               destination         
1        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       10.1.133.75          0.0.0.0/0            tcp dpt:80
2        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       127.0.0.1            0.0.0.0/0            tcp dpt:80
3        0     0 DNAT       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:80 to:10.1.133.75:80
4        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       10.1.133.75          0.0.0.0/0            tcp dpt:443
5        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       127.0.0.1            0.0.0.0/0            tcp dpt:443
6        0     0 DNAT       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:443 to:10.1.133.75:443
7        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       10.1.133.75          0.0.0.0/0            tcp dpt:10254
8        0     0 CNI-HOSTPORT-SETMARK  tcp  --  *      *       127.0.0.1            0.0.0.0/0            tcp dpt:10254
9        0     0 DNAT       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:10254 to:10.1.133.75:10254

Chain CNI-HOSTPORT-DNAT (2 references)
num   pkts bytes target     prot opt in     out     source               destination         
1        0     0 CNI-DN-3df1ea18c45e214f7a5d4  tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            /* dnat name: "k8s-pod-network" id: "90681b52025360fbd9c1a5e1d1eb329ba2907cc73100b25ecbf279c07313c599" */ multiport dports 80,443,10254
2        0     0 CNI-DN-f60ef0085dbdf07a8e3c4  tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            /* dnat name: "k8s-pod-network" id: "73d37dcd35ba04d1967b47c826836515fc3fbd4410bb94e351da206b5d098d77" */ multiport dports 80,443,10254
```

In this pull request, move the devstack-swift setup step before setting up the operator environment (installing MicroK8s) to prevent issues.

Thanks @javierdelapuente and @seb4stien for discovering, diagnosing, and resolving this issue.

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
