### PR TITLE
feat: add terraform version tagging workflow

### DIFF
--- a/.github/workflows/terraform_modules_release.yaml
+++ b/.github/workflows/terraform_modules_release.yaml
@@ -65,7 +65,7 @@ jobs:
 
           tag="${TAG_PREFIX}-${major}.${new_minor}.0"
           if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
-            echo "${tag} unexpectedly already exists; refusing to overwrite." >&2
+            echo "::warning:: ${tag} unexpectedly already exists; refusing to overwrite." >&2
             exit 1
           fi
 

--- a/.github/workflows/terraform_modules_release.yaml
+++ b/.github/workflows/terraform_modules_release.yaml
@@ -1,7 +1,8 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-name: Terraform Modules Tag
+name: Terraform Modules Release
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/terraform_modules_release.yaml
+++ b/.github/workflows/terraform_modules_release.yaml
@@ -70,5 +70,5 @@ jobs:
           fi
 
           echo "Creating ${tag}"
-          git tag "${tag}"
-          git push origin "${tag}"
+          git tag -- "${tag}"
+          git push origin -- "${tag}"

--- a/.github/workflows/terraform_modules_release.yaml
+++ b/.github/workflows/terraform_modules_release.yaml
@@ -8,8 +8,8 @@ on:
     inputs:
       tag-prefix:
         type: string
-        description: Prefix used for the version tag.
-        default: tf
+        description: "Tag prefix including separator; resulting format is <prefix><major>.<minor>.0"
+        default: tf-
       major-version-file:
         type: string
         description: Path to the file containing the major version number.
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  TAG_PREFIX: ${{ inputs.tag-prefix || 'tf' }}
+  TAG_PREFIX: ${{ inputs.tag-prefix || 'tf-' }}
   MAJOR_VERSION_FILE: ${{ inputs.major-version-file || 'terraform/MAJOR_VERSION' }}
 
 jobs:
@@ -51,8 +51,8 @@ jobs:
 
           # Highest existing minor for this major, if any.
           latest_minor="$(
-            git tag --list "${TAG_PREFIX}-${major}.*" \
-              | sed -nE "s/^${TAG_PREFIX}-${major}\.([0-9]+)\.[0-9]+$/\1/p" \
+            git tag --list "${TAG_PREFIX}${major}.*" \
+              | sed -nE "s/^${TAG_PREFIX}${major}\.([0-9]+)\.[0-9]+$/\1/p" \
               | sort -n \
               | tail -1
           )"
@@ -63,7 +63,7 @@ jobs:
             new_minor=$((latest_minor + 1))
           fi
 
-          tag="${TAG_PREFIX}-${major}.${new_minor}.0"
+          tag="${TAG_PREFIX}${major}.${new_minor}.0"
           if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
             echo "::warning:: ${tag} unexpectedly already exists; refusing to overwrite." >&2
             exit 1

--- a/.github/workflows/terraform_modules_tag.yaml
+++ b/.github/workflows/terraform_modules_tag.yaml
@@ -1,0 +1,66 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: Terraform Modules Tag
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'terraform/**'
+
+# Serialize tag creation so concurrent pushes don't compute the same minor.
+concurrency:
+  group: tag-terraform-module
+  cancel-in-progress: false
+
+env:
+  TAG_PREFIX: tf
+  MAJOR_VERSION_FILE: terraform/MAJOR_VERSION
+
+jobs:
+  tag:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Compute and push the next Terraform module tag
+        run: |
+          set -euo pipefail
+
+          # MAJOR_VERSION holds only the major version. Minor is auto-bumped
+          # on every change under terraform/; patch is always 0.
+          major="$(grep -oE '^[0-9]+' "${MAJOR_VERSION_FILE}" | head -1)"
+          if [ -z "${major}" ]; then
+            echo "Could not read a major version from ${MAJOR_VERSION_FILE}" >&2
+            exit 1
+          fi
+
+          # Highest existing minor for this major, if any.
+          latest_minor="$(
+            git tag --list "${TAG_PREFIX}-${major}.*" \
+              | sed -nE "s/^${TAG_PREFIX}-${major}\.([0-9]+)\.[0-9]+$/\1/p" \
+              | sort -n \
+              | tail -1
+          )"
+
+          if [ -z "${latest_minor}" ]; then
+            new_minor=0
+          else
+            new_minor=$((latest_minor + 1))
+          fi
+
+          tag="${TAG_PREFIX}-${major}.${new_minor}.0"
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "${tag} unexpectedly already exists; refusing to overwrite." >&2
+            exit 1
+          fi
+
+          echo "Creating ${tag}"
+          git tag "${tag}"
+          git push origin "${tag}"

