### PR TITLE
chore: revert pipx install

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -220,10 +220,6 @@ jobs:
         if: ${{ matrix.build.type == 'charm' }}
         run: sudo snap install charmcraft --channel ${{ inputs.charmcraft-channel }} --classic
         shell: bash
-      - name: Install pipx
-        if: ${{ matrix.build.type == 'charm' }}
-        run: pip install pipx
-        shell: bash
       - name: Get workflow version
         id: workflow-version
         if: ${{ matrix.build.type == 'charm' }}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,10 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
-## 2026-04-13
-
-- Fix missing `pipx` dependency for `get-workflow-version-action`.
-
 ## 2026-04-09
 
 - Drop extra-test-matrix.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Reverts https://github.com/canonical/operator-workflows/pull/994

<!-- A high level overview of the change -->

### Rationale

- There's a discrepancy between self-hosted runners and github hosted runners w/ pipx. This probably requires further analysis to make the workflow compatible with both runner types.
<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
