### PR TITLE
Add missing `apt update` to integration test

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -371,7 +371,9 @@ jobs:
           VAULT_APPROLE_ROLE_ID: ${{ secrets.VAULT_APPROLE_ROLE_ID }}
           VAULT_APPROLE_SECRET_ID: ${{ secrets.VAULT_APPROLE_SECRET_ID }}
 
-      - run: sudo apt install skopeo -y
+      - run: |
+          sudo apt update
+          sudo apt install skopeo -y
       - name: Plan Integration
         uses: canonical/operator-workflows/internal/plan-integration@main
         id: plan-integration

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-12-19
+- Fix a problem in the integration test caused by a missing `apt install`.
+
 ## 2025-12-09
 - Update the default juju bootstrap bootstrap-constraints to "cores=2 mem=4G root-disk=10G". 
 - Fix the integration test job in documentation pull requests


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add missing `apt update` to integration test

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
