### PR TITLE
Revert "fix: skip check allure if allure not enabled"

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -262,7 +262,6 @@ jobs:
           echo "Installing tox with pipx..."
           pipx install tox
       - name: Check Allure
-        if: env.ENABLE_ALLURE == 'true'
         working-directory: ${{ inputs.working-directory }}
         run: |
           tox -e ${{ inputs.test-tox-env }} --notest --list-dependencies 2>&1


### PR DESCRIPTION
Reverts canonical/operator-workflows#820

This env variable is set in the Check Allure step. This would never be true. I mistakenly approved the previous PR.