### PR TITLE
Adding a dedicated documentation workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,7 +19,7 @@ on:
       linkcheck-files:
         type: string
         description: Where Lychee will look for files to lint
-        default: "'./**/*.md' './**/*.html' './**/*.rst'"
+        default: "'./**/*.md' './**/*.rst'"
         required: false
       linkcheck-fail-on-error:
         description: Exit with 1 when at least one error was reported.

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,53 @@
+name: Documentation
+
+on:
+  workflow_call:
+    inputs:
+      vale-files:
+        type: string
+        description: Where Vale will look for files to lint
+        default: '["README.md","CONTRIBUTING.md","docs/"]'
+        required: false
+      vale-fail-on-error:
+        description: Exit with 1 when at least one error was reported.
+        type: boolean
+        default: true
+        required: false
+      linkcheck-files:
+        type: string
+        description: Where Lychee will look for files to lint
+        default: "'./**/*.md' './**/*.html' './**/*.rst'"
+        required: false
+      linkcheck-fail-on-error:
+        description: Exit with 1 when at least one error was reported.
+        type: boolean
+        default: true
+        required: false
+
+jobs:
+  vale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5.0.0
+
+      - name: Run Vale Linter
+        uses: errata-ai/vale-action@v2.1.1
+        with:
+          files: ${{ inputs.vale-files }}
+          fail_on_error: ${{ inputs.vale-fail-on-error }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5.0.0
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2.5.0
+        with:
+          fail: ${{ inputs.linkcheck-fail-on-error }}
+          args: --verbose --no-progress ${{ inputs.linkcheck-files }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 name: Documentation
 
 on:


### PR DESCRIPTION
### Overview

This PR aims at introducing a dedicated `documentation` workflow to centralize jobs specific to documentation such as:

- Performing the vale checks
- Checking for broken links
- ...
### Rationale

In this first pass, the aim is to simply introduce the jobs to run the links checker and vale linter in it's most native form. By that I mean, it does not have dependencies to the praecepta project in anyway. Instead, running vale how it is mean to be run and leaving any dependencies defined within a project's `.vale-ini` file as well a native support for custom wordlists and style rules.

> You can see a example if this workflow integrated within [irc-bridge-operator](https://github.com/canonical/irc-bridge-operator/compare/update-to-use-vale-package). This branch is currently being worked on to align with the upcoming Praecepta Vale package and full support of custom wordlists.

As we continue refining our docs related operations and workflows, we will be able to continue centralizing the existing docs jobs that live in other workflows in this new one.

