### PR TITLE
fix: upgrade setuptools & wheel with PIP_BREAK_FLAG for compatibility

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -243,7 +243,7 @@ jobs:
             fi
           fi
           # upgrade setuptools & wheel package to avoid UNKNOWN charmbuild installation
-          pip install --upgrade ${PIP_BREAK_FLAG} setuptools wheel
+          python3 -m pip install --upgrade ${PIP_BREAK_FLAG} setuptools wheel
       - name: Get workflow version
         id: workflow-version
         if: ${{ matrix.build.type == 'charm' }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -243,7 +243,7 @@ jobs:
             fi
           fi
           # upgrade setuptools & wheel package to avoid UNKNOWN charmbuild installation
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade ${PIP_BREAK_FLAG} setuptools wheel
       - name: Get workflow version
         id: workflow-version
         if: ${{ matrix.build.type == 'charm' }}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Pass PIP_BREAK_FLAG variable to pip install command
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->
- noble runners require modification of system packages

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->

This is a follow up PR to previous fix, no changelog required.
