### PR TITLE
fix(pipx): missing pipx deps

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -220,6 +220,10 @@ jobs:
         if: ${{ matrix.build.type == 'charm' }}
         run: sudo snap install charmcraft --channel ${{ inputs.charmcraft-channel }} --classic
         shell: bash
+      - name: Install pipx
+        if: ${{ matrix.build.type == 'charm' }}
+        run: pip install pipx
+        shell: bash
       - name: Get workflow version
         id: workflow-version
         if: ${{ matrix.build.type == 'charm' }}
@@ -228,10 +232,6 @@ jobs:
           repository-name: canonical/operator-workflows
           file-name: integration_test.yaml
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install pipx
-        if: ${{ matrix.build.type == 'charm' }}
-        run: pip install pipx
-        shell: bash
       - name: Install charmbuild
         if: ${{ matrix.build.type == 'charm' }}
         run: pip install git+https://github.com/canonical/operator-workflows@${{ steps.workflow-version.outputs.sha }}#subdirectory=charmbuild

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -228,6 +228,10 @@ jobs:
           repository-name: canonical/operator-workflows
           file-name: integration_test.yaml
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install pipx
+        if: ${{ matrix.build.type == 'charm' }}
+        run: pip install pipx
+        shell: bash
       - name: Install charmbuild
         if: ${{ matrix.build.type == 'charm' }}
         run: pip install git+https://github.com/canonical/operator-workflows@${{ steps.workflow-version.outputs.sha }}#subdirectory=charmbuild

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-04-13
+
+- Fix missing `pipx` dependency for `get-workflow-version-action`.
+
 ## 2026-04-09
 
 - Drop extra-test-matrix.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Install pipx for get-workflow-version-action
<!-- A high level overview of the change -->

### Rationale

- pipx is not installed by default on self-hosted runners
<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
