### PR TITLE
feat: add optional `github-token` input to `generate_terraform_docs` workflow

### DIFF
--- a/.github/workflows/generate_terraform_docs.yaml
+++ b/.github/workflows/generate_terraform_docs.yaml
@@ -13,6 +13,10 @@ on:
         type: boolean
         description: Whether to enable auto-merge for the created pull request.
         default: true
+      github-token:
+        type: string
+        description: Token used to create the pull request. Use a PAT to allow CI to trigger on the resulting PR.
+        default: ""
 
 jobs:
   docs:
@@ -35,7 +39,7 @@ jobs:
       uses: canonical/create-pull-request@main
       if: ${{ github.event_name != 'pull_request' }}
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ inputs.github-token || secrets.GITHUB_TOKEN }}
         commit-message: "chore(docs): Update Terraform documentation"
         branch-name: terraform-docs
         title: "chore(docs): Update Terraform documentation"

--- a/.github/workflows/generate_terraform_docs.yaml
+++ b/.github/workflows/generate_terraform_docs.yaml
@@ -13,10 +13,10 @@ on:
         type: boolean
         description: Whether to enable auto-merge for the created pull request.
         default: true
+    secrets:
       github-token:
-        type: string
         description: Token used to create the pull request. Use a PAT to allow CI to trigger on the resulting PR.
-        default: ""
+        required: false
 
 jobs:
   docs:
@@ -39,7 +39,7 @@ jobs:
       uses: canonical/create-pull-request@main
       if: ${{ github.event_name != 'pull_request' }}
       with:
-        github-token: ${{ inputs.github-token || secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.github-token || secrets.GITHUB_TOKEN }}
         commit-message: "chore(docs): Update Terraform documentation"
         branch-name: terraform-docs
         title: "chore(docs): Update Terraform documentation"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-03-09
+
+- Add optional `github-token` input to the `generate_terraform_docs` workflow to allow callers to pass a PAT, enabling CI workflows to trigger on the resulting pull request.
+
 ## 2026-03-04
 
 - Cache rock build results for register-typed rocks.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-03-09
 
-- Add optional `github-token` input to the `generate_terraform_docs` workflow to allow callers to pass a PAT, enabling CI workflows to trigger on the resulting pull request.
+- Add optional `github-token` secret to the `generate_terraform_docs` workflow to allow callers to pass a PAT, enabling CI workflows to trigger on the resulting pull request.
 
 ## 2026-03-04
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ Each revision is versioned by the date of the revision.
 ## 2026-05-04
 
 - Update `docs_rtd` workflow references from `sphinx-docs-starter-pack` to `sphinx-stack`.
+- Add optional `github-token` secret to the `generate_terraform_docs` workflow to allow callers to pass a PAT, enabling CI workflows to trigger on the resulting pull request.
 
 ## 2026-04-22
 
@@ -62,9 +63,6 @@ Each revision is versioned by the date of the revision.
 ## 2026-03-09
 
 - Drop support for building rockcraft from its repository.
-
-## 2026-03-09
-
 - Publish charm workflow supports uploading multiple charm artifacts.
 
 ## 2026-03-04

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,6 +62,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-03-09
 
+- Add optional `github-token` secret to the `generate_terraform_docs` workflow to allow callers to pass a PAT, enabling CI workflows to trigger on the resulting pull request.
 - Drop support for building rockcraft from its repository.
 - Publish charm workflow supports uploading multiple charm artifacts.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -63,6 +63,9 @@ Each revision is versioned by the date of the revision.
 ## 2026-03-09
 
 - Drop support for building rockcraft from its repository.
+
+## 2026-03-09
+
 - Publish charm workflow supports uploading multiple charm artifacts.
 
 ## 2026-03-04

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,7 +62,6 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-03-09
 
-- Add optional `github-token` secret to the `generate_terraform_docs` workflow to allow callers to pass a PAT, enabling CI workflows to trigger on the resulting pull request.
 - Drop support for building rockcraft from its repository.
 - Publish charm workflow supports uploading multiple charm artifacts.
 


### PR DESCRIPTION
Applicable spec: https://github.com/canonical/operator-workflows/issues/966

### Overview

Adds an optional `github-token` input to the `generate_terraform_docs` workflow so callers can supply a PAT instead of the default `GITHUB_TOKEN`.

### Rationale

GitHub prevents workflows from being triggered by commits or PRs created using `GITHUB_TOKEN`. This means that when `terraform-docs` opens or updates a PR, no CI workflows run against it. By allowing callers to pass a PAT, CI can be triggered on the resulting PR.

### Workflow Changes

- Added `github-token` input (type: `string`, default: `""`) to `generate_terraform_docs.yaml` under `workflow_call.inputs`.
- Updated the `Create pull request` step to use `${{ inputs.github-token || secrets.GITHUB_TOKEN }}`, preserving backwards compatibility.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`) - pls tag `trivial`
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)
