### PR TITLE
promote_charm. Allow cross track promotion

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -47,19 +47,6 @@ on:
         default: latest/stable
 
 jobs:
-  validate-channels:
-    name: Validate channels
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v5.0.0
-      - run: |
-          set -e
-          origin_track=$(echo ${{ inputs.origin-channel }} | cut -d "/" -f 1)
-          destination_track=$(echo ${{ inputs.destination-channel }} | cut -d "/" -f 1)
-          if [ $origin_track != $destination_track ]; then
-            echo "::error::Destination track $destination_track does not match origin track $origin_track"
-            exit 1
-          fi
   get-charm-base:
     name: Get charm base
     runs-on: ubuntu-24.04
@@ -156,7 +143,7 @@ jobs:
   promote-charm:
     name: Promote charm
     runs-on: ubuntu-latest
-    needs: [ get-charm-base, validate-channels ]
+    needs: [ get-charm-base ]
     steps:
       - uses: actions/checkout@v5.0.0
       - name: Release charm to channel


### PR DESCRIPTION
### Overview

Allow cross track promotion

### Rationale
If cross-track charm promotion is blocked, the same code must be published under different charm revisions instead of reusing one revision across several channels.

Example:

* Work is done on main, code is published to latest/edge.
* A new release is decided.
* A new charmhub track is created, for example X.
* The revision from edge should be added to X/beta, but this is blocked for no clear reason (see charming-actions, which already support this).
* At this point, a new GitHub branch is not wanted, as it would require continuous cherry-picking. The branch should be cut as late as possible.


### Workflow Changes

No backwards incompatible changes

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
