### PR TITLE
Fix trivyignore check

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -364,6 +364,7 @@ jobs:
             if [ -s unused_cves.txt ]; then
               {
                 echo "### Unused entries in .trivyignore"
+                echo "Image: $ROCK_IMAGE"
                 echo ""
                 echo "The following CVEs are in \`.trivyignore\` but not ignored by Trivy anymore:"
                 echo ""

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -337,6 +337,7 @@ jobs:
         env:
           TRIVY_DISABLE_VEX_NOTICE: true
       - name: Check trivyignore
+        if: matrix.scan.image != ''
         run: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.65.0
           if [ -f ".trivyignore" ]
@@ -375,7 +376,8 @@ jobs:
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          ROCK_IMAGE: ${{ env.IMAGE_REF }}
+          ROCK_IMAGE: ${{ matrix.scan.image }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   integration-test:
     name: Integration tests


### PR DESCRIPTION
Applicable spec: <link>

### Overview

This PR:
- Add GITHUB token variable so checking for trivyignore unused entries can comment on the PR using "gh"
- Fix ROCK_IMAGE variable by using the value matrix.scan.image

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
No changelog.