### PR TITLE
remove unused ref

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -355,7 +355,6 @@ jobs:
       bootstrap-options: ${{ inputs.bootstrap-options }}
       channel: ${{ inputs.channel }}
       extra-arguments: ${{ inputs.extra-arguments }}
-      extra-test-matrix: ${{ inputs.extra-test-matrix }}
       juju-channel: ${{ inputs.juju-channel }}
       microk8s-addons: ${{ inputs.microk8s-addons }}
       modules: ${{ inputs.modules }}


### PR DESCRIPTION
Remove an unused reference that's causing integration test workflow to fail

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
