### PR TITLE
Skip vale style check if not enabled

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ on:
         description: Path to the bash script to be run before the integration tests
         type: string
       vale-style-check:
-        description: Whether to make it required for the vale style check to be successful.
+        description: Whether to enable vale style check.
         type: boolean
         default: false
       vale-files:
@@ -121,6 +121,7 @@ jobs:
           woke-version: latest
   vale:
     name: Style checker
+    if: ${{ inputs.vale-style-check }}
     runs-on: >-
       ${{
         inputs.self-hosted-runner &&

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -557,4 +557,4 @@ jobs:
           [ '${{ needs.metadata-lint.result }}' = 'success' ] || (echo metadata-lint failed && false)
           [ '${{ needs.shellcheck-lint.result }}' = 'success' ] || (echo shellcheck-lint failed && false)
           [ '${{ needs.license-headers-check.result }}' = 'success' ] || (echo license-headers-check failed && false)
-          [ '${{ needs.vale.result }}' = 'success' ] || (echo "vale style check failed" && false)
+          [ "${{ needs.vale.result }}" = "success" ] || [ "${{ needs.vale.result }}" = "skipped" ] || (echo "vale style check failed" && false)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ### Fixed
 
-- Skip the vale action entirely if `vale_style_check` is disabled.
+- Skip the vale action entirely if `vale_style_check` is disabled to temporarily mitigate `fail_on_error` issue. See https://github.com/errata-ai/vale-action/issues/89.
 
 ## 2025-08-19
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-08-20
+
+### Fixed
+
+- Skip the vale action entirely if `vale_style_check` is disabled.
+
 ## 2025-08-19
 
 ### Fixed


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Upstream [errata-ai/vale-action](https://github.com/errata-ai/vale-action) fails on error even if the `fail_on_error` is set to False.(Existing issues: [Issue 89](https://github.com/errata-ai/vale-action/issues/89) [Issue 150](https://github.com/errata-ai/vale-action/issues/150)]. This PR adds logic to skip the workflow entirely if `vale_style_check` is disabled to prevent CI failures in existing PRs. See [#740](https://github.com/canonical/operator-workflows/pull/740#issuecomment-3201787223) 

### Testing

Tested this with OpenCTI - https://github.com/canonical/opencti-operator/actions/runs/17089179744/job/48459330040?pr=41

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
