### PR TITLE
chore: remove flake8 deps check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -373,7 +373,6 @@ jobs:
           EXPECTED_LINT_CMDS="\
               pydocstyle \
               codespell \
-              flake8 \
               isort \
               black \
               mypy \

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-09-03
+
+### Changed
+
+- Eject `flake8` from linting dependencies due to `pflake8` no longer being supported on "noble".
+
 ## 2025-09-02
 
 ### Changed


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Remove flake8 from our linter dependency check
<!-- A high level overview of the change -->

### Rationale

- With the recent base change from Jammy to Noble, we have to update Python from 3.10 to 3.12. However, `pflake8`, which is used in our testing suite with `flake8` + `pyproject.toml`, is no longer maintained and does not work with Python 3.12.
- We should start migrating our testing suites to `tox + uv` or `make + uv`.
<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
