### PR TITLE
fix: set CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS for check-libraries

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -396,6 +396,8 @@ jobs:
       - name: Check libs
         if: ${{ !github.event.pull_request.head.repo.fork && inputs.require-check-lib }}
         uses: canonical/charming-actions/check-libraries@2.7.0
+        env:
+          CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Charmcraft 4.3.0 introduced a backward-incompatible change: `expand-extensions` now fails with exit code 1 for extensions marked as experimental (e.g. `go-framework`) unless `CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS` is set.

This breaks the `Check libraries` CI job for any charm using a 12-factor extension, as `charming-actions/check-libraries` calls `charmcraft expand-extensions` internally.

## Fix

Set `CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=1` on the `Check libs` step so charmcraft proceeds regardless of experimental status.

## Context

- Root cause PR in charmcraft: canonical/charmcraft#2713
- Example failing job: https://github.com/canonical/mattermost-k8s-operator/actions/runs/29367420727/job/87202329026