### PR TITLE
Add wordlist and LICENSE to integration test's ignored changes

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -240,7 +240,8 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             REMOTE=$(git remote show)
             CHANGED_FILES=$(git diff --name-only "$REMOTE/${{ github.event.pull_request.base.ref }}" "${{ github.event.pull_request.head.sha }}")
-            CODE_FILE_CHANGES=$(echo "$CHANGED_FILES" | grep -v "\.md$" | wc -l)
+            IGNORED_PATTERNS="\.md$|\.custom_wordlist\.txt$|^LICENSE$"
+            CODE_FILE_CHANGES=$(echo "$CHANGED_FILES" | grep -Ev -c "$IGNORED_PATTERNS")
             has_code_changes=$([[ $CODE_FILE_CHANGES -eq "0" ]] && echo 'False' || echo 'True')
           fi
           echo "has_code_changes=$has_code_changes" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Overview

Certain docs only changes require adding some words to the `custom_wordlist.txt` which has the effect of triggering the integration tests when a PR is opened. 

This PR aims to slightl change the logic to make it easier to add more exceptions, up to a point. In this first pass, adding `custom_wordlist.txt` along with `LICENSE`. 

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
