### PR TITLE
fix: docutils step of docs.yaml

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -44,7 +44,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
       - name: Install docutils
-        run: sudo apt-get install -y docutils
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y docutils
       - name: Run Vale Linter
         uses: vale-cli/vale-action@v2.1.1
         with:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-10
+
+- Fix failing step in `docs.yaml` by including `apt-get update` in the docutils step. 
+
 ## 2026-06-04
 
 - Make Jupyter Notebook code cell work with docs spread tests.


### PR DESCRIPTION
### Overview

Add `apt-get update` command to docutils step in `docs.yaml`.

### Rationale

Workflow started failing in downstream repos, for example, see [this log from canonical/mattermost-k8s-operator](https://github.com/canonical/mattermost-k8s-operator/actions/runs/27286577161/job/80595350486?pr=69).

This PR updates the workflow to resolve the failure.

### Workflow Changes

Update the `Install docutils` step of `docs.yaml` to include `sudo apt-get update -y` before installing docutils.

### Checklist

- [X] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [X] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
