### PR TITLE
Remove inclusive check from tests workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,51 +74,6 @@ env:
   REPORT_NAME: "report"
 
 jobs:
-  inclusive-naming-check:
-    name: Inclusive naming
-    runs-on: >-
-      ${{
-        inputs.self-hosted-runner &&
-        fromJson(format('[''self-hosted'', ''{0}'', ''{1}'', ''{2}'']',
-          inputs.self-hosted-runner-arch, inputs.self-hosted-runner-label, inputs.self-hosted-runner-image
-        )) || 'ubuntu-22.04'
-      }}
-    steps:
-      - uses: actions/checkout@v5.0.0
-        with:
-          repository: canonical/Inclusive-naming
-          path: tmp-inclusive-naming
-      - run: |
-          mv tmp-inclusive-naming/config.yml /tmp/config.yml
-          rm -rf tmp-inclusive-naming
-      - uses: actions/checkout@v5.0.0
-      - name: Merge configuration files
-        run: |
-          # Combine all entries and replace matching elements by
-          # .name in .rules for the ones in .woke.yaml
-          woke_file=""
-          if [ -f .woke.yaml ]; then
-            woke_file=".woke.yaml"
-          elif [ -f .woke.yml ]; then
-            woke_file=".woke.yml"
-          fi
-          if [ ! -z "$woke_file" ]; then
-            yq eval-all '
-            (
-              . as $item ireduce ({}; . *+ $item) | .rules | unique_by(.name)
-            ) as $mergedArray | . as $item ireduce ({}; . *+ $item) | .rules = $mergedArray
-            ' $woke_file /tmp/config.yml | tee /tmp/merged.yml
-            mv /tmp/merged.yml /tmp/config.yml
-          fi
-      - name: Run inclusive naming check
-        uses: canonical/inclusive-naming@main
-        with:
-          fail-on-error: "true"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
-          woke-args: "${{ inputs.working-directory }} -c /tmp/config.yml"
-          filter-mode: nofilter
-          woke-version: latest
   vale:
     name: Style checker
     if: ${{ inputs.vale-style-check }}
@@ -531,7 +486,6 @@ jobs:
     needs:
       - draft-publish-docs
       - docker-lint
-      - inclusive-naming-check
       - lib-check
       - lint-and-unit-test
       - metadata-lint
@@ -551,7 +505,6 @@ jobs:
       - run: |
           [ '${{ needs.draft-publish-docs.result }}' = 'success' ] || (echo 'Warning: The "Draft Publish Docs" job failed. The workflow will still be considered successful.' )
           [ '${{ needs.docker-lint.result }}' = 'success' ] || (echo docker-lint failed && false)
-          [ '${{ needs.inclusive-naming-check.result }}' = 'success' ] || (echo inclusive-naming-check failed && false)
           [ '${{ needs.lib-check.result }}' = 'success' ] || (echo lib-check failed && false)
           [ '${{ needs.lint-and-unit-test.result }}' = 'success' ] || (echo lint-and-unit-test failed && false)
           [ '${{ needs.metadata-lint.result }}' = 'success' ] || (echo metadata-lint failed && false)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Each revision is versioned by the date of the revision.
 
 ## 2025-09-18
-- Removing the desiccated inclusive check job within the tests workflow.
+- Removing the dedicated inclusive check job within the tests workflow.
 
 ## 2025-09-08
 - Fix the checkout step in `generate_terraform_docs.yaml`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-09-18
+- Removing the desiccated inclusive check job within the tests workflow.
+
 ## 2025-09-08
 - Fix the checkout step in `generate_terraform_docs.yaml`
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Removing the desiccated inclusive check job within the tests workflow

### Rationale

The existing style checker present in the `tests` workflow as well as the new docs workflow already cover the inclusive checks via the Canonical Documentation style guide's [Canonical.400-Enforce-inclusive-terms](https://github.com/canonical/documentation-style-guide/blob/main/vale.ini#L37) rule.

We have also experienced on a few [occasions ](https://github.com/canonical/nginx-ingress-integrator-operator/pull/224)some false positives requiring the use of code-formatting the targeted words and on other [occasions](https://github.com/canonical/discourse-k8s-operator/pull/377), the same "fix" not working at all.

We should rely of the inclusive check run from vale which has not shown those false positives and for which, with the updated docs workflow, provides greater control in ignoring problematic rules.

### Workflow Changes

Removing the desiccated inclusive check job within the tests workflow.

Tested [here](https://github.com/canonical/discourse-k8s-operator/actions/runs/17838670320/job/50722645231?pr=377)

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
