### PR TITLE
Skip integration test build if plan is empty

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -256,7 +256,7 @@ jobs:
   build:
     name: Build ${{ matrix.build.type }} (${{ matrix.build.name }})
     needs: [ plan ]
-    if: ${{ needs.plan.outputs.has-code-changes == 'True' }}
+    if: ${{ needs.plan.outputs.has-code-changes == 'True' && toJSON(fromJSON(needs.plan.outputs.plan).build) != '[]' }}
     runs-on: ${{ inputs.builder-runner-label }}
     strategy:
       matrix:


### PR DESCRIPTION
## Rational

  The integration test workflow fails with "build failed" error when used in repositories that have no build artifacts such as Python libraries.

   Example failure: https://github.com/canonical/flask-multipass-saml-groups/actions/runs/21375014552/job/61532580330?pr=63

In this case:

- The plan job correctly detects code changes (has-code-changes=True)
- The plan generates an empty build array: {"build": []}
- The build job runs with an empty matrix, which results in result='failure'
- The required_status_checks job fails because it expects build to be either 'skipped' or 'success', not 'failure'

 ### Root Cause

   When a GitHub Actions job has an empty matrix (matrix: { build: [] }), the job doesn't run any instances and its result is set to 'failure' rather than 'skipped'. This breaks the status check logic.

### Workflow Changes

   Add an explicit check to skip the build job when the build array is empty. This ensures the job result is 'skipped' (which the status check already handles) rather than 'failure'.

### Tests

Validated within this [integration test](https://github.com/canonical/flask-multipass-saml-groups/actions/runs/21378024155/job/61538650253?pr=63) targeting this branch.


### Checklist

- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
