### PR TITLE
feat: Add lxd-channel input for custom LXD setup in integration tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -38,7 +38,7 @@ on:
         description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: 2.9/stable
-      lxd-channel:
+      build-lxd-channel:
         description: Snap channel to install LXD from in the build job via canonical/setup-lxd.
         type: string
         default: "latest/candidate"
@@ -213,7 +213,7 @@ jobs:
     steps:
       - uses: canonical/setup-lxd@v1
         with:
-          channel: ${{ inputs.lxd-channel }}
+          channel: ${{ inputs.build-lxd-channel }}
       - name: Set LXC security nesting
         if: ${{ inputs.rockcraft-enable-security-nesting }}
         run: |

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -38,6 +38,10 @@ on:
         description: Actions operator juju channel as per https://github.com/charmed-kubernetes/actions-operator#usage
         type: string
         default: 2.9/stable
+      lxd-channel:
+        description: Snap channel to install LXD from in the build job via canonical/setup-lxd.
+        type: string
+        default: "latest/candidate"
       identifier:
         type: string
         description: >-
@@ -208,6 +212,8 @@ jobs:
         build: ${{ fromJSON(needs.plan.outputs.plan).build }}
     steps:
       - uses: canonical/setup-lxd@v1
+        with:
+          channel: ${{ inputs.lxd-channel }}
       - name: Set LXC security nesting
         if: ${{ inputs.rockcraft-enable-security-nesting }}
         run: |


### PR DESCRIPTION
This pull request adds support for specifying a custom LXD snap channel in the integration test GitHub Actions workflow. This allows users to control which LXD version is installed during CI runs, improving flexibility and reproducibility.

**Workflow input enhancements:**

* Added a new `lxd-channel` input to `.github/workflows/integration_test.yaml`, allowing the snap channel for LXD installation to be specified. If left empty, the default channel from the setup-lxd action is used.

**Conditional LXD setup steps:**

* Updated the integration test job to set up LXD using either the default or a custom snap channel, based on the `lxd-channel` input. This is achieved by conditionally running the `canonical/setup-lxd` action with or without the `channel` parameter.