### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @canonical/platform-engineering
+*       @canonical/platform-engineering-emea


### PR DESCRIPTION
Applicable spec: n/a

### Overview

While everyone can contribute to operator-workflows, the "official" ownership is on EMEA.

### Rationale

Identifying the right owners help to direct the reviews to the right persons.

### Workflow Changes

n/a

### Checklist

- [n/a] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [n/a] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
