### PR TITLE
Include {code-cell} for spread testing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-04
+
+- Make Jupyter Notebook code cell work with docs spread tests.
+
 ## 2026-06-03
 
 - Inject a `version` file containing the commit SHA into charm files before publishing to Charmhub.

--- a/spread/create_spread_task_file.py
+++ b/spread/create_spread_task_file.py
@@ -366,7 +366,7 @@ def extract_commands_from_markdown(file_path):
         match_end = match.end()
 
         # Skip blocks that start with { (like {note}, {tip}, or {terminal})
-        if lang_identifier.strip().startswith("{"):
+        if lang_identifier.strip().startswith("{") and not lang_identifier.strip().startswith("{code-cell}"):
             continue
 
         # Skip blocks that are nested within 4+ backtick blocks or in excluded sections


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Any code block identifier starting with `{` is not executed during spread testing.
With Jupyter notebook docs, the code block starts with `{code-cell}` but would needed to be executed with spread.

### Rationale

<!-- The reason the change is needed -->
Make Jupyter notebook docs work with spread test docs.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
