### PR TITLE
chore: Run test.yaml on github runners by default

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ on:
       self-hosted-runner:
         type: boolean
         description: Whether to use self-hosted runners to run the jobs.
-        default: true
+        default: false
       self-hosted-runner-arch:
         type: string
         description: Architecture to use on self-hosted runners to run the jobs.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-18
+
+- Update `test.yaml` to not run by default in `self-hosted-runner`. This is a breaking change.
+
 ## 2026-06-15
 
 - Fix downstream failures of `docs.yaml` by including two new steps to install Vale and sync all the required packages.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Update tests.yaml to run in Github Runners by default. 

This is a breaking change. However, the current pressure in self-hosted-runners is very high and the queues are untennable.

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
