### PR TITLE
Update default runner version to Ubuntu 24.04

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -408,7 +408,7 @@ jobs:
       python-version: ${{ inputs.python-version }}
       use-canonical-k8s: ${{ inputs.use-canonical-k8s }}
       registry: ghcr.io
-      runs-on: ${{ inputs.runs-on || 'ubuntu-22.04' }}
+      runs-on: ${{ inputs.runs-on || 'ubuntu-24.04' }}
       self-hosted-runner-arch: ${{ inputs.self-hosted-runner-arch }}
       self-hosted-runner-image: ${{ inputs.self-hosted-runner-image }}
       self-hosted-runner-label: ${{ inputs.self-hosted-runner-label }}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Update default runner version to Ubuntu 24.04

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
