### PR TITLE
fix: Replace `errata-ai/vale-action` with `vale-cli/vale-action`

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install docutils
         run: sudo apt-get install -y docutils
       - name: Run Vale Linter
-        uses: errata-ai/vale-action@v2.1.1
+        uses: vale-cli/vale-action@v2.1.1
         with:
           files: ${{ inputs.vale-files }}
           vale_flags: ${{ inputs.vale-flags }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -119,7 +119,7 @@ jobs:
           echo "Files identified for Vale check: $files"
           echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Run Vale tests
-        uses: errata-ai/vale-action@v2.1.1
+        uses: vale-cli/vale-action@v2.1.1
         with:
           files: ${{ steps.resolve_vale_files.outputs.files }}
           fail_on_error: ${{ inputs.vale-style-check }}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,7 @@ Each revision is versioned by the date of the revision.
 
 - Drop charmcraftcache.
 - Move the rockcraft and charmcraft installation outside of the build action.
+- Replace `errata-ai/vale-action` with `vale-cli/vale-action` to reflect new repository location.
 
 ## 2026-03-10
 


### PR DESCRIPTION
### Overview

Replaces `errata-ai/vale-action` with `vale-cli/vale-action` in all affected actions and workflows. This should fix them and not result in behavior changes.

### Rationale

The `vale-action` GitHub action was [moved to a new org](https://github.com/vale-cli/vale-action), so the actions need to be updated to reflect the new location.

### Workflow Changes

Replaces `errata-ai/vale-action` with `vale-cli/vale-action` in all affected actions and workflows.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
