### PR TITLE
Fix incorrect call to fromJson

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -175,7 +175,7 @@ jobs:
     runs-on: >-
       ${{
         inputs.self-hosted-runner &&
-        fromJson(format('[''self-hosted'', ''{0}'', ''{1}'', ''{2}'']',
+        fromJSON(format('[''self-hosted'', ''{0}'', ''{1}'', ''{2}'']',
           inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label, inputs.self-hosted-runner-image
         )) || inputs.runs-on
       }}


### PR DESCRIPTION
### Overview

Fix incorrect call to `fromJson` as it should be [fromJSON](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/workflows-and-actions/expressions#fromjson)

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
