### PR TITLE
fix: Pass the specified charmcraft-channel to charming-actions/release-charm when running the promote-charm workflow

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -162,4 +162,5 @@ jobs:
           base-channel: ${{ needs.get-charm-base.outputs.channel }}
           base-architecture: ${{ needs.get-charm-base.outputs.architecture }}
           tag-prefix: ${{ inputs.tag-prefix }}
+          charmcraft-channel: ${{ inputs.charmcraft-channel }}
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-08-21
+
+- In `promote-charm.yaml`, pass the `charmcraft-channel` input to the
+`canonical/charming-actions/release-charm` action as expected, so that
+the Charmcraft version specified in the input is used across the workflow.
+
 ## 2026-08-13
 
 - Add workflow file `terraform_modules_release.yaml` to create tags in the format `<prefix>-<major>.<minor>.0` for Terraform modules (major read from `terraform/MAJOR_VERSION`, minor auto-incremented).


### PR DESCRIPTION
### Overview

While the `promote-charm` workflow allows the desired Charmcraft channel to be specified, that channel is not passed to the `canonical/charming-actions/release-charm` action. This causes a mismatch between the available inputs + desired behavior and what actually happens under the hood - in my case, breaking pipelines as only the `latest/stable` Charmcraft version works as I need, not the `latest/edge` one installed by default.

### Rationale

Match the advertised behavior of setting the `charmcraft-channel` input to the `promote-charm` workflow. 

### Workflow Changes

Pass the `charmcraft-channel` input of the `promote-charm` workflow to its call to `canonical/charming-actions/release-charm`.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
