### PR TITLE
 Search for charmcraft files alias before lib-check 

### DIFF
--- a/.github/workflows/auto_update_charm_libs.yaml
+++ b/.github/workflows/auto_update_charm_libs.yaml
@@ -41,9 +41,9 @@ jobs:
           if [ ${#candidates[@]} -eq 0 ]; then
             exit 0
           fi
-          echo "Copying ${candidates[0]} to charmcraft.yaml"
-          cp "${candidates[0]}" charmcraft.yaml
-          echo "moved=true" >> "$GITHUB_OUTPUT"
+          echo "Linking charmcraft.yaml to ${candidates[0]}"
+          ln -s "${candidates[0]}" charmcraft.yaml
+          echo "linked=true" >> "$GITHUB_OUTPUT"
       - name: Check libs
         working-directory: ${{ inputs.working-directory }}
         run: |
@@ -51,8 +51,8 @@ jobs:
           charmcraft fetch-lib
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
-      - name: Remove temporary charmcraft.yaml
-        if: always() && steps.resolve-charmcraft.outputs.moved == 'true'
+      - name: Remove charmcraft.yaml symlink
+        if: always() && steps.resolve-charmcraft.outputs.linked == 'true'
         working-directory: ${{ inputs.working-directory }}
         run: rm -f charmcraft.yaml
       - name: Create pull request

--- a/.github/workflows/auto_update_charm_libs.yaml
+++ b/.github/workflows/auto_update_charm_libs.yaml
@@ -27,6 +27,23 @@ jobs:
         uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
+      - name: Resolve charmcraft.yaml
+        id: resolve-charmcraft
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if [ -f charmcraft.yaml ] || [ -f charmcraft.yml ]; then
+            exit 0
+          fi
+          candidates=()
+          for f in *charmcraft.yaml *charmcraft.yml; do
+            [ -f "$f" ] && candidates+=("$f")
+          done
+          if [ ${#candidates[@]} -eq 0 ]; then
+            exit 0
+          fi
+          echo "Copying ${candidates[0]} to charmcraft.yaml"
+          cp "${candidates[0]}" charmcraft.yaml
+          echo "moved=true" >> "$GITHUB_OUTPUT"
       - name: Check libs
         working-directory: ${{ inputs.working-directory }}
         run: |
@@ -34,6 +51,10 @@ jobs:
           charmcraft fetch-lib
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
+      - name: Remove temporary charmcraft.yaml
+        if: always() && steps.resolve-charmcraft.outputs.moved == 'true'
+        working-directory: ${{ inputs.working-directory }}
+        run: rm -f charmcraft.yaml
       - name: Create pull request
         uses: canonical/create-pull-request@main
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -407,8 +407,8 @@ jobs:
           if [ ${#candidates[@]} -eq 0 ]; then
             exit 0
           fi
-          echo "Moving ${candidates[0]} to charmcraft.yaml"
-          mv "${candidates[0]}" charmcraft.yaml
+          echo "Linking charmcraft.yaml to ${candidates[0]}"
+          ln -s "${candidates[0]}" charmcraft.yaml
       - name: Check libs
         if: ${{ !github.event.pull_request.head.repo.fork && inputs.require-check-lib }}
         uses: canonical/charming-actions/check-libraries@2.7.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -393,6 +393,22 @@ jobs:
       }}
     steps:
       - uses: actions/checkout@v6.0.3
+      - name: Resolve charmcraft.yaml
+        if: ${{ !github.event.pull_request.head.repo.fork && inputs.require-check-lib }}
+        working-directory: ${{ inputs.working-directory }}/${{ inputs.charm-directory }}
+        run: |
+          if [ -f charmcraft.yaml ] || [ -f charmcraft.yml ]; then
+            exit 0
+          fi
+          candidates=()
+          for f in *charmcraft.yaml *charmcraft.yml; do
+            [ -f "$f" ] && candidates+=("$f")
+          done
+          if [ ${#candidates[@]} -eq 0 ]; then
+            exit 0
+          fi
+          echo "Moving ${candidates[0]} to charmcraft.yaml"
+          mv "${candidates[0]}" charmcraft.yaml
       - name: Check libs
         if: ${{ !github.event.pull_request.head.repo.fork && inputs.require-check-lib }}
         uses: canonical/charming-actions/check-libraries@2.7.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ Each revision is versioned by the date of the revision.
 ## 2026-08-11
 
 - In `test.yaml`, the `lib-check` job now moves a prefixed `*charmcraft.yaml` or `*charmcraft.yml` file to `charmcraft.yaml` when neither `charmcraft.yaml` nor `charmcraft.yml` exists.
+- In `auto_update_charm_libs.yaml`, the `update-lib` job now creates a temporary `charmcraft.yaml` from a prefixed `*charmcraft.yaml` or `*charmcraft.yml` file when neither `charmcraft.yaml` nor `charmcraft.yml` exists, and removes it before the pull request is created.
 
 ## 2026-07-07
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,8 +8,8 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-08-11
 
-- In `test.yaml`, the `lib-check` job now moves a prefixed `*charmcraft.yaml` or `*charmcraft.yml` file to `charmcraft.yaml` when neither `charmcraft.yaml` nor `charmcraft.yml` exists.
-- In `auto_update_charm_libs.yaml`, the `update-lib` job now creates a temporary `charmcraft.yaml` from a prefixed `*charmcraft.yaml` or `*charmcraft.yml` file when neither `charmcraft.yaml` nor `charmcraft.yml` exists, and removes it before the pull request is created.
+- In `test.yaml`, the `lib-check` job now symlinks `charmcraft.yaml` to a prefixed `*charmcraft.yaml` or `*charmcraft.yml` file when neither `charmcraft.yaml` nor `charmcraft.yml` exists.
+- In `auto_update_charm_libs.yaml`, the `update-lib` job now symlinks `charmcraft.yaml` to a prefixed `*charmcraft.yaml` or `*charmcraft.yml` file when neither `charmcraft.yaml` nor `charmcraft.yml` exists, and removes the symlink before the pull request is created.
 
 ## 2026-07-07
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-08-11
+
+- In `test.yaml`, the `lib-check` job now moves a prefixed `*charmcraft.yaml` or `*charmcraft.yml` file to `charmcraft.yaml` when neither `charmcraft.yaml` nor `charmcraft.yml` exists.
+
 ## 2026-07-07
 
 - Remove `docker-lint` job in  `test.yaml`.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

The `lib-check` job runs `canonical/charming-actions/check-libraries`, which expects a `charmcraft.yaml` at the configured charm path. But now some repositories will use a prefixed `charmcraft.yaml` (e.g. [`chrony-charmcraft.yaml`](https://github.com/canonical/chrony-operators/pull/16)) which will cause the job to fail.

### Rationale

Support repositories that use a prefixed `charmcraft.yaml` (e.g. [`chrony-charmcraft.yaml`](https://github.com/canonical/chrony-operators/pull/16)).

### Workflow Changes

The `lib-check` job now moves a prefixed `*charmcraft.yaml` or `*charmcraft.yml` file to `charmcraft.yaml` when neither `charmcraft.yaml` nor `charmcraft.yml` exists.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
