### PR TITLE
Allow copilot to run integration tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -237,7 +237,14 @@ jobs:
         id: plan
         with:
           identifier: ${{ inputs.identifier }}
-          upload-image: ${{ inputs.upload-image }}
+          upload-image: ${{ 
+            inputs.upload-image == '' && 
+            ( 
+              startsWith(github.head_ref,  'copilot/') && 
+              'artifact' || 
+              '' 
+            ) || 
+            inputs.upload-image }}
           working-directory: ${{ inputs.working-directory }}
 
       - name: Find changes
@@ -399,7 +406,15 @@ jobs:
       juju-channel: ${{ inputs.juju-channel }}
       load-test-enabled: ${{ inputs.load-test-enabled }}
       load-test-run-args: ${{ inputs.load-test-run-args }}
-      microk8s-addons: ${{ inputs.microk8s-addons }}
+      microk8s-addons: ${{ 
+          contains(inputs.microk8s-addons, 'registry') && 
+          inputs.microk8s-addons || 
+          ( 
+              startsWith(github.head_ref,  'copilot/') && 
+              format('registry {0}', inputs.microk8s-addons) || 
+              inputs.microk8s-addons 
+          )
+        }}
       modules: ${{ inputs.modules }}
       owner: ${{ github.repository_owner }}
       plan: ${{ needs.plan.outputs.plan }}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
