### PR TITLE
fix: Add .licenserc.yaml deleted by mistake

### DIFF
--- a/.github/files/.licenserc.yaml
+++ b/.github/files/.licenserc.yaml
@@ -1,0 +1,47 @@
+header:
+  - license:
+      copyright-owner: Canonical Ltd.
+      pattern: |
+        Copyright \d{4} Canonical Ltd.
+        Licensed under the Apache2.0. See LICENSE file in charm source for details.
+    paths:
+      - 'lib/**'
+    comment: on-failure
+  - license:
+      spdx-id: Apache-2.0
+      copyright-owner: Canonical Ltd.
+      pattern: |
+        Copyright \d{4} Canonical Ltd.
+        See LICENSE file for licensing details.
+    paths:
+      - '**'
+    paths-ignore:
+      - '.github/**'
+      - '**/.gitkeep'
+      - '**/*.cfg'
+      - '**/*.conf'
+      - '**/*.ini'
+      - '**/*.j2'
+      - '**/*.json'
+      - '**/*.md'
+      - '**/*.rule'
+      - '**/*.tmpl'
+      - '**/*.txt'
+      - '**/*.xml'
+      - '.codespellignore'
+      - '.dockerignore'
+      - '.flake8'
+      - '.jujuignore'
+      - '.gitignore'
+      - '.licenserc.yaml'
+      - '.trivyignore'
+      - '.woke.yaml'
+      - '.woke.yml'
+      - 'CODEOWNERS'
+      - 'icon.svg'
+      - 'LICENSE'
+      - 'pyproject.toml'
+      - 'trivy.yaml'
+      - 'zap_rules.tsv'
+      - 'lib/**'
+    comment: on-failure


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add back `.licenserc.yaml` removed by mistake.

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
