### PR TITLE
chore: disable secrets.INTEGRATION_TEST_ARGS

### DIFF
--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -216,11 +216,20 @@ jobs:
           tox -e ${{ inputs.test-tox-env }} --notest --list-dependencies 2>&1 | grep -q allure \
             && echo 'ENABLE_ALLURE=true' >> $GITHUB_ENV \
             || echo 'ENABLE_ALLURE=false' >> $GITHUB_ENV
+      - name: Enforce Secret Deprecation and Security
+        if: secrets.INTEGRATION_TEST_ARGS
+        run: |
+          if [ "$ENABLE_ALLURE" == "true" ]; then
+            echo "::error title=Security Risk::INTEGRATION_TEST_ARGS may be leaked in Allure reports! Rotate secrets immediately."
+          fi
+          echo "::error::INTEGRATION_TEST_ARGS is no longer supported."
+          echo "Please use INTEGRATION_TEST_SECRET_ENV_NAME_{1..5} and INTEGRATION_TEST_SECRET_ENV_VALUE_{1..5} instead."
+          exit 1
       - name: Collect tests for Allure
         if: env.ENABLE_ALLURE == 'true'
         working-directory: ${{ inputs.working-directory }}
         run: |
-          tox -e ${{ inputs.test-tox-env }} -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} --allure-collection-dir=allure-default --allure-no-capture ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
+          tox -e ${{ inputs.test-tox-env }} -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} --allure-collection-dir=allure-default --allure-no-capture ${{ inputs.extra-arguments }}
       - name: Upload Default Allure results
         if: env.ENABLE_ALLURE == 'true' && github.run_attempt == '1'
         timeout-minutes: 3
@@ -367,9 +376,9 @@ jobs:
             juju add-model testing
           fi
           if [ "$ENABLE_ALLURE" == "true" ]; then
-            tox -e ${{ inputs.test-tox-env }} -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} --alluredir=allure-results --allure-no-capture ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
+            tox -e ${{ inputs.test-tox-env }} -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} --alluredir=allure-results --allure-no-capture ${{ inputs.extra-arguments }}
           else
-            tox -e ${{ inputs.test-tox-env }} -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }} 
+            tox -e ${{ inputs.test-tox-env }} -- --model testing --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }}
           fi
       - name: Run lxd integration tests
         working-directory: ${{ inputs.working-directory }}
@@ -388,9 +397,9 @@ jobs:
           [ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_10 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_10 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_10 }}" || :
           [ -n "${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_11 }}" ] && export ${{ vars.INTEGRATION_TEST_SECRET_ENV_NAME_11 }}="${{ secrets.INTEGRATION_TEST_SECRET_ENV_VALUE_11 }}" || :
           if [ "$ENABLE_ALLURE" == "true" ]; then
-            tox -e ${{ inputs.test-tox-env }} -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} --alluredir=allure-results --allure-no-capture ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
+            tox -e ${{ inputs.test-tox-env }} -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} --alluredir=allure-results --allure-no-capture ${{ inputs.extra-arguments }}
           else
-            tox -e ${{ inputs.test-tox-env }} -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }} ${{ secrets.INTEGRATION_TEST_ARGS }}
+            tox -e ${{ inputs.test-tox-env }} -- --keep-models ${{ env.SERIES }} ${{ env.MODULE }} ${{ env.ARGS }} ${{ inputs.extra-arguments }}
           fi
       - name: Upload Allure results
         timeout-minutes: 3

--- a/.github/workflows/integration_test_run.yaml
+++ b/.github/workflows/integration_test_run.yaml
@@ -217,8 +217,14 @@ jobs:
             && echo 'ENABLE_ALLURE=true' >> $GITHUB_ENV \
             || echo 'ENABLE_ALLURE=false' >> $GITHUB_ENV
       - name: Enforce Secret Deprecation and Security
-        if: secrets.INTEGRATION_TEST_ARGS
+        env:
+          DEPRECATED_TEST_ARGS: ${{ secrets.INTEGRATION_TEST_ARGS }}
         run: |
+          # If the secret is not set, bash -z will be true (empty string)
+          if [ -z "$DEPRECATED_TEST_ARGS" ]; then
+            echo "Validation passed: Deprecated INTEGRATION_TEST_ARGS not in use."
+            exit 0
+          fi
           if [ "$ENABLE_ALLURE" == "true" ]; then
             echo "::error title=Security Risk::INTEGRATION_TEST_ARGS may be leaked in Allure reports! Rotate secrets immediately."
           fi

--- a/README.md
+++ b/README.md
@@ -22,13 +22,7 @@ More information about OWASP ZAP testing can be found [here](OWASPZAP.md).
 
 More information about Trivy testing can be found [here](TRIVY.MD).
 
-The following secrets are available for this workflow:
-
-| Name | Description |
-|--------------------|-------------------|
-| INTEGRATION_TEST_ARGS | Additional arguments to pass to the integration test execution that contain secrets |
-
-Furthermore, in order to export sensitive data as environment variables into the integration test run,
+In order to export sensitive data as environment variables into the integration test run,
 a mapping of variables to secrets can be defined by setting the [GitHub Action Variable](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables)
 `INTEGRATION_TEST_SECRET_ENV_NAME` with the name of the environment variable you want to export and `INTEGRATION_TEST_SECRET_ENV_VALUE` with the value you want the environment variable to have.
  There are six slots available. In addition to the one mentioned above, you can use

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ Each revision is versioned by the date of the revision.
 ## 2026-04-16
 
 - Remove allure logging to remove accidental sensitive value logging.
+- Remove use of secrets.INTEGRATION_TEST_ARGS and fail integration tests if it is used.
 
 ## 2026-04-15
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

The secret INTEGRATION_TEST_ARGS is is no longer supported and must not be used any more. 

The user whould use INTEGRATION_TEST_SECRET_ENV_NAME_{1..5} and  INTEGRATION_TEST_SECRET_ENV_VALUE_{1..5} instead if secrets must be passed to the integration tests.

Fail the integration test if the secret INTEGRATION_TEST_ARGS is set.

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
