### PR TITLE
Ignore reST files for integration testing

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -247,7 +247,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             REMOTE=$(git remote show)
             CHANGED_FILES=$(git diff --name-only "$REMOTE/${{ github.event.pull_request.base.ref }}" "${{ github.event.pull_request.head.sha }}")
-            IGNORED_PATTERNS="\.md$|\.custom_wordlist\.txt$|^LICENSE$"
+            IGNORED_PATTERNS="\.md$|\.rst$|\.custom_wordlist\.txt$|^LICENSE$"
             CODE_FILE_CHANGES=$(echo "$CHANGED_FILES" | grep -Ev "$IGNORED_PATTERNS" | wc -l)
             has_code_changes=$([[ $CODE_FILE_CHANGES -eq "0" ]] && echo 'False' || echo 'True')
           fi

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-10-09
+- Add `*.rst` files to `IGNORED_PATTERNS` for integration testing.
+
 ## 2025-10-08
 - Add `testing` model in the canonical-k8s setup.
 


### PR DESCRIPTION
### Overview

Count reStructuredText files as documentation files when deciding whether to skip integration testing.

### Rationale

I noticed that docs-only PRs in paas-charm still run integration tests (see e.g. [this workflow](https://github.com/canonical/paas-charm/actions/runs/18318486679/job/52360072019?pr=176)). When we set up the `IGNORED_PATTERNS` parameter for integration tests, we only counted Markdown and the custom wordlist as documentation files.

### Workflow Changes

Add `.rst` to `IGNORED_PATTERNS` in `integration_test.yaml`

### Checklist

- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [X] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
