### PR TITLE
chore: update default runners to noble

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -106,7 +106,7 @@ on:
       self-hosted-runner-image:
         type: string
         description: Image of the requested runner. Supports only 'jammy' or 'noble'.
-        default: "jammy"
+        default: "noble"
       self-hosted-runner-label:
         type: string
         description: Label for selecting the self-hosted runners.

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -77,7 +77,7 @@ on:
       self-hosted-runner-image:
         type: string
         description: Image of the requested runner. Supports only 'jammy' or 'noble'.
-        default: "jammy"
+        default: "noble"
       self-hosted-runner-label:
         type: string
         description: Label for selecting the self-hosted runners.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ on:
       self-hosted-runner-image:
         type: string
         description: Image of the requested runner. Supports only 'jammy' or 'noble'.
-        default: "jammy"
+        default: "noble"
       pre-run-script:
         description: Path to the bash script to be run before the integration tests
         type: string

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-09-02
+
+### Changed
+
+- Default self-hosted runners are updated to "noble" from "jammy".
+
 ## 2025-08-21
 
 ### Added

--- a/tests/workflows/integration/test-upload-charm/tests/integration/test_charm.py
+++ b/tests/workflows/integration/test-upload-charm/tests/integration/test_charm.py
@@ -24,7 +24,7 @@ async def test_build_and_deploy(ops_test: OpsTest, pytestconfig):
 
     await asyncio.gather(
         ops_test.model.deploy(
-            charm, resources=resources, application_name=app_name, series="noble"
+            charm, resources=resources, application_name=app_name, series="jammy"
         ),
         ops_test.model.wait_for_idle(
             apps=[app_name], status="active", raise_on_blocked=True, timeout=1000

--- a/tests/workflows/integration/test-upload-charm/tests/integration/test_charm.py
+++ b/tests/workflows/integration/test-upload-charm/tests/integration/test_charm.py
@@ -24,7 +24,7 @@ async def test_build_and_deploy(ops_test: OpsTest, pytestconfig):
 
     await asyncio.gather(
         ops_test.model.deploy(
-            charm, resources=resources, application_name=app_name, series="jammy"
+            charm, resources=resources, application_name=app_name, series="noble"
         ),
         ops_test.model.wait_for_idle(
             apps=[app_name], status="active", raise_on_blocked=True, timeout=1000


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Update default self-hosted runners to select "noble" base

<!-- A high level overview of the change -->

### Rationale

- Edge runners jammy are no longer deployed.
<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
