### PR TITLE
Use copy+unlink instead of rename for cross-filesystem support

### DIFF
--- a/dist/plan-integration/index.js
+++ b/dist/plan-integration/index.js
@@ -119034,7 +119034,8 @@ async function run() {
                 }
                 const { name, files } = manifest;
                 for (const file of files) {
-                    fs.renameSync(path$1.join(tmp, file), path$1.join(plan.working_directory, file));
+                    fs.copyFileSync(path$1.join(tmp, file), path$1.join(plan.working_directory, file));
+                    fs.unlinkSync(path$1.join(tmp, file));
                     const argName = build.type === 'charm' ? 'charm-file' : `${name}-resource`;
                     args.push(`--${argName}=./${file}`);
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3512,9 +3512,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3529,9 +3526,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3546,9 +3540,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3563,9 +3554,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3580,9 +3568,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3597,9 +3582,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3614,9 +3596,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3631,9 +3610,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3648,9 +3624,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3665,9 +3638,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3682,9 +3652,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3699,9 +3666,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3716,9 +3680,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/plan-integration.ts
+++ b/src/plan-integration.ts
@@ -129,10 +129,11 @@ export async function run(): Promise<void> {
         }
         const { name, files } = manifest
         for (const file of files) {
-          fs.renameSync(
+          fs.copyFileSync(
             path.join(tmp, file),
             path.join(plan.working_directory, file)
           )
+          fs.unlinkSync(path.join(tmp, file))
           const argName: string =
             build.type === 'charm' ? 'charm-file' : `${name}-resource`
           args.push(`--${argName}=./${file}`)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Use copy+unlink instead of rename for cross-filesystem support.

### Rationale

/tmp on Ubuntu 26.04 is now a tmpfs filesystem by default, which means we can't use rename to move files in or out of /tmp.

> Ubuntu now comes with the upstream tmp.mount unit by default. As a result, the /tmp directory is now a tmpfs file system by default.

https://documentation.ubuntu.com/release-notes/26.04/summary-for-lts-users/#systemd-259

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
