### PR TITLE
Update Documentation Workflow: Lychee Link Checker Improvements

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -77,13 +77,14 @@ jobs:
           args: >-
             --user-agent "Lychee CI run ${{ github.sha }}"
             --verbose
-            --no-progress ${{ inputs.linkcheck-files }}
+            --no-progress
             --max-concurrency 2
             --retry-wait-time 5
             --max-retries 5
             --cache
             --max-cache-age 5d
             --cache-exclude-status '..100, 404, 429, 500..'
+            ${{ inputs.linkcheck-files }}
       
       - name: Save lychee cache
         uses: actions/cache/save@v4.2.4


### PR DESCRIPTION
### Overview

Updates the documentation workflow’s link checker to improve reliability and reduce transient failures by adjusting concurrency, retry behavior, and adding caching.

### Rationale

The previous configuration could trigger temporary server blocks or fail on transient network issues due to high concurrency and rapid retries. Slowing down the initial check and caching successful results ensures more consistent runs while maintaining reasonable CI speed. Additionally, a manual cache-clear option allows full re-checks when necessary.

### Workflow Changes

* Reduced Lychee concurrency from `150` → `2` on initial runs.
* Increased retry wait time to better handle temporary blocks.
* Added caching of successful link check results for up to `5d` (configurable).
* Introduced `linkcheck-clear-cache` input to allow manual clearing of the cached results.

### Example

I working example can be viewed in this [workflow run](https://github.com/canonical/discourse-k8s-operator/actions/runs/17742074533/job/50418289454?pr=361) for the currently opened discourse PR.

<!-- Any high level changes to workflows and why -->

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
