### PR TITLE
Remove usage of edge runners. Instead use medium

### DIFF
--- a/.github/workflows/workflow_simple_test.yaml
+++ b/.github/workflows/workflow_simple_test.yaml
@@ -35,7 +35,7 @@ jobs:
     with:
       working-directory: "tests/workflows/integration/test-upload-charm/"
       self-hosted-runner: true
-      self-hosted-runner-label: "edge"
+      self-hosted-runner-label: "medium"
       vale-files: '["docs/**/*.md", "README.md"]'
       vale-style-check: true
       with-uv: true

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -50,7 +50,7 @@ jobs:
       working-directory: "tests/workflows/integration/test-upload-charm/"
       trivy-image-config: "tests/workflows/integration/test-upload-charm/trivy.yaml"
       self-hosted-runner: true
-      self-hosted-runner-label: "edge"
+      self-hosted-runner-label: "medium"
       with-uv: true
   integration-rock:
     uses: ./.github/workflows/integration_test.yaml


### PR DESCRIPTION
Remove usage of edge runners. Instead use medium. Edge runners are not available anymore.

This means that we will tiobe/fips/private runners. We may need to put a more restrictive label if there are issues.

Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
