### PR TITLE
Update publish job permission

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -68,6 +68,10 @@ env:
   CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
   ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   select-channel:
     runs-on: ubuntu-latest
@@ -116,9 +120,6 @@ jobs:
     if: ${{ needs.plan.outputs.has-code-changes == 'True' }}
     outputs:
       charm-directory: ${{ steps.publish.outputs.charm-directory }}
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6.0.2
       - run: sudo snap install charmcraft --channel ${{ inputs.charmcraft-channel }} --classic

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -116,6 +116,9 @@ jobs:
     if: ${{ needs.plan.outputs.has-code-changes == 'True' }}
     outputs:
       charm-directory: ${{ steps.publish.outputs.charm-directory }}
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6.0.2
       - run: sudo snap install charmcraft --channel ${{ inputs.charmcraft-channel }} --classic

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-05-28
+
+- Update publish job permissions.
+
 ## 2026-05-04
 
 - Update `docs_rtd` workflow references from `sphinx-docs-starter-pack` to `sphinx-stack`.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Update the publish job permissions as we have restricted the default `GITHUB_TOKEN` permissions at the organization level.

### Rationale

https://github.com/canonical/github-runner-image-builder-operator/pull/224

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
