### PR TITLE
test: use registry for canonical k8s fixture

### DIFF
--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -146,6 +146,9 @@ jobs:
       working-directory: "tests/workflows/integration/test-rock/"
       trivy-image-config: "tests/workflows/integration/test-rock/trivy.yaml"
       provider: k8s
+      # Canonical K8s does not provide the MicroK8s local registry addon used by artifact mode.
+      # Keep this provider test on the explicit remote-image path.
+      upload-image: registry
       extra-arguments: |
         --kube-config=~/.kube/config
       use-canonical-k8s: true


### PR DESCRIPTION
## Summary

- Keep the canonical-K8s workflow fixture on explicit `upload-image: registry` mode.

Canonical K8s does not provide the MicroK8s local registry addon used by artifact mode. Fork pull requests already selected artifact mode before the artifact-default change, so this provider-specific fixture fix is intentionally separate from #1043.

## Validation

- YAML parsing
- `git diff --check`
