### PR TITLE
Integration test should not failed on skipped

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -446,4 +446,4 @@ jobs:
       - run: |
           [ '${{ needs.scan.result }}' = 'skipped' ] || [ '${{ needs.scan.result }}' = 'success' ] || (echo scan failed && false)
           [ '${{ needs.build.result }}' = 'skipped' ] || [ '${{ needs.build.result }}' = 'success' ] || (echo build failed && false)
-          [ '${{ needs.integration-test.result }}' = 'success' ] || (echo integration-test failed && false)
+          [ '${{ needs.integration-test.result }}' = 'skipped' ] || [ '${{ needs.integration-test.result }}' = 'success' ] || (echo integration-test failed && false)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Fix removed code unintentionally in here: https://github.com/canonical/operator-workflows/pull/824.

Without this, integration test cannot be skipped.

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
