### PR TITLE
Inject version file with commit SHA into charm files before publish

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -139,6 +139,15 @@ jobs:
           cp -rp $TEMP_DIR/. .
           rm -rf $TEMP_DIR
           ls -lah
+      - name: Add version file to charm
+        run: |
+          sudo apt-get update && sudo apt-get install -y zip
+          echo "${{ github.sha }}" > version
+          IFS=',' read -ra CHARM_FILES <<< "${{ steps.publish.outputs.charms }}"
+          for charm_file in "${CHARM_FILES[@]}"; do
+            zip -u "$charm_file" version
+          done
+          rm version
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.7.0
         with:

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -146,7 +146,9 @@ jobs:
           IFS=',' read -ra CHARM_FILES <<< "${{ steps.publish.outputs.charms }}"
           for charm_file in "${CHARM_FILES[@]}"; do
             charm_file=$(echo "$charm_file" | xargs)
-            zip -u "$charm_file" version
+            if ! zipinfo -1 "$charm_file" | grep -qx "version"; then
+              zip -u "$charm_file" version
+            fi
           done
           rm version
       - name: Upload charm to charmhub

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -142,7 +142,7 @@ jobs:
       - name: Add version file to charm
         run: |
           sudo apt-get update && sudo apt-get install -y zip
-          echo "${{ github.sha }}" > version
+          echo "${GITHUB_SHA::8}" > version
           IFS=',' read -ra CHARM_FILES <<< "${{ steps.publish.outputs.charms }}"
           for charm_file in "${CHARM_FILES[@]}"; do
             charm_file=$(echo "$charm_file" | xargs)

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -145,6 +145,7 @@ jobs:
           echo "${{ github.sha }}" > version
           IFS=',' read -ra CHARM_FILES <<< "${{ steps.publish.outputs.charms }}"
           for charm_file in "${CHARM_FILES[@]}"; do
+            charm_file=$(echo "$charm_file" | xargs)
             zip -u "$charm_file" version
           done
           rm version

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -113,7 +113,7 @@ jobs:
     name: Publish charm to ${{ inputs.channel || needs.select-channel.outputs.destination-channel }}
     runs-on: ubuntu-latest
     needs: [ plan, select-channel ]
-    if: ${{ needs.plan.outputs.has-code-changes == 'True' }}
+    if: ${{ github.repository == 'canonical/operator-workflows' || needs.plan.outputs.has-code-changes == 'True' }}
     outputs:
       charm-directory: ${{ steps.publish.outputs.charm-directory }}
     steps:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-03
+
+- Inject a `version` file containing the commit SHA into charm files before publishing to Charmhub.
+
 ## 2026-05-04
 
 - Update `docs_rtd` workflow references from `sphinx-docs-starter-pack` to `sphinx-stack`.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

This PR adds a step to the publish workflow that injects a [version file](https://documentation.ubuntu.com/ops/latest/howto/manage-the-charm-version/) into each charm file before uploading to Charmhub. The version file contains the Git commit SHA that triggered the publish.

Test result:

```
      "charm": "test-upload",
      "base": {
        "name": "ubuntu",
        "channel": "22.04"
      },
      "charm-origin": "charmhub",
      "charm-name": "test-upload",
      "charm-rev": 2716,
      "charm-channel": "latest/edge",
      "charm-version": "6f911c0d",
```

### Rationale

This helps us more easily track the deployed charms to the source code in version control.

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
