### PR TITLE
Update workflow references to use sphinx-stack

### DIFF
--- a/.github/workflows/docs_rtd.yaml
+++ b/.github/workflows/docs_rtd.yaml
@@ -49,15 +49,15 @@ jobs:
     name: Check removed URLs
     needs: check-makefile
     if: ${{ needs.check-makefile.outputs.makefile-exists == 'true' }}
-    uses: canonical/sphinx-docs-starter-pack/.github/workflows/check-removed-urls.yml@main
+    uses: canonical/sphinx-stack/.github/workflows/check-removed-urls.yml@main
   markdown-style-checks:
     name: Markdown style checks
     needs: check-makefile
     if: ${{ needs.check-makefile.outputs.makefile-exists == 'true' }}
-    uses: canonical/sphinx-docs-starter-pack/.github/workflows/markdown-style-checks.yml@main
+    uses: canonical/sphinx-stack/.github/workflows/markdown-style-checks.yml@main
   sphinx-python-dependency-build-checks:
     name: Sphinx and Python dependency build checks
     needs: check-makefile
     if: ${{ needs.check-makefile.outputs.makefile-exists == 'true' && inputs.enable-sphinx-python-dependency-build-checks }}
-    uses: canonical/sphinx-docs-starter-pack/.github/workflows/sphinx-python-dependency-build-checks.yml@main
+    uses: canonical/sphinx-stack/.github/workflows/sphinx-python-dependency-build-checks.yml@main
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-05-04
+
+- Update `docs_rtd` workflow references from `sphinx-docs-starter-pack` to `sphinx-stack`.
+
 ## 2026-04-22
 
 - Fix UNKNOWN charmbuild package installation on self-hosted runners.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Tested on PR: https://github.com/canonical/traefik-k8s-operator/pull/656
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
