### PR TITLE
feat: install system packages

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -35,16 +35,21 @@ on:
           Each mapping will be injected into the matrix section of the integration-test.
         type: string
         default: "{}"
-      juju-channel:
-        description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
-        type: string
-        default: 2.9/stable
       identifier:
         type: string
         description: >-
           Identifier for the integration test job: This is used to distinguish between multiple integration test jobs
           running within the same workflow. It is recommended to set this identifier to the job name.
         default: ""
+      install-packages:
+        type: string
+        description: >-
+          Space separated list of apt pacakges to install.
+        default: ""
+      juju-channel:
+        description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
+        type: string
+        default: 2.9/stable
       load-test-enabled:
         type: boolean
         description: Whether load testing is enabled
@@ -396,6 +401,7 @@ jobs:
       channel: ${{ inputs.channel }}
       extra-arguments: ${{ inputs.extra-arguments }}
       extra-test-matrix: ${{ inputs.extra-test-matrix }}
+      install-packages: ${{ inputs.install-packages }}
       juju-channel: ${{ inputs.juju-channel }}
       load-test-enabled: ${{ inputs.load-test-enabled }}
       load-test-run-args: ${{ inputs.load-test-run-args }}

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -19,6 +19,11 @@ on:
           Each mapping will be injected into the matrix section of the integration-test.
         type: string
         default: "{}"
+      install-packages:
+        type: string
+        description: >-
+          Space separated list of apt pacakges to install.
+        default: ""
       juju-channel:
         description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
@@ -197,6 +202,18 @@ jobs:
       - name: Wait for last autorefresh
         run: sudo snap watch --last=auto-refresh?
         timeout-minutes: 10
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          VALID_PACKAGE_RE='^[a-zA-Z0-9][a-zA-Z0-9+._-]*$'
+          read -a PACKAGES <<< "${{ inputs.install-packages }}"
+          for package in "${PACKAGES[@]}"; do
+            if [[ ! "$package" =~ $VALID_PACKAGE_RE ]]; then
+              echo "Invalid package $package";
+              exit 1;
+            fi
+          done;
+          sudo apt-get install -y ${{ inputs.install-packages }}
       - uses: actions/checkout@v5.0.0
       - name: Integration tests variable setting
         shell: python

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-09-12
+- Introduce `install-packages` option for integration tests to allow system pacakge installation.
+
 ## 2025-09-08
 - Fix the checkout step in `generate_terraform_docs.yaml`
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Allows installation of apt packages before running integration test
<!-- A high level overview of the change -->

### Rationale

- Some system packages are required to build python packages like cryptography. This allows installation of apt packages to setup for it.
<!-- The reason the change is needed -->

### Workflow Changes

- integration tests now allow apt package installations
<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
