### PR TITLE
fix: upgrade setuptools & wheel

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -242,6 +242,8 @@ jobs:
               echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
             fi
           fi
+          # upgrade setuptools & wheel package to avoid UNKNOWN charmbuild installation
+          pip install --upgrade pip setuptools wheel
       - name: Get workflow version
         id: workflow-version
         if: ${{ matrix.build.type == 'charm' }}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-04-22
+
+- Fix UNKNOWN charmbuild package installation on self-hosted runners.
+
 ## 2026-04-16
 
 - Fix missing `--break-system-packages` flag for installing `pipx` on newer OSes.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Upgrade setuptools & wheel for self-hosted runners
<!-- A high level overview of the change -->

### Rationale

- Without upgrading setuptools & wheel pip package, the installation of charmbuild fails due to the older build systems not recognizing the name/version.
<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
