### PR TITLE
Feat/pre build script

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -275,15 +275,6 @@ jobs:
       - name: Pre-build script
         if: ${{ inputs.pre-build-script != '' }}
         run: bash -xe ${{ inputs.pre-build-script }}
-        # pre-build-script can be used to bootstrap private-endpoints.
-        # map the secrets related to private-endpoints as environment variables.
-        env:
-          JUJU_CONTROLLER: ${{ secrets.JUJU_CONTROLLER }}
-          JUJU_MODEL: ${{ secrets.JUJU_MODEL }}
-          PRODSTACK: ${{ secrets.PRODSTACK }}
-          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
-          VAULT_APPROLE_ROLE_ID: ${{ secrets.VAULT_APPROLE_ROLE_ID }}
-          VAULT_APPROLE_SECRET_ID: ${{ secrets.VAULT_APPROLE_SECRET_ID }}
       - uses: canonical/operator-workflows/internal/build@main
         id: build
         with:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -262,6 +262,16 @@ jobs:
       matrix:
         build: ${{ fromJSON(needs.plan.outputs.plan).build }}
     steps:
+      - uses: canonical/setup-lxd@v0.1.3
+      - name: Set LXC security nesting
+        if: ${{ inputs.rockcraft-enable-security-nesting }}
+        run: |
+          lxc profile set default security.nesting true
+      - name: Install charmcraftcache
+        if: ${{ inputs.charmcraftcache }}
+        run: |
+          pipx install charmcraftcache
+      - uses: actions/checkout@v5.0.0
       - name: Pre-build script
         if: ${{ inputs.pre-build-script != '' }}
         run: bash -xe ${{ inputs.pre-build-script }}
@@ -274,16 +284,6 @@ jobs:
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
           VAULT_APPROLE_ROLE_ID: ${{ secrets.VAULT_APPROLE_ROLE_ID }}
           VAULT_APPROLE_SECRET_ID: ${{ secrets.VAULT_APPROLE_SECRET_ID }}
-      - uses: canonical/setup-lxd@v0.1.3
-      - name: Set LXC security nesting
-        if: ${{ inputs.rockcraft-enable-security-nesting }}
-        run: |
-          lxc profile set default security.nesting true
-      - name: Install charmcraftcache
-        if: ${{ inputs.charmcraftcache }}
-        run: |
-          pipx install charmcraftcache
-      - uses: actions/checkout@v5.0.0
       - uses: canonical/operator-workflows/internal/build@main
         id: build
         with:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -57,6 +57,9 @@ on:
         description: List of testing modules to run the tests in JSON format, i.e. '["foo", "bar"]'. Each element will be passed to pytest through tox as -k argument
         type: string
         default: '[""]'
+      pre-build-script:
+        description: Path to the bash script to be run before the build step
+        type: string
       pre-run-script:
         description: Path to the bash script to be run before the integration tests
         type: string
@@ -259,6 +262,18 @@ jobs:
       matrix:
         build: ${{ fromJSON(needs.plan.outputs.plan).build }}
     steps:
+      - name: Pre-build script
+        if: ${{ inputs.pre-build-script != '' }}
+        run: bash -xe ${{ inputs.pre-build-script }}
+        # pre-build-script can be used to bootstrap private-endpoints.
+        # map the secrets related to private-endpoints as environment variables.
+        env:
+          JUJU_CONTROLLER: ${{ secrets.JUJU_CONTROLLER }}
+          JUJU_MODEL: ${{ secrets.JUJU_MODEL }}
+          PRODSTACK: ${{ secrets.PRODSTACK }}
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+          VAULT_APPROLE_ROLE_ID: ${{ secrets.VAULT_APPROLE_ROLE_ID }}
+          VAULT_APPROLE_SECRET_ID: ${{ secrets.VAULT_APPROLE_SECRET_ID }}
       - uses: canonical/setup-lxd@v0.1.3
       - name: Set LXC security nesting
         if: ${{ inputs.rockcraft-enable-security-nesting }}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ charm = pytestconfig.getoption("--charm-file")[0] # the charm only has one base
 
 tmate can be run on failed tests either by setting the `tmate-debug` input to 'true' or by re-running a job with the "Enable debug logging" checkbox checked.
 
+By providing a file path to `pre-build-script` variable, a script can be run before the build step. This is especially valuable if a set of operations need to be done before packing the rock or charm.
+
 ### Publish Charm Workflow (`canonical/operator-workflows/.github/workflows/publish_charm.yaml@main`)
 Publishes the charm and its resources to appropriate channel, as defined [here](https://github.com/canonical/charming-actions/tree/main/channel).
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

In Netbox we don't want to include the application code in the repository and install it with a small script. 
This script has to be run before packing the rock. This is a possible common issue for 12 Factor applications and would be nice to have an option to run scripts before build step.

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
