### PR TITLE
Add break-system-packages only if self-hosted-runner is true

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -278,7 +278,7 @@ jobs:
         id: run-lint
         run: |
           options=""
-          if [[ "${{ inputs.self-hosted-runner-image }}" == "noble" ]]; then
+          if [[ "${{ inputs.self-hosted-runner }}" == "true" && "${{ inputs.self-hosted-runner-image }}" == "noble" ]]; then
             options+=" --break-system-packages"
           fi
           python3 -m pip install check-jsonschema $options


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Fix workflow for adding parameter only if self-hosted-runner is true and image is noble.

Example:
https://github.com/canonical/synapse-operator/actions/runs/17407525292/job/49415825462?pr=870

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
