### PR TITLE
docs: add required GitHub token permissions per workflow

### DIFF
--- a/.github/workflows/run_bot_pr_approval.yaml
+++ b/.github/workflows/run_bot_pr_approval.yaml
@@ -9,4 +9,6 @@ on:
 jobs:
   bot_pr_approval:
     uses: canonical/operator-workflows/.github/workflows/bot_pr_approval.yaml@main
+    permissions:
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/workflow_simple_test.yaml
+++ b/.github/workflows/workflow_simple_test.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   simple:
     uses: ./.github/workflows/test.yaml
+    permissions:
+      contents: read
+      pull-requests: write
     secrets: inherit
     strategy:
       fail-fast: false
@@ -25,6 +28,9 @@ jobs:
       with-uv: true
   simple-self-hosted:
     uses: ./.github/workflows/test.yaml
+    permissions:
+      contents: read
+      pull-requests: write
     secrets: inherit
     with:
       working-directory: "tests/workflows/integration/test-upload-charm/"
@@ -73,6 +79,9 @@ jobs:
   test-comment:
     name: Comment on the pull request
     uses: ./.github/workflows/comment.yaml
+    permissions:
+      pull-requests: write
+      actions: read
     if: always() && !cancelled()
     needs:
       - simple

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   integration:
     uses: ./.github/workflows/integration_test.yaml
+    permissions:
+      contents: read
+      packages: write
     secrets: inherit
     with:
       identifier: test-upload
@@ -20,6 +23,9 @@ jobs:
       with-uv: true
   integration-artifact:
     uses: ./.github/workflows/integration_test.yaml
+    permissions:
+      contents: read
+      packages: write
     secrets: inherit
     with:
       identifier: test-upload-artifact
@@ -33,6 +39,9 @@ jobs:
       with-uv: true
   integration-self-hosted:
     uses: ./.github/workflows/integration_test.yaml
+    permissions:
+      contents: read
+      packages: write
     secrets: inherit
     with:
       juju-channel: '3/stable'
@@ -45,6 +54,9 @@ jobs:
       with-uv: true
   integration-rock:
     uses: ./.github/workflows/integration_test.yaml
+    permissions:
+      contents: read
+      packages: write
     secrets: inherit
     with:
       working-directory: "tests/workflows/integration/test-rock/"
@@ -52,6 +64,9 @@ jobs:
       with-uv: true
   integration-rock-artifact:
     uses: ./.github/workflows/integration_test.yaml
+    permissions:
+      contents: read
+      packages: write
     secrets: inherit
     with:
       working-directory: "tests/workflows/integration/test-rock/"
@@ -61,6 +76,10 @@ jobs:
       with-uv: true
   publish:
     uses: ./.github/workflows/publish_charm.yaml
+    permissions:
+      contents: write
+      packages: write
+      actions: read
     secrets: inherit
     needs: [ integration ]
     with:
@@ -72,6 +91,10 @@ jobs:
       workflow-run-id: ${{ github.run_id }}
   publish-artifact:
     uses: ./.github/workflows/publish_charm.yaml
+    permissions:
+      contents: write
+      packages: write
+      actions: read
     secrets: inherit
     needs: [ publish, integration-artifact ]
     with:
@@ -115,6 +138,9 @@ jobs:
           [ '${{ needs.allure-report.result }}' != 'failure' ] || (echo allure-report failed && false)
   integration-canonical-k8s:
     uses: ./.github/workflows/integration_test.yaml
+    permissions:
+      contents: read
+      packages: write
     secrets: inherit
     with:
       working-directory: "tests/workflows/integration/test-rock/"
@@ -133,6 +159,9 @@ jobs:
       with-uv: true
   integration-alternative-rock-filename:
     uses: ./.github/workflows/integration_test.yaml
+    permissions:
+      contents: read
+      packages: write
     secrets: inherit
     with:
       working-directory: "tests/workflows/integration/test-alter-rock-name/"

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -87,6 +87,8 @@ jobs:
       - integration
       - integration-artifact
       - integration-self-hosted
+    permissions:
+      contents: write
     uses: ./.github/workflows/allure_report.yaml
   check:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -110,3 +110,38 @@ three input variables:
 Runs `terraform test` in the `tests` subfolder of the specified directories.
 
 You can find an example on how to call it in the [`platform-engineering-charm-template`](https://github.com/canonical/platform-engineering-charm-template/blob/main/.github/workflows/test_terraform_module.yaml).
+
+## Required GitHub Token Permissions
+
+GitHub organisations can set the default `GITHUB_TOKEN` permissions to read-only. When your organisation uses read-only defaults, calling jobs must explicitly grant any permissions beyond `contents: read`. The table below lists the **minimum required permissions** for each reusable workflow so you can be explicit in your own calling workflows.
+
+| Workflow | Required permissions | Reason |
+|---|---|---|
+| `allure_report.yaml` | `contents: write` | Pushes the Allure report to the `gh-pages` branch |
+| `auto_update_charm_libs.yaml` | `contents: write`<br>`pull-requests: write`<br>`id-token: write` | Creates PRs to update charm libraries; uses OIDC for Charmhub authentication |
+| `bot_pr_approval.yaml` | `pull-requests: write` | Approves bot-authored PRs via the GitHub API |
+| `comment_contributing.yaml` | `pull-requests: write` | Posts a contributing-guide comment on newly opened PRs |
+| `comment.yaml` | `pull-requests: write`<br>`actions: read` | Creates and deletes PR comments; downloads artifacts from a specific workflow run by ID |
+| `docs_rtd.yaml` | `contents: read` | Checks out the repository for Read the Docs build checks |
+| `docs_spread.yaml` | `contents: read` | Checks out the repository for Spread-based documentation testing |
+| `docs.yaml` | `contents: read` | Checks out the repository for Vale and Lychee linting |
+| `generate_terraform_docs.yaml` | `contents: write`<br>`pull-requests: write` | Commits generated Terraform docs and opens a PR with the changes |
+| `integration_test.yaml` | `contents: read`<br>`packages: write`<br>`pull-requests: write` *(optional)* | Checks out the repository; pushes built OCI images to `ghcr.io` when `upload-image: registry` is used or when running on non-forked PRs; `pull-requests: write` is only needed to post `.trivyignore` warning comments (non-fatal if absent) |
+| `promote_charm.yaml` | `contents: write` | Creates a git tag via `charming-actions/release-charm` |
+| `publish_charm.yaml` | `contents: write`<br>`packages: write`<br>`actions: read` | Creates git tags and releases libraries; pushes OCI images to `ghcr.io`; downloads build artifacts from a prior integration test run |
+| `terraform_modules_test.yaml` | `contents: read` | Checks out the repository to run `terraform test` |
+| `test.yaml` | `contents: read`<br>`pull-requests: write` | Checks out the repository; `charming-actions/check-libraries` posts a comment on PRs when charm libraries are out of date |
+
+### Example calling workflow
+
+```yaml
+jobs:
+  integration-tests:
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit
+```
+
+> **Note:** `packages: write` is only needed by `integration_test.yaml` and `publish_charm.yaml` when OCI images are pushed to `ghcr.io`. If your charm has no OCI images, `contents: read` is sufficient for `integration_test.yaml`.


### PR DESCRIPTION
### Overview

Documents the minimum `GITHUB_TOKEN` permissions required by each reusable workflow.

### Rationale

The canonical org recently changed the default `GITHUB_TOKEN` permissions to read-only. Downstream repositories calling these reusable workflows need to know what permissions to explicitly grant.


### Checklist

- [x] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Documentation-only change; no changelog entry needed -->
