### PR TITLE
Update generate_terraform_docs.yaml

### DIFF
--- a/.github/workflows/generate_terraform_docs.yaml
+++ b/.github/workflows/generate_terraform_docs.yaml
@@ -7,7 +7,7 @@ on:
     inputs:
       terraform-directory:
         type: string
-        description: The working directory for the terraform
+        description: A comma-separated list of working directories for Terraform
         default: "terraform"
 
 jobs:
@@ -23,12 +23,21 @@ jobs:
       with:
         working-dir: ${{ inputs.terraform-directory }}
         output-file: README.md
-        output-method: replace
-    - uses: planetscale/ghcommit-action@v0.2.17
+        output-method: inject
+
+    # terraform-docs/gh-actions changes the permissions of repository files
+    - name: Change file ownership
+      run: sudo chown $USER -R .
+
+    - name: Create pull request
+      uses: canonical/create-pull-request@main
+      if: ${{ github.event_name != 'pull_request' }}
       with:
-        commit_message: "terraform-docs: automated action"
-        repo: ${{ github.event.pull_request.head.repo.full_name }}
-        branch: ${{ github.event.pull_request.head.ref }}
-        file_pattern: '${{ inputs.terraform-directory }}/*.md'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "chore(docs): Update Terraform documentation"
+        branch-name: terraform-docs
+        title: "chore(docs): Update Terraform documentation"
+        body: "Update Terraform documentation in `${{ inputs.terraform-directory }}`."
+        upsert: true
+        ignore-no-changes: true
+        auto-merge: true

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-09-08
+- The `generate_terraform_docs` workflow now creates a pull request when used outside of a pull request.
+
 ## 2025-09-04
 - Allow cross-track charm promotions. Validation of the track name is removed when promote a charm.
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Update the `.github/workflows/generate_terraform_docs.yaml` workflow:

* Create a pull request from the change generated by the terraform-docs action if the workflow is not running inside a pull request.
* Use inject mode instead of replace mode for the terraform-docs action to preserve the original content.

Examples of the workflow run:

Workflow run inside a pull request: https://github.com/weiiwang01/hockeypuck-k8s-operator/actions/runs/17526645485/job/49778002573?pr=1
Created pull request: https://github.com/weiiwang01/hockeypuck-k8s-operator/pull/2

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
