### PR TITLE
fix: rename ambiguous 'check' job ids

### DIFF
--- a/.github/workflows/workflow_simple_test.yaml
+++ b/.github/workflows/workflow_simple_test.yaml
@@ -63,7 +63,7 @@ jobs:
             git diff --ignore-space-at-eol --text dist/
             exit 1
           fi
-  check:
+  unit-tests-check:
     runs-on: ubuntu-latest
     if: always() && !cancelled()
     timeout-minutes: 5

--- a/.github/workflows/workflow_test.yaml
+++ b/.github/workflows/workflow_test.yaml
@@ -113,7 +113,7 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/allure_report.yaml
-  check:
+  integration-tests-check:
     runs-on: ubuntu-latest
     if: always() && !cancelled()
     timeout-minutes: 5


### PR DESCRIPTION
Both workflow_simple_test.yaml and workflow_test.yaml had a job named 'check', producing identical GitHub check-run names on every PR.
Branch protection could not distinguish between them, so requiring 'check' silently depended on both jobs at once with no way to select one.

Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Workflow Changes

<!-- Any high level changes to workflows and why -->

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/platform-engineering-contributing-guide) was applied
- [ ] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
