### PR TITLE
Fix: Add testing model

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -315,6 +315,7 @@ jobs:
           LB_LAST_ADDR="$(echo "${IPADDR}" | awk -F'.' '{print $1,$2,$3,255}' OFS='.')"
           LB_ADDR_RANGE="${LB_FIRST_ADDR}-${LB_LAST_ADDR}"
           sudo k8s set load-balancer.cidrs=$LB_ADDR_RANGE load-balancer.enabled=true load-balancer.l2-mode=true
+          sudo k8s add-model testing
       - name: Setup Devstack Swift
         if: ${{ inputs.setup-devstack-swift }}
         id: setup-devstack-swift


### PR DESCRIPTION
Applicable spec: <link>

### Overview

In integration tests, [the Microk8s setup](https://github.com/charmed-kubernetes/actions-operator/blob/main/src/bootstrap/index.ts) adds the `testing` model, and all the integration tests expect the `testing` model to be there, so I am adding the `testing` model in the canonical-k8s setup.

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
