### PR TITLE
fix: install get-workflow-version-action dependencies for self-hosted runners

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -220,6 +220,20 @@ jobs:
         if: ${{ matrix.build.type == 'charm' }}
         run: sudo snap install charmcraft --channel ${{ inputs.charmcraft-channel }} --classic
         shell: bash
+      - name: Install get-workflow-version-action dependencies (self-hosted runners)
+        if: ${{ matrix.build.type == 'charm' }}
+        shell: bash
+        run: |
+          if ! dpkg -s python3-venv &> /dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y python3-venv
+          fi
+          if ! command -v pipx &> /dev/null; then
+            python3 -m pip install --upgrade pip
+            python3 -m pip install --user pipx
+            python3 -m pipx ensurepath
+            echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          fi
       - name: Get workflow version
         id: workflow-version
         if: ${{ matrix.build.type == 'charm' }}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-04-14
+- Support get-workflow-version-action for self-hosted runners.
+
 ## 2026-04-09
 
 - Drop extra-test-matrix.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Installs dependencies for get-workflow-version-action (pipx, python3-venv) which isn't installed by default on self-hosted runners
<!-- A high level overview of the change -->

### Rationale

- To support operator-workflows on self-hosted runners
<!-- The reason the change is needed -->

### Workflow Changes

- Installs pipx, python3-venv if not available
<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