--- a/.github/workflows/terraform_modules_tag.yaml
+++ b/.github/workflows/terraform_modules_tag.yaml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   tag:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/terraform_modules_tag.yaml
+++ b/.github/workflows/terraform_modules_tag.yaml
@@ -3,12 +3,19 @@
 
 name: Terraform Modules Tag
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'terraform/**'
+  workflow_call:
+    inputs:
+      tag-prefix:
+        type: string
+        description: Prefix used for the version tag.
+        default: tf
+      major-version-file:
+        type: string
+        description: Path to the file containing the major version number.
+        default: terraform/MAJOR_VERSION
+
+permissions:
+  contents: read
 
 # Serialize tag creation so concurrent pushes don't compute the same minor.
 concurrency:
@@ -16,8 +23,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  TAG_PREFIX: tf
-  MAJOR_VERSION_FILE: terraform/MAJOR_VERSION
+  TAG_PREFIX: ${{ inputs.tag-prefix || 'tf' }}
+  MAJOR_VERSION_FILE: ${{ inputs.major-version-file || 'terraform/MAJOR_VERSION' }}
 
 jobs:
   tag:

--- a/README.md
+++ b/README.md
@@ -111,12 +111,37 @@ Runs `terraform test` in the `tests` subfolder of the specified directories.
 
 You can find an example on how to call it in the [`platform-engineering-charm-template`](https://github.com/canonical/platform-engineering-charm-template/blob/main/.github/workflows/test_terraform_module.yaml).
 
+### Terraform Modules Release (`canonical/operator-workflows/.github/workflows/terraform_modules_release.yaml@main`)
+
+Automatically computes and pushes a semver tag of the form `<prefix><major>.<minor>.0` whenever Terraform module changes are merged. The major version is read from a file in the caller's repository; the minor is auto-incremented from the highest existing tag for that major and resets to `0` when the major is bumped.
+
+Inputs:
+
+* `tag-prefix` *(default: `tf-`)*: Prefix used for the version tag, including any separator (e.g. `tf-` produces `tf-1.0.0`).
+* `major-version-file` *(default: `terraform/MAJOR_VERSION`)*: Path to the file containing the major version number.
+
+Example calling workflow:
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths: ['terraform/**']
+
+jobs:
+  tag:
+    uses: canonical/operator-workflows/.github/workflows/terraform_modules_release.yaml@main
+    with:  # Optional input overrides
+      tag-prefix: tf-                            
+      major-version-file: terraform/MAJOR_VERSION
+```
+
 ## Required GitHub Token Permissions
 
 GitHub organisations can set the default `GITHUB_TOKEN` permissions to read-only. When your organisation uses read-only defaults, calling jobs must explicitly grant any permissions beyond `contents: read`. The table below lists the **minimum required permissions** for each reusable workflow so you can be explicit in your own calling workflows.
 
 | Workflow | Required permissions | Reason |
-|---|---|---|
+| --- | --- | --- |
 | `allure_report.yaml` | `contents: write` | Pushes the Allure report to the `gh-pages` branch |
 | `auto_update_charm_libs.yaml` | `contents: write`<br>`pull-requests: write`<br>`id-token: write` | Creates PRs to update charm libraries; uses OIDC for Charmhub authentication |
 | `bot_pr_approval.yaml` | `pull-requests: write` | Approves bot-authored PRs via the GitHub API |
@@ -129,6 +154,7 @@ GitHub organisations can set the default `GITHUB_TOKEN` permissions to read-only
 | `integration_test.yaml` | `contents: read`<br>`packages: write`<br>`pull-requests: write` *(optional)* | Checks out the repository; pushes built OCI images to `ghcr.io` when `upload-image: registry` is used or when running on non-forked PRs; `pull-requests: write` is only needed to post `.trivyignore` warning comments (non-fatal if absent) |
 | `promote_charm.yaml` | `contents: write` | Creates a git tag via `charming-actions/release-charm` |
 | `publish_charm.yaml` | `contents: write`<br>`packages: write`<br>`actions: read` | Creates git tags and releases libraries; pushes OCI images to `ghcr.io`; downloads build artifacts from a prior integration test run |
+| `terraform_modules_release.yaml` | `contents: write` | Creates and pushes a semver tag for Terraform module releases |
 | `terraform_modules_test.yaml` | `contents: read` | Checks out the repository to run `terraform test` |
 | `test.yaml` | `contents: read`<br>`pull-requests: write` | Checks out the repository; `charming-actions/check-libraries` posts a comment on PRs when charm libraries are out of date |
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-08-13
 
-- Add workflow file `terraform_modules_tag_version.yaml` to create git tags using the format `<prefix>-X.Y.Z` for the terraform modules.
+- Add workflow file `terraform_modules_release.yaml` to create git tags using the format `<prefix>-X.Y.Z` for the terraform modules.
 
 ## 2026-08-11
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-08-13
+
+- Add workflow file `terraform_modules_tag_version.yaml` to create git tags using the format `<prefix>-X.Y.Z` for the terraform modules.
+
 ## 2026-08-11
 
 - In `test.yaml`, the `lib-check` job now symlinks `charmcraft.yaml` to a prefixed `*charmcraft.yaml` or `*charmcraft.yml` file when neither `charmcraft.yaml` nor `charmcraft.yml` exists.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,8 +8,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-08-13
 
-- Add workflow file `terraform_modules_release.yaml` to create git tags using the format `<prefix>-X.Y.Z` for the terraform modules.
-
+- Add workflow file `terraform_modules_release.yaml` to create tags in the format `<prefix>-<major>.<minor>.0` for Terraform modules (major read from `terraform/MAJOR_VERSION`, minor auto-incremented).
 ## 2026-08-11
 
 - In `test.yaml`, the `lib-check` job now symlinks `charmcraft.yaml` to a prefixed `*charmcraft.yaml` or `*charmcraft.yml` file when neither `charmcraft.yaml` nor `charmcraft.yml` exists.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ Each revision is versioned by the date of the revision.
 ## 2026-08-13
 
 - Add workflow file `terraform_modules_release.yaml` to create tags in the format `<prefix>-<major>.<minor>.0` for Terraform modules (major read from `terraform/MAJOR_VERSION`, minor auto-incremented).
+
 ## 2026-08-11
 
 - In `test.yaml`, the `lib-check` job now symlinks `charmcraft.yaml` to a prefixed `*charmcraft.yaml` or `*charmcraft.yml` file when neither `charmcraft.yaml` nor `charmcraft.yml` exists.


### PR DESCRIPTION
Applicable spec: [CC008](https://docs.google.com/document/d/1k1psLCfcf0Nr5KeVtWGFi9wmzhcg5AP9GVZTsRyVQSQ/edit?usp=sharing)

### Overview

Adds a reusable workflow (`terraform_modules_release.yaml`) that automatically computes and pushes a semver tag whenever Terraform module changes are merged to a caller's main branch (in compiance with CC008).

Versioning scheme: `<prefix>-<major>.<minor>.0`
- Major is read from a file in the caller's repo (default: `terraform/MAJOR_VERSION`)
- Minor is auto-incremented from the highest existing tag for that major
- Patch is always `0` 

### Rationale

Terraform modules need versioned releases so consumers can pin to a stable ref. This automates that process in the same reusable-workflow pattern already used for charm publishing and testing, avoiding per-repo maintenance.

### Workflow Changes

`terraform_modules_tag.yaml` — new reusable workflow:
- Two overridable inputs: `tag-prefix` (default: `tf`) and `major-version-file` (default: `terraform/MAJOR_VERSION`)
- Concurrency group with `cancel-in-progress: false` prevents two runs from computing the same next minor; the in-progress run always completes before a queued run starts

### Usage

Callers add to their repo:

```yaml
on:
  push:
    branches: [main]
    paths: ['terraform/**']

jobs:
  tag:
    uses: canonical/operator-workflows/.github/workflows/terraform_modules_release.yaml@main
    with:                                        # optional: override  defaults
      tag-prefix: tf 
      major-version-file: terraform/MAJOR_VERSION
```

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
