### PR TITLE
fix: add detection for pip --break-system-packages support in integration tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -220,6 +220,15 @@ jobs:
         if: ${{ matrix.build.type == 'charm' }}
         run: sudo snap install charmcraft --channel ${{ inputs.charmcraft-channel }} --classic
         shell: bash
+      - name: Detect pip --break-system-packages support
+        if: ${{ matrix.build.type == 'charm' }}
+        shell: bash
+        run: |
+          PIP_BREAK_FLAG='' # Guard against older versions of pip that don't have --break-system-packages
+          if python3 -m pip install --help 2>/dev/null | grep -q -- '--break-system-packages'; then
+            PIP_BREAK_FLAG='--break-system-packages'
+          fi
+          echo "PIP_BREAK_FLAG=${PIP_BREAK_FLAG}" >> "${GITHUB_ENV}"
       - name: Install get-workflow-version-action dependencies (self-hosted runners)
         if: ${{ matrix.build.type == 'charm' }}
         shell: bash
@@ -232,18 +241,12 @@ jobs:
             if apt-cache show pipx &> /dev/null; then
               sudo apt-get install -y pipx
             else
-              PIP_BREAK_FLAG='' # Guard against older versions of pip that don't have --break-system-packages
-              if python3 -m pip install --help 2>/dev/null | grep -q -- '--break-system-packages'; then
-                PIP_BREAK_FLAG='--break-system-packages'
-              fi
               python3 -m pip install --upgrade ${PIP_BREAK_FLAG} pip
               python3 -m pip install --user ${PIP_BREAK_FLAG} pipx
               python3 -m pipx ensurepath
               echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
             fi
           fi
-          # upgrade setuptools & wheel package to avoid UNKNOWN charmbuild installation
-          python3 -m pip install --upgrade ${PIP_BREAK_FLAG} setuptools wheel
       - name: Get workflow version
         id: workflow-version
         if: ${{ matrix.build.type == 'charm' }}
@@ -254,7 +257,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install charmbuild
         if: ${{ matrix.build.type == 'charm' }}
-        run: pip install git+https://github.com/canonical/operator-workflows@${{ steps.workflow-version.outputs.sha }}#subdirectory=charmbuild
+        run: |
+          # upgrade setuptools & wheel package to avoid UNKNOWN charmbuild installation
+          python3 -m pip install --upgrade ${PIP_BREAK_FLAG} setuptools wheel
+          python3 -m pip install ${PIP_BREAK_FLAG} git+https://github.com/canonical/operator-workflows@${{ steps.workflow-version.outputs.sha }}#subdirectory=charmbuild
         shell: bash
       - name: Install rockcraft
         if: ${{ matrix.build.type == 'rock' }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -259,7 +259,7 @@ jobs:
         if: ${{ matrix.build.type == 'charm' }}
         run: |
           # upgrade setuptools & wheel package to avoid UNKNOWN charmbuild installation
-          python3 -m pip install --upgrade ${PIP_BREAK_FLAG} setuptools wheel
+          python3 -m pip install --upgrade ${PIP_BREAK_FLAG} pip setuptools wheel
           python3 -m pip install ${PIP_BREAK_FLAG} git+https://github.com/canonical/operator-workflows@${{ steps.workflow-version.outputs.sha }}#subdirectory=charmbuild
         shell: bash
       - name: Install rockcraft


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Separates PIP_BREAK_FLAG into a separate step
- Upgrade setuptools & wheel just before charmbuild installation - get workflow version uses older version of setuptools/wheel that breaks when updating setuptools before the step.
<!-- A high level overview of the change -->

### Rationale

- Different workflow step requires different setuptools/wheel versions.
<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

The fix is a follow up from previous PRs.

<!-- Explanation for any unchecked items above -->
